### PR TITLE
Add MCP OAuth 2.1 authorization server

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -9,9 +9,13 @@
         "@modelcontextprotocol/sdk": "^1.12.1",
         "@noble/ed25519": "^2.2.3",
         "@noble/hashes": "^1.7.2",
+        "@types/react": "^19.2.14",
+        "@types/react-dom": "^19.2.3",
         "borsh": "^2.0.0",
         "bs58": "^6.0.0",
         "express": "^5.2.1",
+        "react": "^19.2.5",
+        "react-dom": "^19.2.5",
         "thirdweb": "^5",
         "zod": "^3.24.4",
       },
@@ -378,6 +382,10 @@
     "@types/qs": ["@types/qs@6.15.0", "", {}, "sha512-JawvT8iBVWpzTrz3EGw9BTQFg3BQNmwERdKE22vlTxawwtbyUSlMppvZYKLZzB5zgACXdXxbD3m1bXaMqP/9ow=="],
 
     "@types/range-parser": ["@types/range-parser@1.2.7", "", {}, "sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ=="],
+
+    "@types/react": ["@types/react@19.2.14", "", { "dependencies": { "csstype": "^3.2.2" } }, "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w=="],
+
+    "@types/react-dom": ["@types/react-dom@19.2.3", "", { "peerDependencies": { "@types/react": "^19.2.0" } }, "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ=="],
 
     "@types/send": ["@types/send@1.2.1", "", { "dependencies": { "@types/node": "*" } }, "sha512-arsCikDvlU99zl1g69TcAB3mzZPpxgw0UQnaHeC1Nwb015xp8bknZv5rIfri9xTOcMuaVgvabfIRA7PSZVuZIQ=="],
 

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "start": "bun run src/index.ts",
     "test": "bun test",
     "typecheck": "tsc --noEmit",
-    "build": "bun build ./src/index.ts --outdir ./dist --target bun",
+    "build": "bun build ./src/index.ts --outdir ./dist --target bun && bun build ./src/login.tsx --outdir ./public --target browser --minify",
     "start:sse": "bun run src/sse-server.ts"
   },
   "dependencies": {
@@ -17,9 +17,13 @@
     "@modelcontextprotocol/sdk": "^1.12.1",
     "@noble/ed25519": "^2.2.3",
     "@noble/hashes": "^1.7.2",
+    "@types/react": "^19.2.14",
+    "@types/react-dom": "^19.2.3",
     "borsh": "^2.0.0",
     "bs58": "^6.0.0",
     "express": "^5.2.1",
+    "react": "^19.2.5",
+    "react-dom": "^19.2.5",
     "thirdweb": "^5",
     "zod": "^3.24.4"
   },

--- a/public/login.html
+++ b/public/login.html
@@ -1,0 +1,47 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Sign in · Singularity</title>
+  <style>
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+    body {
+      background: #000;
+      color: #fff;
+      font-family: -apple-system, BlinkMacSystemFont, 'Inter', sans-serif;
+      min-height: 100vh;
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      justify-content: center;
+      gap: 24px;
+      padding: 24px;
+    }
+    #app { display: flex; flex-direction: column; align-items: center; gap: 28px; width: 100%; max-width: 480px; }
+    .wordmark { font-size: 22px; font-weight: 700; letter-spacing: -0.5px; }
+    .sub { font-size: 13px; color: #555; text-align: center; margin-top: 4px; }
+    .status { font-size: 13px; color: #555; }
+    .token-card { display: flex; flex-direction: column; gap: 16px; width: 100%; }
+    .ok-badge { color: #22c55e; font-size: 14px; font-weight: 600; }
+    .box { background: #0d0d0d; border: 1px solid #1a1a1a; border-radius: 10px; padding: 16px; }
+    .label { font-size: 11px; color: #444; text-transform: uppercase; letter-spacing: .8px; margin-bottom: 6px; }
+    .mono { font-family: monospace; font-size: 11px; color: #a78bfa; word-break: break-all; line-height: 1.5; }
+    .meta { font-size: 11px; color: #444; margin-top: 6px; }
+    .cfg { background: #0d0d0d; border: 1px solid #1a1a1a; border-radius: 10px; overflow: hidden; }
+    .cfg-head { padding: 8px 14px; font-size: 11px; color: #444; border-bottom: 1px solid #1a1a1a; display: flex; justify-content: space-between; align-items: center; }
+    .cfg-body { padding: 12px 14px; font-family: monospace; font-size: 10.5px; color: #555; white-space: pre-wrap; line-height: 1.6; }
+    .copy-btn {
+      background: transparent; border: 1px solid #1a1a1a; border-radius: 6px;
+      color: #444; font-size: 11px; cursor: pointer; padding: 4px 10px; transition: all .15s;
+    }
+    .copy-btn:hover { border-color: #7c3aed; color: #fff; }
+    .copy-btn.ok { border-color: #22c55e !important; color: #22c55e !important; }
+    .copy-btn:not(.small) { width: 100%; padding: 8px; margin-top: 10px; }
+  </style>
+</head>
+<body>
+  <div id="app"></div>
+  <script type="module" src="/login.js"></script>
+</body>
+</html>

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,3 +1,5 @@
+export const ISSUER_URL = process.env.ISSUER_URL || "https://eto-mcp.fly.dev";
+
 export const config = {
   port: parseInt(process.env.PORT || "3000"),
   etoRpcUrl: process.env.ETO_RPC_URL || "http://localhost:8899",

--- a/src/gateway/oauth-provider.ts
+++ b/src/gateway/oauth-provider.ts
@@ -1,0 +1,160 @@
+import { randomBytes } from "crypto";
+import type { Response } from "express";
+import type { OAuthServerProvider, AuthorizationParams } from "@modelcontextprotocol/sdk/server/auth/provider.js";
+import type { OAuthRegisteredClientsStore } from "@modelcontextprotocol/sdk/server/auth/clients.js";
+import type { OAuthClientInformationFull, OAuthTokenRevocationRequest, OAuthTokens } from "@modelcontextprotocol/sdk/shared/auth.js";
+import type { AuthInfo } from "@modelcontextprotocol/sdk/server/auth/types.js";
+import { createSession, verifySession } from "./session.js";
+import { config } from "../config.js";
+
+interface PendingCode {
+  address: string;
+  code_challenge: string;
+  client_id: string;
+  redirect_uri: string;
+  scope: string[];
+  exp: number;
+}
+
+const clientsMap = new Map<string, OAuthClientInformationFull>();
+const pendingCodes = new Map<string, PendingCode>();
+const refreshTokens = new Map<string, { address: string; client_id: string; scope: string[] }>();
+
+const clientsStore: OAuthRegisteredClientsStore = {
+  getClient(clientId: string) {
+    return clientsMap.get(clientId);
+  },
+  registerClient(clientData) {
+    const client_id = randomBytes(16).toString("hex");
+    const client: OAuthClientInformationFull = {
+      ...clientData,
+      client_id,
+      client_id_issued_at: Math.floor(Date.now() / 1000),
+    };
+    clientsMap.set(client_id, client);
+    return client;
+  },
+};
+
+/** Issue a short-lived auth code after a successful SIWE — called from POST /oauth-callback */
+export function issueAuthCode(
+  address: string,
+  params: { codeChallenge: string; client_id: string; redirectUri: string; scopes?: string[]; state?: string }
+): string {
+  const code = randomBytes(32).toString("base64url");
+  pendingCodes.set(code, {
+    address,
+    code_challenge: params.codeChallenge,
+    client_id: params.client_id,
+    redirect_uri: params.redirectUri,
+    scope: params.scopes ?? ["mcp:tools"],
+    exp: Math.floor(Date.now() / 1000) + 600,
+  });
+  return code;
+}
+
+export const oauthProvider: OAuthServerProvider = {
+  clientsStore,
+
+  async authorize(client: OAuthClientInformationFull, params: AuthorizationParams, res: Response) {
+    const oauthState = Buffer.from(
+      JSON.stringify({
+        client_id: client.client_id,
+        redirect_uri: params.redirectUri,
+        code_challenge: params.codeChallenge,
+        scope: params.scopes,
+        state: params.state,
+      })
+    ).toString("base64url");
+    res.redirect(`/login?oauth_state=${oauthState}`);
+  },
+
+  async challengeForAuthorizationCode(_client: OAuthClientInformationFull, code: string) {
+    const pending = pendingCodes.get(code);
+    if (!pending) throw new Error("Unknown authorization code");
+    return pending.code_challenge;
+  },
+
+  async exchangeAuthorizationCode(
+    client: OAuthClientInformationFull,
+    code: string,
+    _codeVerifier?: string,
+    _redirectUri?: string,
+    _resource?: URL
+  ): Promise<OAuthTokens> {
+    const pending = pendingCodes.get(code);
+    if (!pending) throw new Error("Unknown or expired authorization code");
+    if (pending.exp < Math.floor(Date.now() / 1000)) {
+      pendingCodes.delete(code);
+      throw new Error("Authorization code expired");
+    }
+    pendingCodes.delete(code);
+
+    const accessToken = createSession({
+      userId: pending.address,
+      walletId: pending.address,
+      clientId: client.client_id,
+      network: config.network,
+      ttlSeconds: config.auth.sessionTtlSeconds,
+      authStrategy: "siwe",
+    });
+
+    const refreshToken = randomBytes(32).toString("base64url");
+    refreshTokens.set(refreshToken, {
+      address: pending.address,
+      client_id: client.client_id,
+      scope: pending.scope,
+    });
+
+    return {
+      access_token: accessToken,
+      token_type: "bearer",
+      expires_in: config.auth.sessionTtlSeconds,
+      refresh_token: refreshToken,
+      scope: pending.scope.join(" "),
+    };
+  },
+
+  async exchangeRefreshToken(
+    client: OAuthClientInformationFull,
+    refreshToken: string,
+    _scopes?: string[],
+    _resource?: URL
+  ): Promise<OAuthTokens> {
+    const stored = refreshTokens.get(refreshToken);
+    if (!stored || stored.client_id !== client.client_id) {
+      throw new Error("Invalid refresh token");
+    }
+
+    const accessToken = createSession({
+      userId: stored.address,
+      walletId: stored.address,
+      clientId: client.client_id,
+      network: config.network,
+      ttlSeconds: config.auth.sessionTtlSeconds,
+      authStrategy: "siwe",
+    });
+
+    return {
+      access_token: accessToken,
+      token_type: "bearer",
+      expires_in: config.auth.sessionTtlSeconds,
+      scope: stored.scope.join(" "),
+    };
+  },
+
+  async verifyAccessToken(token: string): Promise<AuthInfo> {
+    const session = verifySession(token);
+    if (!session) throw new Error("Invalid or expired token");
+    return {
+      token,
+      clientId: session.client_id ?? session.sub,
+      scopes: session.caps,
+      expiresAt: session.exp,
+    };
+  },
+
+  async revokeToken(_client: OAuthClientInformationFull, request: OAuthTokenRevocationRequest) {
+    refreshTokens.delete(request.token);
+  },
+};

--- a/src/gateway/session.ts
+++ b/src/gateway/session.ts
@@ -21,6 +21,7 @@ export interface SessionPayload {
   network: "mainnet" | "testnet" | "devnet";
   agent_id?: string;
   auth_strategy?: AuthStrategy;
+  client_id?: string;    // OAuth client ID (set when issued via OAuth 2.1 flow)
 }
 
 export const CAPABILITY_SCOPES = {
@@ -87,6 +88,7 @@ export function createSession(opts: {
   agentId?: string;
   ttlSeconds?: number;
   authStrategy?: AuthStrategy;
+  clientId?: string;
 }): string {
   const now = Math.floor(Date.now() / 1000);
   const payload: SessionPayload = {
@@ -101,6 +103,7 @@ export function createSession(opts: {
     network: opts.network || "testnet",
     agent_id: opts.agentId,
     auth_strategy: opts.authStrategy,
+    client_id: opts.clientId,
   };
   const json = JSON.stringify(payload);
   const sig = hmacSign(json);

--- a/src/login.tsx
+++ b/src/login.tsx
@@ -1,0 +1,156 @@
+import React, { useEffect, useState } from "react";
+import { createRoot } from "react-dom/client";
+import { createThirdwebClient, defineChain } from "thirdweb";
+import { ThirdwebProvider, ConnectButton, useActiveAccount } from "thirdweb/react";
+import { signLoginPayload } from "thirdweb/auth";
+import { inAppWallet, createWallet } from "thirdweb/wallets";
+
+const BASE = window.location.origin;
+const CLIENT_ID = "42e44fb49ce221f80be2eac65642c044";
+
+const client = createThirdwebClient({ clientId: CLIENT_ID });
+const etoChain = defineChain({
+  id: 17743,
+  name: "ETO Testnet",
+  nativeCurrency: { name: "ETO", symbol: "ETO", decimals: 9 },
+  rpc: "https://rpc.entropytoorder.xyz",
+});
+const wallets = [
+  inAppWallet({ auth: { options: ["email", "google", "apple", "phone", "passkey"] } }),
+  createWallet("io.metamask"),
+  createWallet("com.coinbase.wallet"),
+  createWallet("io.rabby"),
+  createWallet("walletConnect"),
+];
+
+// Read OAuth state from URL — present when /authorize redirected here
+const oauthState = new URLSearchParams(window.location.search).get("oauth_state");
+const isOAuthMode = !!oauthState;
+
+async function doAuth(account: any) {
+  const payload = await fetch(`${BASE}/auth/login`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ address: account.address, chainId: 17743 }),
+  }).then((r) => r.json());
+  if (payload.code) throw new Error(payload.message);
+  const { signature } = await signLoginPayload({ account, payload });
+  return { payload, signature };
+}
+
+function Inner() {
+  const account = useActiveAccount();
+  const [status, setStatus] = useState("");
+  const [result, setResult] = useState<{ token: string; exp: number } | null>(null);
+  const [done, setDone] = useState(false);
+
+  useEffect(() => {
+    if (!account || done) return;
+    setDone(true);
+    setStatus("Signing in…");
+
+    doAuth(account)
+      .then(async ({ payload, signature }) => {
+        if (isOAuthMode) {
+          // OAuth mode: POST to /oauth-callback, server issues code and redirects
+          setStatus("Redirecting back to your MCP client…");
+          const res = await fetch(`${BASE}/oauth-callback`, {
+            method: "POST",
+            headers: { "content-type": "application/json" },
+            body: JSON.stringify({ payload, signature, oauth_state: oauthState }),
+          });
+          if (res.redirected) {
+            window.location.href = res.url;
+          } else {
+            const text = await res.text();
+            setStatus(`Redirect failed: ${text}`);
+          }
+        } else {
+          // Standalone mode: verify and show bearer token
+          const r = await fetch(`${BASE}/auth/verify`, {
+            method: "POST",
+            headers: { "content-type": "application/json" },
+            body: JSON.stringify({ payload, signature, strategy: "siwe" }),
+          }).then(async (r) => {
+            const b = await r.json();
+            if (!r.ok) throw new Error(b.message);
+            return b;
+          });
+          setResult(r);
+          setStatus("");
+        }
+      })
+      .catch((e) => {
+        setStatus(e.message);
+        setDone(false); // allow retry
+      });
+  }, [account]);
+
+  if (result) {
+    const sseUrl = `${BASE}/sse`;
+    const claudeCode = `claude mcp add singularity --transport sse \\\n  --header "Authorization: Bearer ${result.token}" \\\n  ${sseUrl}`;
+    const jsonCfg = JSON.stringify({
+      mcpServers: { singularity: { url: sseUrl, headers: { Authorization: `Bearer ${result.token}` } } },
+    }, null, 2);
+
+    return (
+      <div className="token-card">
+        <div className="ok-badge">✓ Authenticated</div>
+        <div className="box">
+          <div className="label">Bearer Token</div>
+          <div className="mono">{result.token}</div>
+          <div className="meta">Expires {new Date(result.exp * 1000).toLocaleString()}</div>
+          <CopyBtn text={result.token} label="Copy token" />
+        </div>
+        <div className="cfg">
+          <div className="cfg-head">Claude Code <CopyBtn text={claudeCode} label="copy" small /></div>
+          <pre className="cfg-body">{claudeCode}</pre>
+        </div>
+        <div className="cfg">
+          <div className="cfg-head">Claude Desktop / Cursor / Windsurf <CopyBtn text={jsonCfg} label="copy" small /></div>
+          <pre className="cfg-body">{jsonCfg}</pre>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div style={{ display: "flex", flexDirection: "column", alignItems: "center", gap: 16 }}>
+      <ConnectButton
+        client={client}
+        wallets={wallets}
+        chain={etoChain}
+        theme="dark"
+        connectModal={{ size: "compact", title: "Sign in to Singularity", titleIcon: "" }}
+        connectButton={{ label: isOAuthMode ? "Connect to authorise" : "Connect to get started" }}
+      />
+      {status && <div className="status">{status}</div>}
+    </div>
+  );
+}
+
+function CopyBtn({ text, label, small }: { text: string; label: string; small?: boolean }) {
+  const [ok, setOk] = useState(false);
+  return (
+    <button
+      className={`copy-btn${small ? " small" : ""}${ok ? " ok" : ""}`}
+      onClick={() => { navigator.clipboard.writeText(text); setOk(true); setTimeout(() => setOk(false), 2000); }}
+    >
+      {ok ? "✓ Copied" : label}
+    </button>
+  );
+}
+
+function App() {
+  return (
+    <ThirdwebProvider>
+      <div className="wordmark">Singularity</div>
+      <div className="sub">
+        {isOAuthMode ? "Connect your wallet to authorise your MCP client" : "MCP Server · ETO Chain"}
+      </div>
+      <Inner />
+    </ThirdwebProvider>
+  );
+}
+
+createRoot(document.getElementById("app")!).render(<App />);

--- a/src/sse-server.ts
+++ b/src/sse-server.ts
@@ -3,32 +3,100 @@ import { readFileSync } from "fs";
 import { join, dirname } from "path";
 import { fileURLToPath } from "url";
 import { SSEServerTransport } from "@modelcontextprotocol/sdk/server/sse.js";
+import { mcpAuthRouter } from "@modelcontextprotocol/sdk/server/auth/router.js";
 import { createServer } from "./server.js";
-import { config } from "./config.js";
+import { config, ISSUER_URL } from "./config.js";
 import { blockhashCache } from "./write/blockhash-cache.js";
 import { wsManager } from "./read/ws-manager.js";
 import { log, dumpStats } from "./utils/logger.js";
 import { authRouter } from "./gateway/auth-routes.js";
 import { runWithAuth } from "./gateway/auth.js";
 import { sessionStore } from "./signing/session-context.js";
+import { oauthProvider, issueAuthCode } from "./gateway/oauth-provider.js";
+import { verifyPayload } from "./gateway/thirdweb.js";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const LLMS_TXT = readFileSync(join(__dirname, "../public/llms.txt"), "utf8");
 
 const PORT = parseInt(process.env.PORT || "8080", 10);
+const RESOURCE_METADATA_URL = `${ISSUER_URL}/.well-known/oauth-protected-resource`;
 
 const app = express();
 
-// CORS for cross-origin MCP clients
+// CORS — must be first so OPTIONS preflight works for all routes including oauth endpoints
 app.use((req, res, next) => {
   res.header("Access-Control-Allow-Origin", "*");
-  res.header("Access-Control-Allow-Methods", "GET, POST, OPTIONS");
-  res.header("Access-Control-Allow-Headers", "Content-Type, Authorization");
+  res.header("Access-Control-Allow-Methods", "GET, POST, DELETE, OPTIONS");
+  res.header("Access-Control-Allow-Headers", "Content-Type, Authorization, MCP-Protocol-Version");
   if (req.method === "OPTIONS") {
     res.sendStatus(204);
     return;
   }
   next();
+});
+
+// OAuth 2.1 authorization server — serves /.well-known/*, /register, /authorize, /token, /revoke
+// Must be installed at the application root per MCP SDK requirements.
+app.use(mcpAuthRouter({
+  provider: oauthProvider,
+  issuerUrl: new URL(ISSUER_URL),
+  scopesSupported: ["mcp:tools"],
+  resourceName: "Singularity MCP Server",
+}));
+
+// Static assets (login.js bundle, etc.)
+app.use(express.static(join(__dirname, "../public")));
+
+// Auth UI — thirdweb ConnectButton → SIWE → bearer token (standalone + OAuth mode)
+app.get("/login", (_req, res) => {
+  res.sendFile(join(__dirname, "../public/login.html"));
+});
+
+// OAuth callback — login.tsx POSTs here after SIWE sign-in in OAuth mode
+// Body: { payload: LoginPayload, signature: string, oauth_state: string (base64url JSON) }
+app.post("/oauth-callback", express.json(), async (req, res) => {
+  const { payload, signature, oauth_state } = req.body ?? {};
+  if (!payload || !signature || !oauth_state) {
+    res.status(400).json({ error: "Missing payload, signature, or oauth_state" });
+    return;
+  }
+
+  let params: {
+    client_id: string;
+    redirect_uri: string;
+    code_challenge: string;
+    scope?: string[];
+    state?: string;
+  };
+  try {
+    params = JSON.parse(Buffer.from(oauth_state, "base64url").toString());
+  } catch {
+    res.status(400).json({ error: "Invalid oauth_state" });
+    return;
+  }
+
+  const result = await verifyPayload({ payload, signature }).catch(() => ({ valid: false as const, error: "verify failed" }));
+  if (!result.valid) {
+    const redirectErr = new URL(params.redirect_uri);
+    redirectErr.searchParams.set("error", "access_denied");
+    if (params.state) redirectErr.searchParams.set("state", params.state);
+    res.redirect(redirectErr.toString());
+    return;
+  }
+
+  const address = (result as any).payload?.address ?? payload.address;
+  const code = issueAuthCode(address, {
+    codeChallenge: params.code_challenge,
+    client_id: params.client_id,
+    redirectUri: params.redirect_uri,
+    scopes: params.scope,
+    state: params.state,
+  });
+
+  const redirectUrl = new URL(params.redirect_uri);
+  redirectUrl.searchParams.set("code", code);
+  if (params.state) redirectUrl.searchParams.set("state", params.state);
+  res.redirect(redirectUrl.toString());
 });
 
 // llms.txt — agent-readable description of this server
@@ -45,9 +113,7 @@ app.get("/health", (_req, res) => {
   res.json({ status: "ok", version: "1.0.0", tools: 81, network: config.network });
 });
 
-// Auth endpoints: /auth/login, /auth/verify, /auth/me. Mounted under /auth so
-// the router's body-parser never intercepts /message, which must reach the
-// MCP SDK with its raw stream intact.
+// Auth endpoints: /auth/login, /auth/verify, /auth/me.
 app.use("/auth", authRouter);
 
 // Track active transports for cleanup
@@ -61,7 +127,6 @@ app.get("/sse", async (req, res) => {
   const sessionId = transport.sessionId;
   transports.set(sessionId, transport);
 
-  // Clean up on disconnect
   res.on("close", () => {
     transports.delete(sessionId);
     log("info", "sse", "SSE connection closed", { sessionId });
@@ -74,32 +139,19 @@ app.get("/sse", async (req, res) => {
 });
 
 // Message endpoint — client sends JSON-RPC messages here
-// Note: SSEServerTransport.handlePostMessage reads the body itself via raw-body,
-// so express.json() middleware is NOT used here.
-//
-// Auth flow: the bearer token (if any) is stashed in an AsyncLocalStorage via
-// runWithAuth(). The MCP tool-handler wrapper in tools/index.ts reads that ALS,
-// runs authenticate() + requireCapability() + rateLimiter.check(), and then
-// calls runInScope(session.sub, ...) to land the handler in the right
-// persistence bucket. We seed a placeholder scope ("__pending__") here so
-// anything that peeks at currentScope() before the scope is resolved gets a
-// clearly named fallback instead of __default__.
 app.post("/message", async (req, res) => {
   const sessionId = req.query.sessionId as string;
 
-  // Auth gate runs first: callers with no Bearer get 401, not 400, when auth
-  // is enforced. This keeps unauthenticated probes from learning about session
-  // state. We also strictly validate the scheme — "Authorization: Basic ..."
-  // and other non-Bearer schemes must 401, not fall through as if authed.
   const authHeader = req.header("authorization") ?? "";
   const bearerMatch = authHeader.match(/^Bearer\s+(.+)$/i);
   const bearer = bearerMatch?.[1]?.trim();
   if (!bearer && !config.auth.devBypass) {
+    res.set("WWW-Authenticate", `Bearer realm="mcp", resource_metadata="${RESOURCE_METADATA_URL}"`);
     res.status(401).json({
       code: "AUTH_001",
       category: "auth",
       message: "Authentication required",
-      explanation: "No Bearer token. Call POST /auth/login → sign → POST /auth/verify.",
+      explanation: "No Bearer token. Add this MCP server to your client and complete the OAuth flow.",
     });
     return;
   }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,8 +10,9 @@
     "rootDir": "./src",
     "declaration": true,
     "resolveJsonModule": true,
-    "types": ["bun"]
+    "types": ["bun"],
+    "jsx": "react-jsx"
   },
-  "include": ["src/**/*.ts"],
+  "include": ["src/**/*.ts", "src/**/*.tsx"],
   "exclude": ["node_modules", "dist"]
 }


### PR DESCRIPTION
## Summary

- Implements a full OAuth 2.1 authorization server on `eto-mcp.fly.dev` — same pattern as Linear, Figma, and Notion
- Any MCP client (Claude Code, Cursor, Windsurf, VS Code) now auto-handles auth with zero manual token copy-paste
- Thirdweb ConnectButton (email, Google, Apple, MetaMask, WalletConnect, etc.) is the identity layer

## How it works

```
client hits /sse
  → 401 + WWW-Authenticate: Bearer realm="mcp", resource_metadata=".../.well-known/oauth-protected-resource"
  → client fetches /.well-known/oauth-protected-resource → finds AS at https://eto-mcp.fly.dev
  → client fetches /.well-known/oauth-authorization-server → discovers /authorize, /token, /register
  → POST /register (DCR) → gets client_id
  → browser opens /authorize → 302 /login?oauth_state=...
  → thirdweb ConnectButton → user signs SIWE once
  → POST /oauth-callback → server issues auth code → redirects to localhost callback
  → client POSTs code + PKCE verifier to /token → gets bearer token
  → all future MCP calls work automatically
```

## New endpoints (via MCP SDK `mcpAuthRouter`)

| Endpoint | Description |
|---|---|
| `GET /.well-known/oauth-protected-resource` | RFC 9728 — resource metadata |
| `GET /.well-known/oauth-authorization-server` | RFC 8414 — AS metadata |
| `POST /register` | RFC 7591 — Dynamic Client Registration |
| `GET /authorize` | Redirects to thirdweb login page |
| `POST /token` | PKCE S256 code exchange → bearer token |
| `DELETE /token` | Token revocation |
| `POST /oauth-callback` | Internal — SIWE verify + auth code issuance |

## Changes

- **`src/gateway/oauth-provider.ts`** (new) — `OAuthServerProvider` implementation: in-memory DCR client store, auth code store, refresh token store; `verifyAccessToken` reuses existing HMAC session tokens
- **`src/sse-server.ts`** — mounts `mcpAuthRouter`, adds `/oauth-callback`, updates 401 to include `WWW-Authenticate` header
- **`src/gateway/session.ts`** — adds `client_id?` to `SessionPayload` + `createSession` opts
- **`src/config.ts`** — exports `ISSUER_URL`
- **`src/login.tsx`** — dual mode: OAuth (redirects back to MCP client after SIWE) vs standalone (shows token card)
- **`tsconfig.json`** — adds `jsx: react-jsx`, includes `.tsx`
- **`package.json`** — adds `react`, `react-dom` deps for bundled login UI

## Test plan

- [ ] `curl https://eto-mcp.fly.dev/.well-known/oauth-protected-resource` returns JSON
- [ ] `curl https://eto-mcp.fly.dev/.well-known/oauth-authorization-server` returns JSON with authorization_endpoint, token_endpoint, registration_endpoint
- [ ] `curl -X POST https://eto-mcp.fly.dev/message` returns 401 with `WWW-Authenticate: Bearer realm="mcp", resource_metadata=...`
- [ ] `POST /register` returns `client_id`
- [ ] `GET /authorize?client_id=<registered>&...` returns 302 to `/login?oauth_state=...`
- [ ] `claude mcp add singularity --transport sse https://eto-mcp.fly.dev/sse` opens browser with thirdweb ConnectButton automatically

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added OAuth 2.0/2.1 authentication with authorization code grant flow
  * New sign-in page supporting Web3 wallet authentication
  * Session token management with OAuth client identification
  * MCP client configuration generation for authenticated users
  * Support for standalone and OAuth callback authentication flows

* **Chores**
  * Updated build configuration to support browser-based login
  * Added React runtime dependencies

<!-- end of auto-generated comment: release notes by coderabbit.ai -->