### PR TITLE
feat(FN-191): orphan-ledger reconciliation hook on issue-card + open-checking

### DIFF
--- a/keeper/bpps/bank/handlers/issue-card.flag-reconciliation.test.ts
+++ b/keeper/bpps/bank/handlers/issue-card.flag-reconciliation.test.ts
@@ -1,0 +1,71 @@
+/**
+ * FN-191 — issue-card flagReconciliation hook tests.
+ *
+ * AC:
+ *   - flagReconciliation is invoked exactly once with (card_pda, holder, body)
+ *     when issueCardCredential throws after recordCard succeeded.
+ *   - flagReconciliation is NOT invoked when issueCardCredential succeeds.
+ *   - flagReconciliation is NOT invoked when recordCard itself throws
+ *     (no orphan to reconcile in that case — ledger never wrote).
+ *   - flagReconciliation that itself throws does not mask the primary
+ *     `issue_failed` error.
+ */
+import { describe, it, expect, vi } from "vitest";
+import { issueCard, IssueCardRejected, type IssueCardDeps } from "./issue-card";
+
+const SUBJECT = "1".repeat(64);
+const BANK = "0".repeat(64);
+const LINKED = "2".repeat(64);
+
+function baseDeps(): IssueCardDeps {
+  return {
+    verifyHolderCredentials: vi.fn().mockResolvedValue(true),
+    verifyLinkedAccount: vi.fn().mockResolvedValue(true),
+    issueCardCredential: vi.fn().mockResolvedValue({ tx_signature: "tx", credential_pda: "pda" }),
+    recordCard: vi.fn().mockResolvedValue(undefined),
+    flagReconciliation: vi.fn().mockResolvedValue(undefined),
+  };
+}
+
+const req = {
+  subject: SUBJECT,
+  bank_issuer: BANK,
+  linked_account_pda: LINKED,
+  issued_slot: 1_000_000,
+};
+
+describe("FN-191 — issue-card flagReconciliation", () => {
+  it("invokes flagReconciliation exactly once when issueCardCredential throws", async () => {
+    const deps = baseDeps();
+    deps.issueCardCredential = vi.fn().mockRejectedValue(new Error("chain rpc down"));
+    await expect(issueCard(req, deps)).rejects.toThrow(IssueCardRejected);
+    expect(deps.flagReconciliation).toHaveBeenCalledOnce();
+    const [card_pda, holder, body] = (deps.flagReconciliation as any).mock.calls[0]!;
+    expect(card_pda).toMatch(/^[0-9a-f]{64}$/);
+    expect(holder).toBe(SUBJECT);
+    expect(body.linked_account_pda).toBe(LINKED);
+  });
+
+  it("does NOT invoke flagReconciliation on the happy path", async () => {
+    const deps = baseDeps();
+    await issueCard(req, deps);
+    expect(deps.flagReconciliation).not.toHaveBeenCalled();
+  });
+
+  it("does NOT invoke flagReconciliation when recordCard itself throws (nothing to reconcile)", async () => {
+    const deps = baseDeps();
+    deps.recordCard = vi.fn().mockRejectedValue(new Error("ledger down"));
+    await expect(issueCard(req, deps)).rejects.toThrow(IssueCardRejected);
+    expect(deps.flagReconciliation).not.toHaveBeenCalled();
+  });
+
+  it("does NOT mask the primary issue_failed error if flagReconciliation itself throws", async () => {
+    const deps = baseDeps();
+    deps.issueCardCredential = vi.fn().mockRejectedValue(new Error("chain rpc down"));
+    deps.flagReconciliation = vi.fn().mockRejectedValue(new Error("flag service down"));
+    await expect(issueCard(req, deps)).rejects.toMatchObject({
+      reason: "issue_failed",
+    });
+    expect(deps.flagReconciliation).toHaveBeenCalledOnce();
+  });
+});

--- a/keeper/bpps/bank/handlers/issue-card.ts
+++ b/keeper/bpps/bank/handlers/issue-card.ts
@@ -150,6 +150,23 @@ export interface IssueCardDeps {
    * instruction lands.
    */
   recordCard(pda: string, card: CardDebitCredentialBody): Promise<void>;
+
+  /**
+   * FN-191: orphan-ledger reconciliation hook. Called from the
+   * `issue_failed` path AFTER `recordCard` succeeded but the on-chain
+   * `issueCardCredential` threw. Mirrors the `flagReconciliation` hook
+   * in `offramp.ts` so ops can take corrective action and the eventual
+   * GC sweeper can find the orphan via this signal instead of
+   * scanning the entire ledger.
+   *
+   * Implementations MUST be idempotent — the runtime may invoke this
+   * more than once for the same `card_pda` (retry storms, replays).
+   */
+  flagReconciliation(
+    card_pda: string,
+    holder: string,
+    body: CardDebitCredentialBody,
+  ): Promise<void>;
 }
 
 // ---------------------------------------------------------------------------
@@ -282,6 +299,16 @@ export async function issueCard(
   try {
     await deps.issueCardCredential(credential);
   } catch {
+    // FN-191: ledger entry from recordCard is now orphaned. Flag for
+    // reconciliation BEFORE rethrowing so ops gets a deterministic
+    // signal and the eventual GC sweeper has a stable handle.
+    // flagReconciliation must not throw — if it does, swallow it: the
+    // primary error (issue_failed) is what callers care about.
+    try {
+      await deps.flagReconciliation(card_pda, body.holder, body);
+    } catch {
+      // intentionally swallowed
+    }
     throw new IssueCardRejected("issue_failed");
   }
 
@@ -325,6 +352,12 @@ export const stubs: IssueCardDeps = {
   recordCard: async (pda, card) => {
     console.log(
       `[STUB] recordCard pda=${pda.slice(0, 8)} holder=${card.holder.slice(0, 8)}`,
+    );
+  },
+  flagReconciliation: async (card_pda, holder, _body) => {
+    // FN-191 stub — mirrors offramp's flagReconciliation logger.
+    console.warn(
+      `[STUB] RECONCILE NEEDED issue-card card_pda=${card_pda.slice(0, 12)} holder=${holder.slice(0, 8)} (issue_failed post-recordCard)`,
     );
   },
 };

--- a/keeper/bpps/bank/handlers/open-checking.flag-reconciliation.test.ts
+++ b/keeper/bpps/bank/handlers/open-checking.flag-reconciliation.test.ts
@@ -1,0 +1,70 @@
+/**
+ * FN-191 — open-checking flagReconciliation hook tests.
+ *
+ * AC:
+ *   - flagReconciliation is invoked exactly once with
+ *     (account_pda, holder, body) when issueCheckingCredential throws after
+ *     recordCheckingAccount succeeded.
+ *   - flagReconciliation is NOT invoked on the happy path.
+ *   - flagReconciliation is NOT invoked when recordCheckingAccount itself throws.
+ *   - flagReconciliation that itself throws does not mask the primary
+ *     `issue_failed` error.
+ */
+import { describe, it, expect, vi } from "vitest";
+import { openChecking, OpenCheckingRejected, type OpenCheckingDeps } from "./open-checking";
+
+const SUBJECT = "1".repeat(64);
+const BANK = "0".repeat(64);
+
+function baseDeps(): OpenCheckingDeps {
+  return {
+    verifyHolderCredentials: vi.fn().mockResolvedValue(true),
+    issueCheckingCredential: vi.fn().mockResolvedValue({ tx_signature: "tx", credential_pda: "pda" }),
+    recordCheckingAccount: vi.fn().mockResolvedValue(undefined),
+    flagReconciliation: vi.fn().mockResolvedValue(undefined),
+  };
+}
+
+const req = {
+  subject: SUBJECT,
+  bank_issuer: BANK,
+  opened_slot: 1_000_000,
+  opening_deposit_atomic: 5_000_000,
+};
+
+describe("FN-191 — open-checking flagReconciliation", () => {
+  it("invokes flagReconciliation exactly once when issueCheckingCredential throws", async () => {
+    const deps = baseDeps();
+    deps.issueCheckingCredential = vi.fn().mockRejectedValue(new Error("chain rpc down"));
+    await expect(openChecking(req, deps)).rejects.toThrow(OpenCheckingRejected);
+    expect(deps.flagReconciliation).toHaveBeenCalledOnce();
+    const [account_pda, holder, body] = (deps.flagReconciliation as any).mock.calls[0]!;
+    expect(account_pda).toMatch(/^[0-9a-f]{64}$/);
+    expect(holder).toBe(SUBJECT);
+    expect(body.opened_slot).toBe(1_000_000);
+    expect(body.opening_balance).toBe(5_000_000);
+  });
+
+  it("does NOT invoke flagReconciliation on the happy path", async () => {
+    const deps = baseDeps();
+    await openChecking(req, deps);
+    expect(deps.flagReconciliation).not.toHaveBeenCalled();
+  });
+
+  it("does NOT invoke flagReconciliation when recordCheckingAccount itself throws", async () => {
+    const deps = baseDeps();
+    deps.recordCheckingAccount = vi.fn().mockRejectedValue(new Error("ledger down"));
+    await expect(openChecking(req, deps)).rejects.toThrow(OpenCheckingRejected);
+    expect(deps.flagReconciliation).not.toHaveBeenCalled();
+  });
+
+  it("does NOT mask the primary issue_failed error if flagReconciliation itself throws", async () => {
+    const deps = baseDeps();
+    deps.issueCheckingCredential = vi.fn().mockRejectedValue(new Error("chain rpc down"));
+    deps.flagReconciliation = vi.fn().mockRejectedValue(new Error("flag service down"));
+    await expect(openChecking(req, deps)).rejects.toMatchObject({
+      reason: "issue_failed",
+    });
+    expect(deps.flagReconciliation).toHaveBeenCalledOnce();
+  });
+});

--- a/keeper/bpps/bank/handlers/open-checking.ts
+++ b/keeper/bpps/bank/handlers/open-checking.ts
@@ -60,6 +60,20 @@ export interface OpenCheckingDeps {
   issueCheckingCredential: (cred: OpenCheckingResult['credential']) => Promise<{ tx_signature: string; credential_pda: string }>;
   /** Record CheckingAccount in the local mock ledger. STUBBED. */
   recordCheckingAccount: (pda: string, account: { holder: string; opened_slot: number; opening_balance: number }) => Promise<void>;
+  /**
+   * FN-191: orphan-ledger reconciliation hook. Called from the
+   * `issue_failed` path after `recordCheckingAccount` succeeded but the
+   * on-chain `issueCheckingCredential` threw. Mirrors the
+   * `flagReconciliation` hook in `offramp.ts` so ops gets a deterministic
+   * signal and the eventual GC sweeper can find the orphan.
+   *
+   * Implementations MUST be idempotent.
+   */
+  flagReconciliation: (
+    account_pda: string,
+    holder: string,
+    body: { opened_slot: number; opening_balance: number },
+  ) => Promise<void>;
 }
 
 export class OpenCheckingRejected extends Error {
@@ -117,8 +131,19 @@ export async function openChecking(req: OpenCheckingRequest, deps: OpenCheckingD
   try {
     await deps.issueCheckingCredential(credential);
   } catch {
-    // Best-effort: ledger entry is now orphaned. v1 will use a sweeper to GC
-    // ledger entries with no corresponding on-chain credential_pda.
+    // FN-191: ledger entry from recordCheckingAccount is now orphaned.
+    // Flag for reconciliation BEFORE rethrowing so the eventual GC
+    // sweeper has a deterministic handle. flagReconciliation must not
+    // throw — if it does, swallow: the primary issue_failed error is
+    // what callers act on.
+    try {
+      await deps.flagReconciliation(checking_account_pda, req.subject, {
+        opened_slot: req.opened_slot,
+        opening_balance: opening,
+      });
+    } catch {
+      // intentionally swallowed
+    }
     throw new OpenCheckingRejected('issue_failed');
   }
 
@@ -140,6 +165,12 @@ export const stubs: OpenCheckingDeps = {
     const credential_pda = createHash('sha256').update('cred:' + sig).digest('hex');
     console.log(`[STUB] issueCheckingCredential subject=${cred.subject.slice(0, 8)} → tx=${sig.slice(0, 16)}`);
     return { tx_signature: sig, credential_pda };
+  },
+  flagReconciliation: async (account_pda, holder, _body) => {
+    // FN-191 stub — mirrors offramp's flagReconciliation logger.
+    console.warn(
+      `[STUB] RECONCILE NEEDED open-checking account_pda=${account_pda.slice(0, 12)} holder=${holder.slice(0, 8)} (issue_failed post-recordCheckingAccount)`,
+    );
   },
   recordCheckingAccount: async (pda, acc) => {
     console.log(`[STUB] recordCheckingAccount pda=${pda.slice(0, 8)} holder=${acc.holder.slice(0, 8)} opening=${acc.opening_balance}`);


### PR DESCRIPTION
Closes the security-auditor finding [SECURITY][MEDIUM] in keeper/bpps/bank handlers (issue-card and open-checking) where the off-chain ledger was written BEFORE on-chain credential issuance and the on-chain failure path didn't flag the orphan.

Adds `flagReconciliation` to both handler deps interfaces, mirroring the existing pattern in `offramp.ts`. v0 stubs log a warning. Errors thrown by `flagReconciliation` itself are swallowed so the primary `issue_failed` error is what callers act on.

## Test plan

- [x] 8 new unit tests (4 per handler): invoked-once on failure, not-invoked on happy path, not-invoked when recordCard itself throws, primary error not masked when flagReconciliation throws
- [x] All 340 existing bank-handler tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)