### PR TITLE
fix: unblock master — inline BANK_NETWORK_LABEL + computeBankNetworkId

### DIFF
--- a/keeper/bpps/bank/catalog.ts
+++ b/keeper/bpps/bank/catalog.ts
@@ -31,10 +31,7 @@
  */
 
 import { createHash } from "node:crypto";
-import {
-  BANK_NETWORK_LABEL,
-  computeBankNetworkId,
-} from "../../../../apps/issuer-admin/src/bank/init-network.js";
+import { BANK_NETWORK_LABEL, computeBankNetworkId } from "./network-id.js";
 import type {
   BankCapability,
   BankCapabilityKey,

--- a/keeper/bpps/bank/network-id.ts
+++ b/keeper/bpps/bank/network-id.ts
@@ -1,0 +1,27 @@
+/**
+ * Inlined copy of `BANK_NETWORK_LABEL` + `computeBankNetworkId` from
+ * `apps/issuer-admin/src/bank/init-network.ts` (FN-095). The original lives
+ * in the OUTER `eto/` repo; eto-mcp's CI checks out only this repo, so the
+ * cross-repo import broke `tests/unit/bank-bpp.test.ts` and `catalog.ts`
+ * with `Failed to load url ../../../../apps/issuer-admin/...`.
+ *
+ * Keep the values byte-identical with the source file. If the canonical
+ * label or hash function ever changes, update both files in lockstep.
+ */
+import { blake3 } from "@noble/hashes/blake3.js";
+
+export const BANK_NETWORK_LABEL = "bank.eto.us-test";
+
+const utf8 = (s: string): Uint8Array => new TextEncoder().encode(s);
+
+export function computeBankNetworkId(
+  label: string = BANK_NETWORK_LABEL,
+): Uint8Array {
+  const out = blake3(utf8(label));
+  if (out.length !== 32) {
+    throw new Error(
+      `internal: blake3 output expected 32 bytes, got ${out.length}`,
+    );
+  }
+  return out;
+}

--- a/tests/unit/bank-bpp.test.ts
+++ b/tests/unit/bank-bpp.test.ts
@@ -25,7 +25,7 @@ import { zBppConfig } from "../../keeper/templates/bpp/types.js";
 import {
   BANK_NETWORK_LABEL,
   computeBankNetworkId,
-} from "../../../apps/issuer-admin/src/bank/init-network.js";
+} from "../../keeper/bpps/bank/network-id.js";
 
 /* -------------------------------------------------------------------------- */
 /* Fixtures                                                                   */


### PR DESCRIPTION
## Why
Master's CI is currently red on `tests/unit/bank-bpp.test.ts`:
```
Failed to load url ../../../../apps/issuer-admin/src/bank/init-network.js
in keeper/bpps/bank/catalog.ts.
```

Both `catalog.ts` and `bank-bpp.test.ts` import `BANK_NETWORK_LABEL` and `computeBankNetworkId` from `apps/issuer-admin/...`, which lives in the **outer** `eto/` repo. CI only checks out `eto-mcp`, so the path resolves to nothing and the test suite fails. This blocks every fusion PR's `typecheck · test · build` required check.

## What
- New `keeper/bpps/bank/network-id.ts` inlines the two symbols byte-identical (uses `@noble/hashes/blake3`, already a dep).
- `keeper/bpps/bank/catalog.ts` and `tests/unit/bank-bpp.test.ts` updated to import from the local module.
- Source-of-truth note in the new file: if FN-095's label/hash changes in `apps/issuer-admin`, update both in lockstep.

## Validation
- `bun run typecheck` ✓
- `bun run test` ✓ (947 pass, 0 fail)
- `tests/unit/bank-bpp.test.ts` 51/51 ✓

## Side effects
None. Same blake3 hash inputs → same outputs as before.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Extracted bank network identification logic into a dedicated local module to improve code organization, reduce external module dependencies, and centralize related functionality in a single, maintainable location for future development and easier code management.

* **Tests**
  * Updated unit test imports to reflect the reorganized module structure, ensuring test suite remains properly aligned with refactored code components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->