### PR TITLE
feat(FN-190): scaffold spec/banking/credentials/ JSON-LD VC templates

### DIFF
--- a/spec/banking/credentials/account-checking.json
+++ b/spec/banking/credentials/account-checking.json
@@ -1,0 +1,80 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://schema.eto.dev/banking/account-checking/v1",
+  "$comment": "FN-190 — JSON-LD VC template for an eUSD checking account credential. Mirrors src/issuers/bank.ts:buildAccountCheckingVc and SINGULARITY-LAYER-1.md §10.3.1.",
+  "title": "CheckingAccountCredential",
+  "type": "object",
+  "required": [
+    "@context",
+    "type",
+    "issuer",
+    "issuanceDate",
+    "credentialSubject",
+    "issuerAuthority"
+  ],
+  "properties": {
+    "@context": {
+      "type": "array",
+      "minItems": 2,
+      "items": { "type": "string" },
+      "default": [
+        "https://www.w3.org/2018/credentials/v1",
+        "https://schema.eto.dev/banking/account-checking/v1"
+      ]
+    },
+    "type": {
+      "type": "array",
+      "items": { "type": "string" },
+      "contains": { "const": "VerifiableCredential" },
+      "default": ["VerifiableCredential", "CheckingAccountCredential"]
+    },
+    "issuer": {
+      "type": "string",
+      "description": "Issuer DID, e.g. did:eto:bank:eto-reference",
+      "pattern": "^did:eto:"
+    },
+    "issuanceDate": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "credentialSubject": {
+      "type": "object",
+      "required": ["id", "account_pda", "holder", "opened_slot", "currency", "opening_balance"],
+      "additionalProperties": false,
+      "properties": {
+        "id": {
+          "type": "string",
+          "pattern": "^did:eto:agentcard:[0-9a-fA-F]{64}$"
+        },
+        "account_pda": {
+          "type": "string",
+          "pattern": "^[0-9a-fA-F]{64}$"
+        },
+        "holder": {
+          "type": "string",
+          "pattern": "^[0-9a-fA-F]{64}$"
+        },
+        "opened_slot": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "currency": { "const": "eUSD" },
+        "opening_balance": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Atomic eUSD units (6-decimal)."
+        }
+      }
+    },
+    "issuerAuthority": {
+      "type": "string",
+      "pattern": "^[0-9a-fA-F]{64}$",
+      "description": "On-chain issuer-authority pubkey (hex64)."
+    },
+    "claim_hash": {
+      "type": "string",
+      "pattern": "^[0-9a-fA-F]{64}$",
+      "description": "SHA-256 over the JCS-canonicalized credentialSubject (set at issuance, optional in the template)."
+    }
+  }
+}

--- a/spec/banking/credentials/account-savings.json
+++ b/spec/banking/credentials/account-savings.json
@@ -1,0 +1,91 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://schema.eto.dev/banking/account-savings/v1",
+  "$comment": "FN-190 — JSON-LD VC template for an eUSD savings account credential. Mirrors src/issuers/bank.ts:buildAccountSavingsVc.",
+  "title": "SavingsAccountCredential",
+  "type": "object",
+  "required": [
+    "@context",
+    "type",
+    "issuer",
+    "issuanceDate",
+    "credentialSubject",
+    "issuerAuthority"
+  ],
+  "properties": {
+    "@context": {
+      "type": "array",
+      "minItems": 2,
+      "items": { "type": "string" },
+      "default": [
+        "https://www.w3.org/2018/credentials/v1",
+        "https://schema.eto.dev/banking/account-savings/v1"
+      ]
+    },
+    "type": {
+      "type": "array",
+      "items": { "type": "string" },
+      "contains": { "const": "VerifiableCredential" },
+      "default": ["VerifiableCredential", "SavingsAccountCredential"]
+    },
+    "issuer": {
+      "type": "string",
+      "pattern": "^did:eto:"
+    },
+    "issuanceDate": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "credentialSubject": {
+      "type": "object",
+      "required": [
+        "id",
+        "account_pda",
+        "holder",
+        "opened_slot",
+        "currency",
+        "opening_balance",
+        "apy_bps"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "id": {
+          "type": "string",
+          "pattern": "^did:eto:agentcard:[0-9a-fA-F]{64}$"
+        },
+        "account_pda": {
+          "type": "string",
+          "pattern": "^[0-9a-fA-F]{64}$"
+        },
+        "holder": {
+          "type": "string",
+          "pattern": "^[0-9a-fA-F]{64}$"
+        },
+        "opened_slot": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "currency": { "const": "eUSD" },
+        "opening_balance": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Atomic eUSD units (6-decimal)."
+        },
+        "apy_bps": {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 100000,
+          "description": "Annual yield in basis points (e.g. 400 = 4.00% APY)."
+        }
+      }
+    },
+    "issuerAuthority": {
+      "type": "string",
+      "pattern": "^[0-9a-fA-F]{64}$"
+    },
+    "claim_hash": {
+      "type": "string",
+      "pattern": "^[0-9a-fA-F]{64}$"
+    }
+  }
+}

--- a/spec/banking/credentials/card-debit.json
+++ b/spec/banking/credentials/card-debit.json
@@ -1,0 +1,120 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://schema.eto.dev/banking/card-debit/v1",
+  "$comment": "FN-190 — JSON-LD VC template for a debit-card credential. Mirrors src/issuers/bank.ts:buildCardDebitVc and the keeper handler in keeper/bpps/bank/handlers/issue-card.ts. merchant_category_blocklist added in FN-103.",
+  "title": "CardDebitCredential",
+  "type": "object",
+  "required": [
+    "@context",
+    "type",
+    "issuer",
+    "issuanceDate",
+    "credentialSubject",
+    "issuerAuthority"
+  ],
+  "properties": {
+    "@context": {
+      "type": "array",
+      "minItems": 2,
+      "items": { "type": "string" },
+      "default": [
+        "https://www.w3.org/2018/credentials/v1",
+        "https://schema.eto.dev/banking/card-debit/v1"
+      ]
+    },
+    "type": {
+      "type": "array",
+      "items": { "type": "string" },
+      "contains": { "const": "VerifiableCredential" },
+      "default": ["VerifiableCredential", "CardDebitCredential"]
+    },
+    "issuer": {
+      "type": "string",
+      "pattern": "^did:eto:"
+    },
+    "issuanceDate": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "credentialSubject": {
+      "type": "object",
+      "required": [
+        "id",
+        "card_id_hash",
+        "holder",
+        "linked_account_pda",
+        "jurisdiction",
+        "issued_slot",
+        "spending_limit_per_day",
+        "network_brand",
+        "tier"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "id": {
+          "type": "string",
+          "pattern": "^did:eto:agentcard:[0-9a-fA-F]{64}$"
+        },
+        "card_id_hash": {
+          "type": "string",
+          "pattern": "^[0-9a-fA-F]{64}$",
+          "description": "Salted SHA-256 of card PAN. Opaque — never PAN-recoverable."
+        },
+        "holder": {
+          "type": "string",
+          "pattern": "^[0-9a-fA-F]{64}$"
+        },
+        "linked_account_pda": {
+          "type": "string",
+          "pattern": "^[0-9a-fA-F]{64}$"
+        },
+        "jurisdiction": {
+          "type": "string",
+          "pattern": "^[a-z]{2}$",
+          "description": "Lowercase ISO 3166-1 alpha-2."
+        },
+        "issued_slot": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "expires_slot": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "0 = no expiry (sentinel)."
+        },
+        "spending_limit_per_day": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Atomic eUSD units."
+        },
+        "spending_limit_per_tx": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "network_brand": {
+          "enum": ["visa", "mastercard", "amex", "internal"]
+        },
+        "tier": {
+          "enum": ["standard", "premium", "metal"]
+        },
+        "merchant_category_blocklist": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "pattern": "^[0-9]{4}$"
+          },
+          "uniqueItems": true,
+          "description": "MCC codes blocked for this card. Optional — empty/absent = no restriction. Added in FN-103."
+        }
+      }
+    },
+    "issuerAuthority": {
+      "type": "string",
+      "pattern": "^[0-9a-fA-F]{64}$"
+    },
+    "claim_hash": {
+      "type": "string",
+      "pattern": "^[0-9a-fA-F]{64}$"
+    }
+  }
+}

--- a/spec/banking/credentials/tax-1099.json
+++ b/spec/banking/credentials/tax-1099.json
@@ -1,0 +1,101 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://schema.eto.dev/banking/tax-1099/v1",
+  "$comment": "FN-190 — JSON-LD VC template for an annual 1099 tax credential. No runtime emitter yet (lands with FN-3.13.1.x); this template establishes the field shape so the eventual issuer mirrors it.",
+  "title": "Tax1099Credential",
+  "type": "object",
+  "required": [
+    "@context",
+    "type",
+    "issuer",
+    "issuanceDate",
+    "credentialSubject",
+    "issuerAuthority"
+  ],
+  "properties": {
+    "@context": {
+      "type": "array",
+      "minItems": 2,
+      "items": { "type": "string" },
+      "default": [
+        "https://www.w3.org/2018/credentials/v1",
+        "https://schema.eto.dev/banking/tax-1099/v1"
+      ]
+    },
+    "type": {
+      "type": "array",
+      "items": { "type": "string" },
+      "contains": { "const": "VerifiableCredential" },
+      "default": ["VerifiableCredential", "Tax1099Credential"]
+    },
+    "issuer": {
+      "type": "string",
+      "pattern": "^did:eto:"
+    },
+    "issuanceDate": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "credentialSubject": {
+      "type": "object",
+      "required": [
+        "id",
+        "year",
+        "interest_income_atomic",
+        "fees_atomic",
+        "withholding_atomic",
+        "currency"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "id": {
+          "type": "string",
+          "pattern": "^did:eto:agentcard:[0-9a-fA-F]{64}$"
+        },
+        "year": {
+          "type": "integer",
+          "minimum": 2024,
+          "maximum": 2100,
+          "description": "Tax year the 1099 covers (calendar year, end-of-year cutoff)."
+        },
+        "interest_income_atomic": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Total interest income for the year, in atomic eUSD units (6-decimal). Box 1 equivalent."
+        },
+        "fees_atomic": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Total bank fees paid during the year. Atomic eUSD."
+        },
+        "withholding_atomic": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Federal withholding (if any). Atomic eUSD. Box 4 equivalent."
+        },
+        "currency": { "const": "eUSD" },
+        "linked_account_pdas": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "pattern": "^[0-9a-fA-F]{64}$"
+          },
+          "description": "Source account PDAs aggregated into this 1099. Optional but recommended for audit replay."
+        },
+        "download_url": {
+          "type": "string",
+          "format": "uri",
+          "description": "Off-chain signed PDF download. Optional — credential is sufficient on its own."
+        }
+      }
+    },
+    "issuerAuthority": {
+      "type": "string",
+      "pattern": "^[0-9a-fA-F]{64}$"
+    },
+    "claim_hash": {
+      "type": "string",
+      "pattern": "^[0-9a-fA-F]{64}$"
+    }
+  }
+}


### PR DESCRIPTION
Prerequisite for FN-077. Adds 4 JSON Schema (draft 2020-12) templates under `spec/banking/credentials/`:

- **account-checking.json** — mirrors `src/issuers/bank.ts:buildAccountCheckingVc`
- **account-savings.json** — mirrors `buildAccountSavingsVc` + adds `apy_bps`
- **card-debit.json** — mirrors `buildCardDebitVc`, includes FN-103's `merchant_category_blocklist`
- **tax-1099.json** — new shape (no runtime emitter yet). Carries year, interest_income, fees, withholding (atomic eUSD), optional linked_account_pdas array + signed-PDF URL.

Each template pins the W3C VC envelope plus the per-credential subject shape with strict patterns (64-hex pubkeys/PDAs, `did:eto:agentcard:*` subject id, ISO 3166-1 alpha-2 jurisdiction, 4-digit MCC strings).

Coordinated with the bank-mock emitter so subject field names line up across the runtime + spec.

🤖 Generated with [Claude Code](https://claude.com/claude-code)