### PR TITLE
feat(auth): harden OAuth 2.1 layer — state persistence, rotation, reuse detection, signed state

### DIFF
--- a/src/gateway/oauth-provider.ts
+++ b/src/gateway/oauth-provider.ts
@@ -118,7 +118,7 @@ export const oauthProvider: OAuthServerProvider = {
     client: OAuthClientInformationFull,
     code: string,
     _codeVerifier?: string,
-    _redirectUri?: string,
+    redirectUri?: string,
     _resource?: URL
   ): Promise<OAuthTokens> {
     const pending = pendingCodes.get(code);
@@ -128,6 +128,16 @@ export const oauthProvider: OAuthServerProvider = {
       persistPendingCodes();
       throw new Error("Authorization code expired");
     }
+    // OAuth 2.1 §5.2: if redirect_uri was used at /authorize, the same value
+    // MUST be sent at /token. The SDK forwards whatever the client sent here;
+    // if it's missing the client already violated its own flow, but we still
+    // enforce match when present.
+    if (redirectUri !== undefined && redirectUri !== pending.redirect_uri) {
+      pendingCodes.delete(code);
+      persistPendingCodes();
+      throw new Error("redirect_uri mismatch");
+    }
+    // Codes are single-use: burn on any exit (success or failure past this point).
     pendingCodes.delete(code);
     persistPendingCodes();
 

--- a/src/gateway/oauth-provider.ts
+++ b/src/gateway/oauth-provider.ts
@@ -6,7 +6,7 @@ import type { OAuthServerProvider, AuthorizationParams } from "@modelcontextprot
 import type { OAuthRegisteredClientsStore } from "@modelcontextprotocol/sdk/server/auth/clients.js";
 import type { OAuthClientInformationFull, OAuthTokenRevocationRequest, OAuthTokens } from "@modelcontextprotocol/sdk/shared/auth.js";
 import type { AuthInfo } from "@modelcontextprotocol/sdk/server/auth/types.js";
-import { createSession, verifySession, revokeJti } from "./session.js";
+import { createSession, verifySession, revokeJti, signOauthState } from "./session.js";
 import { config } from "../config.js";
 import { atomicWriteJson, loadJsonArray } from "./persisted-store.js";
 
@@ -127,16 +127,17 @@ export const oauthProvider: OAuthServerProvider = {
   clientsStore,
 
   async authorize(client: OAuthClientInformationFull, params: AuthorizationParams, res: Response) {
-    const oauthState = Buffer.from(
-      JSON.stringify({
-        client_id: client.client_id,
-        redirect_uri: params.redirectUri,
-        code_challenge: params.codeChallenge,
-        scope: params.scopes,
-        state: params.state,
-      })
-    ).toString("base64url");
-    res.redirect(`/login?oauth_state=${oauthState}`);
+    const oauthState = signOauthState({
+      client_id: client.client_id,
+      redirect_uri: params.redirectUri,
+      code_challenge: params.codeChallenge,
+      scope: params.scopes,
+      state: params.state,
+      // Bind the state to roughly the authorize->callback window so a stale
+      // state can't be replayed after the login session it belonged to.
+      iat: Math.floor(Date.now() / 1000),
+    });
+    res.redirect(`/login?oauth_state=${encodeURIComponent(oauthState)}`);
   },
 
   async challengeForAuthorizationCode(_client: OAuthClientInformationFull, code: string) {

--- a/src/gateway/oauth-provider.ts
+++ b/src/gateway/oauth-provider.ts
@@ -14,6 +14,7 @@ const STORE_DIR = process.env.ETO_WALLET_DIR || join(homedir(), ".eto", "wallets
 const CLIENTS_PATH = join(STORE_DIR, "oauth_clients.json");
 const PENDING_CODES_PATH = join(STORE_DIR, "oauth_pending_codes.json");
 const REFRESH_TOKENS_PATH = join(STORE_DIR, "refresh_tokens.json");
+const RETIRED_REFRESH_PATH = join(STORE_DIR, "retired_refresh_tokens.json");
 
 interface PendingCode {
   address: string;
@@ -24,11 +25,17 @@ interface PendingCode {
   exp: number;
 }
 
-type RefreshEntry = { address: string; client_id: string; scope: string[] };
+type RefreshEntry = { address: string; client_id: string; scope: string[]; family_id: string };
+type RetiredEntry = { family_id: string; retired_at: number };
 
 const clientsMap = new Map<string, OAuthClientInformationFull>();
 const pendingCodes = new Map<string, PendingCode>();
 const refreshTokens = new Map<string, RefreshEntry>();
+// Retired refresh tokens from rotation. Re-presentation of one of these means
+// an attacker either got the retired token first or the legitimate holder is
+// replaying — either way, RFC 6749bis / OAuth 2.0 BCP §4.13.2 says revoke the
+// whole family. Entries are pruned at load once retired_at + refreshTtl passes.
+const retiredRefresh = new Map<string, RetiredEntry>();
 
 // Load persisted state on module init. Fly.io machines restart on deploy and
 // may restart on idle with auto_stop_machines="stop"; without persistence the
@@ -43,12 +50,19 @@ const refreshTokens = new Map<string, RefreshEntry>();
     if (v.exp > now) pendingCodes.set(k, v);
   }
   for (const [k, v] of loadJsonArray<[string, RefreshEntry]>(REFRESH_TOKENS_PATH)) {
-    refreshTokens.set(k, v);
+    // Backfill family_id for tokens persisted by older binaries. Each such
+    // token gets its own singleton family so reuse detection still works
+    // for any token issued after rotation lands.
+    refreshTokens.set(k, { ...v, family_id: v.family_id ?? randomBytes(16).toString("hex") });
+  }
+  const retirementCutoff = now - config.auth.refreshTtlSeconds;
+  for (const [k, v] of loadJsonArray<[string, RetiredEntry]>(RETIRED_REFRESH_PATH)) {
+    if (v.retired_at > retirementCutoff) retiredRefresh.set(k, v);
   }
   const loaded = clientsMap.size + pendingCodes.size + refreshTokens.size;
   if (loaded > 0) {
     console.error(
-      `[eto-mcp] Loaded OAuth state: ${clientsMap.size} clients, ${pendingCodes.size} pending codes, ${refreshTokens.size} refresh tokens`,
+      `[eto-mcp] Loaded OAuth state: ${clientsMap.size} clients, ${pendingCodes.size} pending codes, ${refreshTokens.size} refresh tokens, ${retiredRefresh.size} retired`,
     );
   }
 })();
@@ -56,6 +70,23 @@ const refreshTokens = new Map<string, RefreshEntry>();
 function persistClients() { atomicWriteJson(CLIENTS_PATH, [...clientsMap.entries()]); }
 function persistPendingCodes() { atomicWriteJson(PENDING_CODES_PATH, [...pendingCodes.entries()]); }
 function persistRefreshTokens() { atomicWriteJson(REFRESH_TOKENS_PATH, [...refreshTokens.entries()]); }
+function persistRetiredRefresh() { atomicWriteJson(RETIRED_REFRESH_PATH, [...retiredRefresh.entries()]); }
+
+function revokeFamily(family_id: string): number {
+  let n = 0;
+  for (const [tok, entry] of refreshTokens) {
+    if (entry.family_id === family_id) {
+      refreshTokens.delete(tok);
+      retiredRefresh.set(tok, { family_id, retired_at: Math.floor(Date.now() / 1000) });
+      n++;
+    }
+  }
+  if (n > 0) {
+    persistRefreshTokens();
+    persistRetiredRefresh();
+  }
+  return n;
+}
 
 const clientsStore: OAuthRegisteredClientsStore = {
   getClient(clientId: string) {
@@ -155,6 +186,7 @@ export const oauthProvider: OAuthServerProvider = {
       address: pending.address,
       client_id: client.client_id,
       scope: pending.scope,
+      family_id: randomBytes(16).toString("hex"),
     });
     persistRefreshTokens();
 
@@ -173,10 +205,31 @@ export const oauthProvider: OAuthServerProvider = {
     _scopes?: string[],
     _resource?: URL
   ): Promise<OAuthTokens> {
+    // Reuse detection (OAuth 2.0 BCP §4.13.2): a retired token showing up
+    // again means the token leaked — revoke the whole family rather than
+    // silently accepting it.
+    const retired = retiredRefresh.get(refreshToken);
+    if (retired) {
+      const revoked = revokeFamily(retired.family_id);
+      console.error(`[eto-mcp] refresh reuse detected, family=${retired.family_id} revoked=${revoked}`);
+      throw new Error("Refresh token reuse detected; token family revoked");
+    }
+
     const stored = refreshTokens.get(refreshToken);
     if (!stored || stored.client_id !== client.client_id) {
       throw new Error("Invalid refresh token");
     }
+
+    // Rotate: retire the old token, mint a new one in the same family.
+    refreshTokens.delete(refreshToken);
+    retiredRefresh.set(refreshToken, {
+      family_id: stored.family_id,
+      retired_at: Math.floor(Date.now() / 1000),
+    });
+    const newRefreshToken = randomBytes(32).toString("base64url");
+    refreshTokens.set(newRefreshToken, { ...stored });
+    persistRefreshTokens();
+    persistRetiredRefresh();
 
     const accessToken = createSession({
       userId: stored.address,
@@ -191,6 +244,7 @@ export const oauthProvider: OAuthServerProvider = {
       access_token: accessToken,
       token_type: "bearer",
       expires_in: config.auth.sessionTtlSeconds,
+      refresh_token: newRefreshToken,
       scope: stored.scope.join(" "),
     };
   },
@@ -207,6 +261,17 @@ export const oauthProvider: OAuthServerProvider = {
   },
 
   async revokeToken(_client: OAuthClientInformationFull, request: OAuthTokenRevocationRequest) {
-    if (refreshTokens.delete(request.token)) persistRefreshTokens();
+    const entry = refreshTokens.get(request.token);
+    if (entry) {
+      refreshTokens.delete(request.token);
+      // Retire rather than forget — if the revoked token is replayed we want
+      // the reuse-detection path to tear down the whole family.
+      retiredRefresh.set(request.token, {
+        family_id: entry.family_id,
+        retired_at: Math.floor(Date.now() / 1000),
+      });
+      persistRefreshTokens();
+      persistRetiredRefresh();
+    }
   },
 };

--- a/src/gateway/oauth-provider.ts
+++ b/src/gateway/oauth-provider.ts
@@ -6,7 +6,7 @@ import type { OAuthServerProvider, AuthorizationParams } from "@modelcontextprot
 import type { OAuthRegisteredClientsStore } from "@modelcontextprotocol/sdk/server/auth/clients.js";
 import type { OAuthClientInformationFull, OAuthTokenRevocationRequest, OAuthTokens } from "@modelcontextprotocol/sdk/shared/auth.js";
 import type { AuthInfo } from "@modelcontextprotocol/sdk/server/auth/types.js";
-import { createSession, verifySession } from "./session.js";
+import { createSession, verifySession, revokeJti } from "./session.js";
 import { config } from "../config.js";
 import { atomicWriteJson, loadJsonArray } from "./persisted-store.js";
 
@@ -272,6 +272,13 @@ export const oauthProvider: OAuthServerProvider = {
       });
       persistRefreshTokens();
       persistRetiredRefresh();
+      return;
     }
+    // Not a known refresh token — try access-token path. Access tokens are
+    // stateless HMAC; revocation adds the jti to a denylist checked at
+    // verify time. RFC 7009 says the token type hint is advisory, so we
+    // don't rely on request.token_type_hint.
+    const session = verifySession(request.token);
+    if (session) revokeJti(session.jti, session.exp);
   },
 };

--- a/src/gateway/oauth-provider.ts
+++ b/src/gateway/oauth-provider.ts
@@ -1,4 +1,6 @@
 import { randomBytes } from "crypto";
+import { homedir } from "os";
+import { join } from "path";
 import type { Response } from "express";
 import type { OAuthServerProvider, AuthorizationParams } from "@modelcontextprotocol/sdk/server/auth/provider.js";
 import type { OAuthRegisteredClientsStore } from "@modelcontextprotocol/sdk/server/auth/clients.js";
@@ -6,6 +8,12 @@ import type { OAuthClientInformationFull, OAuthTokenRevocationRequest, OAuthToke
 import type { AuthInfo } from "@modelcontextprotocol/sdk/server/auth/types.js";
 import { createSession, verifySession } from "./session.js";
 import { config } from "../config.js";
+import { atomicWriteJson, loadJsonArray } from "./persisted-store.js";
+
+const STORE_DIR = process.env.ETO_WALLET_DIR || join(homedir(), ".eto", "wallets");
+const CLIENTS_PATH = join(STORE_DIR, "oauth_clients.json");
+const PENDING_CODES_PATH = join(STORE_DIR, "oauth_pending_codes.json");
+const REFRESH_TOKENS_PATH = join(STORE_DIR, "refresh_tokens.json");
 
 interface PendingCode {
   address: string;
@@ -16,9 +24,38 @@ interface PendingCode {
   exp: number;
 }
 
+type RefreshEntry = { address: string; client_id: string; scope: string[] };
+
 const clientsMap = new Map<string, OAuthClientInformationFull>();
 const pendingCodes = new Map<string, PendingCode>();
-const refreshTokens = new Map<string, { address: string; client_id: string; scope: string[] }>();
+const refreshTokens = new Map<string, RefreshEntry>();
+
+// Load persisted state on module init. Fly.io machines restart on deploy and
+// may restart on idle with auto_stop_machines="stop"; without persistence the
+// in-memory maps are wiped and clients see "unknown client" / "expired code"
+// mid-flow.
+(function loadAll() {
+  const now = Math.floor(Date.now() / 1000);
+  for (const [k, v] of loadJsonArray<[string, OAuthClientInformationFull]>(CLIENTS_PATH)) {
+    clientsMap.set(k, v);
+  }
+  for (const [k, v] of loadJsonArray<[string, PendingCode]>(PENDING_CODES_PATH)) {
+    if (v.exp > now) pendingCodes.set(k, v);
+  }
+  for (const [k, v] of loadJsonArray<[string, RefreshEntry]>(REFRESH_TOKENS_PATH)) {
+    refreshTokens.set(k, v);
+  }
+  const loaded = clientsMap.size + pendingCodes.size + refreshTokens.size;
+  if (loaded > 0) {
+    console.error(
+      `[eto-mcp] Loaded OAuth state: ${clientsMap.size} clients, ${pendingCodes.size} pending codes, ${refreshTokens.size} refresh tokens`,
+    );
+  }
+})();
+
+function persistClients() { atomicWriteJson(CLIENTS_PATH, [...clientsMap.entries()]); }
+function persistPendingCodes() { atomicWriteJson(PENDING_CODES_PATH, [...pendingCodes.entries()]); }
+function persistRefreshTokens() { atomicWriteJson(REFRESH_TOKENS_PATH, [...refreshTokens.entries()]); }
 
 const clientsStore: OAuthRegisteredClientsStore = {
   getClient(clientId: string) {
@@ -32,6 +69,7 @@ const clientsStore: OAuthRegisteredClientsStore = {
       client_id_issued_at: Math.floor(Date.now() / 1000),
     };
     clientsMap.set(client_id, client);
+    persistClients();
     return client;
   },
 };
@@ -50,6 +88,7 @@ export function issueAuthCode(
     scope: params.scopes ?? ["mcp:tools"],
     exp: Math.floor(Date.now() / 1000) + 600,
   });
+  persistPendingCodes();
   return code;
 }
 
@@ -86,9 +125,11 @@ export const oauthProvider: OAuthServerProvider = {
     if (!pending) throw new Error("Unknown or expired authorization code");
     if (pending.exp < Math.floor(Date.now() / 1000)) {
       pendingCodes.delete(code);
+      persistPendingCodes();
       throw new Error("Authorization code expired");
     }
     pendingCodes.delete(code);
+    persistPendingCodes();
 
     const accessToken = createSession({
       userId: pending.address,
@@ -105,6 +146,7 @@ export const oauthProvider: OAuthServerProvider = {
       client_id: client.client_id,
       scope: pending.scope,
     });
+    persistRefreshTokens();
 
     return {
       access_token: accessToken,
@@ -155,6 +197,6 @@ export const oauthProvider: OAuthServerProvider = {
   },
 
   async revokeToken(_client: OAuthClientInformationFull, request: OAuthTokenRevocationRequest) {
-    refreshTokens.delete(request.token);
+    if (refreshTokens.delete(request.token)) persistRefreshTokens();
   },
 };

--- a/src/gateway/persisted-store.ts
+++ b/src/gateway/persisted-store.ts
@@ -1,0 +1,20 @@
+import { mkdirSync, readFileSync, renameSync, writeFileSync } from "fs";
+import { dirname } from "path";
+
+// Atomic JSON write: write to tmp, fsync-free rename into place. Same
+// filesystem required (rename(2) is only atomic within a single mount).
+// A half-written tmp file after a crash is ignored on the next load.
+export function atomicWriteJson(path: string, data: unknown): void {
+  mkdirSync(dirname(path), { recursive: true });
+  const tmp = `${path}.tmp`;
+  writeFileSync(tmp, JSON.stringify(data), { mode: 0o600 });
+  renameSync(tmp, path);
+}
+
+export function loadJsonArray<T>(path: string): T[] {
+  try {
+    return JSON.parse(readFileSync(path, "utf8")) as T[];
+  } catch {
+    return [];
+  }
+}

--- a/src/gateway/session.ts
+++ b/src/gateway/session.ts
@@ -6,8 +6,15 @@ import { join } from "path";
 import { atomicWriteJson, loadJsonArray } from "./persisted-store.js";
 
 /**
- * Session management using signed tokens.
- * Phase 1: Simple HMAC-signed JSON tokens (PASETO v4 deferred to Phase 2).
+ * Session management using HMAC-SHA256 signed JSON tokens.
+ *
+ * Token format: base64url(json_payload).hex(hmac_sha256(payload))
+ * NOT a standard JWT — no `alg` header, no JWS envelope. If this needs to be
+ * consumed by a third party JWT verifier in the future, migrate to PASETO v4
+ * or JWS and drop this format.
+ *
+ * Signing key is sourced from SESSION_SIGNING_KEY, falling back to the
+ * historical PASETO_SIGNING_KEY env var for backwards compatibility.
  */
 
 export type AuthStrategy = "siwe" | "inapp_email" | "inapp_oauth" | "dev";
@@ -64,12 +71,16 @@ export type Capability = keyof typeof CAPABILITY_SCOPES;
 
 const ALL_CAPS = Object.keys(CAPABILITY_SCOPES) as Capability[];
 
-// Signing key: must be set in production
+// Signing key: must be set in production.
+// Accepts either SESSION_SIGNING_KEY (preferred) or PASETO_SIGNING_KEY
+// (legacy name — the implementation is HMAC-SHA256, not PASETO).
 const signingKey = (() => {
-  const envKey = process.env.PASETO_SIGNING_KEY;
+  const envKey = process.env.SESSION_SIGNING_KEY ?? process.env.PASETO_SIGNING_KEY;
   if (process.env.NODE_ENV === "production") {
     if (!envKey || envKey.length < 32) {
-      console.error("FATAL: PASETO_SIGNING_KEY must be set to at least 32 characters in production");
+      console.error(
+        "FATAL: SESSION_SIGNING_KEY (or legacy PASETO_SIGNING_KEY) must be set to at least 32 characters in production",
+      );
       process.exit(1);
     }
   }

--- a/src/gateway/session.ts
+++ b/src/gateway/session.ts
@@ -103,6 +103,30 @@ export function revokeJti(jti: string, exp: number): void {
   atomicWriteJson(DENYLIST_PATH, [...denyList.entries()]);
 }
 
+// Signed oauth_state used to carry /authorize params through /login to
+// /oauth-callback. Same HMAC key as session tokens — clients (or a
+// compromised /login page) can't tamper with redirect_uri, code_challenge,
+// client_id, scope, or state without the signature breaking.
+export function signOauthState(payload: object): string {
+  const json = JSON.stringify(payload);
+  const sig = hmacSign(json);
+  return `${Buffer.from(json).toString("base64url")}.${sig}`;
+}
+
+export function verifyOauthState<T = unknown>(token: string): T | null {
+  try {
+    const [b64, sig] = token.split(".");
+    if (!b64 || !sig) return null;
+    const json = Buffer.from(b64, "base64url").toString();
+    const expected = Buffer.from(hmacSign(json), "hex");
+    const actual = Buffer.from(sig, "hex");
+    if (expected.length !== actual.length || !timingSafeEqual(expected, actual)) return null;
+    return JSON.parse(json) as T;
+  } catch {
+    return null;
+  }
+}
+
 export function createSession(opts: {
   userId: string;
   walletId: string;

--- a/src/gateway/session.ts
+++ b/src/gateway/session.ts
@@ -1,6 +1,9 @@
 import { sha256 } from "@noble/hashes/sha256";
 import { hmac } from "@noble/hashes/hmac";
 import { timingSafeEqual } from "crypto";
+import { homedir } from "os";
+import { join } from "path";
+import { atomicWriteJson, loadJsonArray } from "./persisted-store.js";
 
 /**
  * Session management using signed tokens.
@@ -80,6 +83,26 @@ function hmacSign(data: string): string {
   return Buffer.from(mac).toString("hex");
 }
 
+// Access-token denylist. Access tokens are stateless HMAC so we can't revoke
+// them structurally — a revocation list is the only way. Keyed by jti -> exp;
+// entries expire naturally when the underlying token would have.
+const DENYLIST_PATH = join(
+  process.env.ETO_WALLET_DIR || join(homedir(), ".eto", "wallets"),
+  "revoked_jtis.json",
+);
+const denyList = new Map<string, number>();
+(function loadDenyList() {
+  const now = Math.floor(Date.now() / 1000);
+  for (const [jti, exp] of loadJsonArray<[string, number]>(DENYLIST_PATH)) {
+    if (exp > now) denyList.set(jti, exp);
+  }
+})();
+
+export function revokeJti(jti: string, exp: number): void {
+  denyList.set(jti, exp);
+  atomicWriteJson(DENYLIST_PATH, [...denyList.entries()]);
+}
+
 export function createSession(opts: {
   userId: string;
   walletId: string;
@@ -125,6 +148,9 @@ export function verifySession(token: string): SessionPayload | null {
 
     // Check expiry
     if (payload.exp < Math.floor(Date.now() / 1000)) return null;
+
+    // Check revocation list (access-token denylist)
+    if (denyList.has(payload.jti)) return null;
 
     return payload;
   } catch {

--- a/src/login.tsx
+++ b/src/login.tsx
@@ -52,19 +52,21 @@ function Inner() {
     doAuth(account)
       .then(async ({ payload, signature }) => {
         if (isOAuthMode) {
-          // OAuth mode: POST to /oauth-callback, server issues code and redirects
+          // OAuth mode: POST to /oauth-callback. The server returns
+          // { location: "..." } (JSON, not 302) so we can navigate to any
+          // scheme — fetch() can't follow redirects to cursor:// or vscode://.
           setStatus("Redirecting back to your MCP client…");
           const res = await fetch(`${BASE}/oauth-callback`, {
             method: "POST",
             headers: { "content-type": "application/json" },
             body: JSON.stringify({ payload, signature, oauth_state: oauthState }),
           });
-          if (res.redirected) {
-            window.location.href = res.url;
-          } else {
-            const text = await res.text();
-            setStatus(`Redirect failed: ${text}`);
+          const body = await res.json().catch(() => null);
+          if (!res.ok || !body?.location) {
+            setStatus(`Redirect failed: ${body?.error ?? res.statusText}`);
+            return;
           }
+          window.location.href = body.location;
         } else {
           // Standalone mode: verify and show bearer token
           const r = await fetch(`${BASE}/auth/verify`, {

--- a/src/sse-server.ts
+++ b/src/sse-server.ts
@@ -14,6 +14,7 @@ import { runWithAuth } from "./gateway/auth.js";
 import { sessionStore } from "./signing/session-context.js";
 import { oauthProvider, issueAuthCode } from "./gateway/oauth-provider.js";
 import { verifyPayload } from "./gateway/thirdweb.js";
+import { verifyOauthState } from "./gateway/session.js";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const LLMS_TXT = readFileSync(join(__dirname, "../public/llms.txt"), "utf8");
@@ -61,17 +62,23 @@ app.post("/oauth-callback", express.json(), async (req, res) => {
     return;
   }
 
-  let params: {
+  const params = verifyOauthState<{
     client_id: string;
     redirect_uri: string;
     code_challenge: string;
     scope?: string[];
     state?: string;
-  };
-  try {
-    params = JSON.parse(Buffer.from(oauth_state, "base64url").toString());
-  } catch {
-    res.status(400).json({ error: "Invalid oauth_state" });
+    iat?: number;
+  }>(oauth_state);
+  if (!params) {
+    res.status(400).json({ error: "Invalid or tampered oauth_state" });
+    return;
+  }
+  // Bound authorize->callback round-trip at 30 min — defends against stale
+  // state replay after the login session expired.
+  const MAX_STATE_AGE_SEC = 30 * 60;
+  if (typeof params.iat === "number" && Date.now() / 1000 - params.iat > MAX_STATE_AGE_SEC) {
+    res.status(400).json({ error: "oauth_state expired; restart login" });
     return;
   }
 

--- a/src/sse-server.ts
+++ b/src/sse-server.ts
@@ -181,6 +181,18 @@ app.post("/message", async (req, res) => {
 
 // Start
 async function startSseServer(): Promise<void> {
+  // Warn loudly if ISSUER_URL wasn't set explicitly in production. The
+  // /.well-known/* metadata advertises this URL to MCP clients; a mismatch
+  // with the public hostname makes /authorize and /token route to the wrong
+  // host and the client looks like it's in a redirect loop.
+  if (process.env.NODE_ENV === "production" && !process.env.ISSUER_URL) {
+    console.error(
+      `[eto-mcp] WARN: ISSUER_URL not set — defaulting to ${ISSUER_URL}. ` +
+      `If you reverse-proxy this server under a different hostname, set ` +
+      `ISSUER_URL explicitly or MCP clients will hit the default host.`,
+    );
+  }
+
   blockhashCache.startRefresh();
 
   wsManager.connect().then(ok => {

--- a/src/sse-server.ts
+++ b/src/sse-server.ts
@@ -87,7 +87,10 @@ app.post("/oauth-callback", express.json(), async (req, res) => {
     const redirectErr = new URL(params.redirect_uri);
     redirectErr.searchParams.set("error", "access_denied");
     if (params.state) redirectErr.searchParams.set("state", params.state);
-    res.redirect(redirectErr.toString());
+    // Return JSON instead of 302 so the browser can navigate even when
+    // redirect_uri is a custom scheme (cursor://, vscode://, cloud://...).
+    // fetch() can't follow cross-scheme redirects; the client JS does it.
+    res.json({ location: redirectErr.toString(), error: "access_denied" });
     return;
   }
 
@@ -103,7 +106,7 @@ app.post("/oauth-callback", express.json(), async (req, res) => {
   const redirectUrl = new URL(params.redirect_uri);
   redirectUrl.searchParams.set("code", code);
   if (params.state) redirectUrl.searchParams.set("state", params.state);
-  res.redirect(redirectUrl.toString());
+  res.json({ location: redirectUrl.toString() });
 });
 
 // llms.txt — agent-readable description of this server


### PR DESCRIPTION
## Summary

Hardens the OAuth 2.1 authorization server to fix the user-visible redirect loops and close several spec / security gaps. Eight files, 7 atomic commits — no squash please.

### What was broken

| # | Severity | Issue |
|---|---|---|
| 1 | 🔴 HIGH | `clientsMap`, `pendingCodes`, `refreshTokens` were in-memory Maps. Fly machine restart (redeploy or `auto_stop_machines=stop`) wiped them → MCP clients saw `unknown_client` / `code expired` mid-flow, surfaced as redirect loops. |
| 2 | 🔴 HIGH | `exchangeAuthorizationCode` never verified `redirect_uri` at `/token` matched the one used at `/authorize`. OAuth 2.1 §5.2 mandates this. |
| 3 | 🟡 MED | `exchangeRefreshToken` minted a new access token but **did not rotate** the refresh token. Compromise = 30 days of unbounded access. |
| 4 | 🟡 MED | `revokeToken` silently no-op'd on access tokens (stateless HMAC has no store to delete from). Users thought they'd revoked a token; it stayed valid up to 24h. |
| 5 | 🟡 MED | `oauth_state` was plain base64url(JSON) — a compromised `/login` page could tamper with `redirect_uri` / scope / `client_id` before the callback POST. |
| 6 | 🟡 MED | `ISSUER_URL` silently defaulted to `eto-mcp.fly.dev` in prod. Reverse-proxying under a custom domain → `.well-known/*` pointed clients at the wrong host → redirect loop. |
| 7 | 🟢 LOW | `PASETO_SIGNING_KEY` env var was misnomer — impl is HMAC-SHA256, not PASETO. Future you will be confused. |
| 8 | 🟢 LOW | `/oauth-callback` responded with 302. `fetch()` can't follow redirects to custom schemes (`cursor://`, `vscode://`, `claude://`) — MCP desktop clients that use custom schemes could never complete OAuth. |

### Commits (atomic, one issue each)

1. **feat(auth): persist OAuth clients, pending codes, and refresh tokens** — new `persisted-store.ts` helper writes atomically (tmp + rename). All three maps hydrate on init.
2. **fix(auth): verify redirect_uri matches on authorization code exchange** — OAuth 2.1 §5.2.
3. **feat(auth): rotate refresh tokens on use + detect reuse** — BCP §4.13.2. Each refresh retires the old token; if a retired token is replayed, the whole family is revoked.
4. **feat(auth): access-token denylist via revoked-jti persistence** — `revokeToken` now actually does something for access tokens via a jti denylist checked on every `verifySession`.
5. **feat(auth): HMAC-sign oauth_state** — tamper-proof state passed through `/login`, with `iat` + 30 min max age.
6. **feat(auth): /oauth-callback returns JSON location** — browser navigates via `window.location.href` so any scheme works.
7. **chore(auth): ISSUER_URL prod warn + SESSION_SIGNING_KEY alias + docs**

### Out of scope (follow-up)

- Unit tests — `tests/unit/` exists but none added here. Suggested coverage: `verifySession` denylist, `oauth_state` sign/verify round-trip, refresh-token rotation + reuse detection, `redirect_uri` mismatch rejection. Noting this explicitly so it's deferred not forgotten.
- Setting `ISSUER_URL` as a Fly secret — infra change, do separately.
- EVM deploy not returning tx hash — separate bug, separate PR.

### Backwards compatibility

- Persisted files use new names (`oauth_clients.json`, `oauth_pending_codes.json`, `refresh_tokens.json`, `retired_refresh_tokens.json`, `revoked_jtis.json`). No migration needed — they're created empty on first run.
- Legacy refresh tokens loaded from disk get a fresh singleton `family_id` so reuse detection kicks in on first refresh.
- `PASETO_SIGNING_KEY` env var still works (preferred is `SESSION_SIGNING_KEY`).

## Test plan

- [ ] Deploy to Fly, kick a machine (`flyctl machine restart`), complete full OAuth flow with Claude Desktop — verify client/code state survives.
- [ ] Tamper with `oauth_state` query param on `/login` → callback must reject with 400.
- [ ] Use a refresh token twice → second use must fail + revoke family.
- [ ] Revoke an access token via `/revoke` → subsequent `/message` call with that token must 401.
- [ ] Complete OAuth flow from a client with `redirect_uri=cursor://...` style custom scheme.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * OAuth authorization state now signed and validated with timestamp freshness checks (30-minute window)
  * Token refresh now includes family-based reuse detection and rotation
  * Authorization and token state persists across service restarts

* **Bug Fixes**
  * Enhanced token revocation handling with improved consistency
  * OAuth callback endpoint now returns structured JSON responses instead of HTTP redirects

<!-- end of auto-generated comment: release notes by coderabbit.ai -->