### PR TITLE
chore: add @noble/curves dep for local-signer.ts

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -5,6 +5,7 @@
     "": {
       "name": "eto-mcp",
       "dependencies": {
+        "@noble/curves": "^1.4.0",
         "@noble/ed25519": "^2.0.0",
         "@noble/hashes": "^1.4.0",
         "ajv": "^8.20.0",
@@ -71,6 +72,8 @@
     "@jest/schemas": ["@jest/schemas@29.6.3", "", { "dependencies": { "@sinclair/typebox": "^0.27.8" } }, "sha512-mo5j5X+jIZmJQveBKeS/clAueipV7KgiX1vMgCxam1RNYiqE1w62n0/tJJnHtjW8ZHcQco5gY85jA3mi0L+nSA=="],
 
     "@jridgewell/sourcemap-codec": ["@jridgewell/sourcemap-codec@1.5.5", "", {}, "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og=="],
+
+    "@noble/curves": ["@noble/curves@1.9.7", "", { "dependencies": { "@noble/hashes": "1.8.0" } }, "sha512-gbKGcRUYIjA3/zCCNaWDciTMFI0dCkvou3TL8Zmy5Nc7sJ47a0jtOeZoTaMxkuqRo9cRhjOdZJXegxYE5FN/xw=="],
 
     "@noble/ed25519": ["@noble/ed25519@2.3.0", "", {}, "sha512-M7dvXL2B92/M7dw9+gzuydL8qn/jiqNHaoR3Q+cb1q1GHV7uwE17WCyFMG+Y+TZb5izcaXk5TdJRrDUxHXL78A=="],
 

--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "vitest": "^1.6.0"
   },
   "dependencies": {
+    "@noble/curves": "^1.4.0",
     "@noble/ed25519": "^2.0.0",
     "@noble/hashes": "^1.4.0",
     "ajv": "^8.20.0",


### PR DESCRIPTION
src/signing/local-signer.ts imports `@noble/curves/secp256k1` and `@noble/curves/abstract/utils` but the package wasn't in package.json. Surfaced when PRs #30 (FN-011) and #32 (FN-012) added test files that transitively loaded local-signer. Pinned to `@noble/curves@^1.4.0` (mirroring the @noble/hashes@^1.4.0 deep-import-compatible pin).