### PR TITLE
ci: add PR-gating workflow (typecheck · test · build)

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -1,0 +1,55 @@
+name: PR Checks
+
+on:
+  pull_request:
+    branches: [master]
+  push:
+    branches: [master]
+
+concurrency:
+  group: pr-checks-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  typecheck-test-build:
+    name: typecheck · test · build
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.3.10
+
+      - name: Cache Bun deps
+        uses: actions/cache@v4
+        with:
+          path: ~/.bun/install/cache
+          key: bun-${{ runner.os }}-${{ hashFiles('**/bun.lock') }}
+          restore-keys: bun-${{ runner.os }}-
+
+      - name: Install
+        run: bun install --frozen-lockfile
+
+      - name: Typecheck
+        run: bun run typecheck
+
+      - name: Test
+        run: bun run test
+        env:
+          NODE_OPTIONS: --max-old-space-size=4096
+
+      - name: Build
+        run: bun run build
+
+      - name: Verify no leftover build artifacts
+        run: |
+          if [ -n "$(git status --porcelain)" ]; then
+            echo "Working tree dirty after build:"
+            git status --short
+            exit 1
+          fi

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,18 @@ dist/
 *.log
 *.tsbuildinfo
 .omc/
+target/
+.gstack/
+.env
+.env.local
+
+# Foundry build artifacts
+mesh/contracts/cache/
+mesh/contracts/out/
+.eto/
+
+# Fusion runtime + agent worktrees
+.worktrees/
+.fusion/
+.tbd/
+coverage/


### PR DESCRIPTION
## Summary

Adds the first PR-gating CI workflow for eto-mcp, run on every PR to `master`:
- `bun install --frozen-lockfile`
- `bun run typecheck` (`tsc -p tsconfig.issuers.json`)
- `bun run test` (`vitest run`)
- `bun run build` (`tsc -p tsconfig.build.issuers.json`)
- working-tree-clean check after build

Once this lands, master will be protected: every fusion-agent task must open a PR + pass this workflow before it can merge. That replaces the previous "fusion auto-squashes locally" pattern that's been silently breaking master.

Also extends `.gitignore` to exclude `.fusion/`, `.worktrees/`, `.tbd/`, `coverage/` so fusion's runtime state never accidentally lands in commits.

## Test plan

- [ ] CI runs and reports status on this PR
- [ ] Once green, branch-protect master to require this check

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added automated quality checks (type checking, testing, and building) to the CI/CD pipeline for pull requests.
  * Updated project configuration to exclude additional build artifacts and workspace directories.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->