### PR TITLE
feat(FN-105): wire recordCard to shared bank credential ledger

### DIFF
--- a/keeper/bpps/bank/credential-ledger.test.ts
+++ b/keeper/bpps/bank/credential-ledger.test.ts
@@ -1,0 +1,115 @@
+/**
+ * FN-105 — credential-ledger unit + cross-handler integration tests.
+ *
+ * Confirms that issue-card and open-checking record into the same store
+ * (the requirement from FN-090's follow-up: "the same ledger store used
+ * by open-checking").
+ */
+import { describe, it, expect, beforeEach } from "vitest";
+import {
+  createInMemoryBankLedger,
+  defaultBankLedger,
+} from "./credential-ledger.js";
+import { stubs as issueCardStubs } from "./handlers/issue-card.js";
+import { stubs as openCheckingStubs } from "./handlers/open-checking.js";
+
+const HEX64 = "a".repeat(64);
+const HEX64_B = "b".repeat(64);
+
+describe("createInMemoryBankLedger", () => {
+  it("records a card and a checking entry under distinct PDAs", async () => {
+    const ledger = createInMemoryBankLedger(() => 1_000);
+    await ledger.recordCard("card-pda-1", {
+      holder: HEX64,
+      linked_account_pda: "linked-pda-1",
+      jurisdiction: "US-TEST",
+      card_id_hash: "h".repeat(64),
+      issued_slot: 100,
+      expires_slot: 200,
+    } as never);
+    await ledger.recordCheckingAccount("acct-pda-1", {
+      holder: HEX64_B,
+      opened_slot: 50,
+      opening_balance: 0,
+    });
+    expect(ledger.size()).toBe(2);
+    const card = ledger.lookup("card-pda-1");
+    const acct = ledger.lookup("acct-pda-1");
+    expect(card?.kind).toBe("card.debit.v1");
+    expect(card?.holder).toBe(HEX64);
+    expect(card?.recorded_at_ms).toBe(1_000);
+    expect(acct?.kind).toBe("account.checking.v1");
+    expect(acct?.holder).toBe(HEX64_B);
+  });
+
+  it("clear() empties the store", async () => {
+    const ledger = createInMemoryBankLedger();
+    await ledger.recordCheckingAccount("p", { holder: HEX64, opened_slot: 1, opening_balance: 0 });
+    expect(ledger.size()).toBe(1);
+    ledger.clear();
+    expect(ledger.size()).toBe(0);
+    expect(ledger.lookup("p")).toBeUndefined();
+  });
+
+  it("re-recording the same PDA overwrites (idempotent at the same key)", async () => {
+    const ledger = createInMemoryBankLedger(() => 5);
+    await ledger.recordCheckingAccount("p", { holder: HEX64, opened_slot: 1, opening_balance: 100 });
+    await ledger.recordCheckingAccount("p", { holder: HEX64, opened_slot: 1, opening_balance: 200 });
+    expect(ledger.size()).toBe(1);
+    const e = ledger.lookup("p");
+    expect(e?.kind === "account.checking.v1" ? e.body.opening_balance : -1).toBe(200);
+  });
+
+  it("list() returns all entries", async () => {
+    const ledger = createInMemoryBankLedger();
+    await ledger.recordCheckingAccount("a", { holder: HEX64, opened_slot: 1, opening_balance: 0 });
+    await ledger.recordCheckingAccount("b", { holder: HEX64, opened_slot: 1, opening_balance: 0 });
+    expect(ledger.list().map((e) => e.pda).sort()).toEqual(["a", "b"]);
+  });
+});
+
+describe("FN-105 — issue-card + open-checking share defaultBankLedger", () => {
+  beforeEach(() => defaultBankLedger.clear());
+
+  it("issueCard.stubs.recordCard writes to defaultBankLedger", async () => {
+    await issueCardStubs.recordCard("card-pda-X", {
+      holder: HEX64,
+      linked_account_pda: "linked-pda-X",
+      jurisdiction: "US-TEST",
+      card_id_hash: "h".repeat(64),
+      issued_slot: 100,
+      expires_slot: 200,
+    } as never);
+    expect(defaultBankLedger.size()).toBe(1);
+    expect(defaultBankLedger.lookup("card-pda-X")?.kind).toBe("card.debit.v1");
+  });
+
+  it("openChecking.stubs.recordCheckingAccount writes to defaultBankLedger", async () => {
+    await openCheckingStubs.recordCheckingAccount("acct-pda-Y", {
+      holder: HEX64,
+      opened_slot: 1,
+      opening_balance: 1_000,
+    });
+    expect(defaultBankLedger.size()).toBe(1);
+    expect(defaultBankLedger.lookup("acct-pda-Y")?.kind).toBe("account.checking.v1");
+  });
+
+  it("both stubs share the same store — entries from both handlers coexist", async () => {
+    await openCheckingStubs.recordCheckingAccount("acct-1", {
+      holder: HEX64,
+      opened_slot: 1,
+      opening_balance: 0,
+    });
+    await issueCardStubs.recordCard("card-1", {
+      holder: HEX64,
+      linked_account_pda: "acct-1",
+      jurisdiction: "US-TEST",
+      card_id_hash: "h".repeat(64),
+      issued_slot: 100,
+      expires_slot: 200,
+    } as never);
+    expect(defaultBankLedger.size()).toBe(2);
+    const kinds = defaultBankLedger.list().map((e) => e.kind).sort();
+    expect(kinds).toEqual(["account.checking.v1", "card.debit.v1"]);
+  });
+});

--- a/keeper/bpps/bank/credential-ledger.ts
+++ b/keeper/bpps/bank/credential-ledger.ts
@@ -1,0 +1,91 @@
+/**
+ * FN-105 — shared in-memory ledger for issued bank credentials.
+ *
+ * Both `issue-card` and `open-checking` need to record a credential to
+ * a local ledger BEFORE issuing the on-chain credential, so a future GC
+ * sweeper can find orphan ledger entries when the on-chain step fails
+ * (see FN-191's `flagReconciliation` hook). v0's stubs were per-handler
+ * `console.log` calls; this module gives them a single store so the
+ * sweeper has one place to look.
+ *
+ * Scope (v0): in-memory `Map<pda, Entry>` only. Durable storage and
+ * cross-process coordination land in v1 alongside the GC sweeper.
+ */
+import type { CardDebitCredentialBody } from "./handlers/issue-card.js";
+
+export type LedgerEntryKind = "card.debit.v1" | "account.checking.v1";
+
+export interface CardLedgerEntry {
+  kind: "card.debit.v1";
+  pda: string;
+  holder: string;
+  recorded_at_ms: number;
+  body: CardDebitCredentialBody;
+}
+
+export interface CheckingLedgerEntry {
+  kind: "account.checking.v1";
+  pda: string;
+  holder: string;
+  recorded_at_ms: number;
+  body: { holder: string; opened_slot: number; opening_balance: number };
+}
+
+export type LedgerEntry = CardLedgerEntry | CheckingLedgerEntry;
+
+export interface BankCredentialLedger {
+  recordCard(pda: string, body: CardDebitCredentialBody): Promise<void>;
+  recordCheckingAccount(
+    pda: string,
+    account: { holder: string; opened_slot: number; opening_balance: number },
+  ): Promise<void>;
+  lookup(pda: string): LedgerEntry | undefined;
+  list(): readonly LedgerEntry[];
+  size(): number;
+  clear(): void;
+}
+
+export function createInMemoryBankLedger(
+  now: () => number = Date.now,
+): BankCredentialLedger {
+  const entries = new Map<string, LedgerEntry>();
+  return {
+    async recordCard(pda, body) {
+      entries.set(pda, {
+        kind: "card.debit.v1",
+        pda,
+        holder: body.holder,
+        recorded_at_ms: now(),
+        body,
+      });
+    },
+    async recordCheckingAccount(pda, account) {
+      entries.set(pda, {
+        kind: "account.checking.v1",
+        pda,
+        holder: account.holder,
+        recorded_at_ms: now(),
+        body: account,
+      });
+    },
+    lookup(pda) {
+      return entries.get(pda);
+    },
+    list() {
+      return Array.from(entries.values());
+    },
+    size() {
+      return entries.size;
+    },
+    clear() {
+      entries.clear();
+    },
+  };
+}
+
+/**
+ * Default process-wide ledger instance shared by the v0 stubs in
+ * `issue-card.ts` and `open-checking.ts`. Tests should call `clear()`
+ * in beforeEach to avoid cross-test bleed.
+ */
+export const defaultBankLedger: BankCredentialLedger = createInMemoryBankLedger();

--- a/keeper/bpps/bank/handlers/issue-card.ts
+++ b/keeper/bpps/bank/handlers/issue-card.ts
@@ -36,6 +36,7 @@ import {
   type IssueCardInput,
   BankIssuerError,
 } from "../../../../src/issuers/bank.js";
+import { defaultBankLedger } from "../credential-ledger.js";
 
 // ---------------------------------------------------------------------------
 // Schema gate
@@ -350,8 +351,11 @@ export const stubs: IssueCardDeps = {
     return { tx_signature, credential_pda };
   },
   recordCard: async (pda, card) => {
+    // FN-105: persist to the shared bank credential ledger so the v1
+    // GC sweeper sees this entry alongside open-checking entries.
+    await defaultBankLedger.recordCard(pda, card);
     console.log(
-      `[STUB] recordCard pda=${pda.slice(0, 8)} holder=${card.holder.slice(0, 8)}`,
+      `[STUB] recordCard pda=${pda.slice(0, 8)} holder=${card.holder.slice(0, 8)} → ledger size=${defaultBankLedger.size()}`,
     );
   },
   flagReconciliation: async (card_pda, holder, _body) => {

--- a/keeper/bpps/bank/handlers/open-checking.ts
+++ b/keeper/bpps/bank/handlers/open-checking.ts
@@ -28,6 +28,8 @@
 
 import { createHash } from 'node:crypto';
 
+import { defaultBankLedger } from '../credential-ledger.js';
+
 export interface OpenCheckingRequest {
   subject: string;                    // hex pubkey — receives credential, owns account
   bank_issuer: string;                // hex — bank issuer pubkey (this BPP's signing identity)
@@ -173,6 +175,9 @@ export const stubs: OpenCheckingDeps = {
     );
   },
   recordCheckingAccount: async (pda, acc) => {
-    console.log(`[STUB] recordCheckingAccount pda=${pda.slice(0, 8)} holder=${acc.holder.slice(0, 8)} opening=${acc.opening_balance}`);
+    // FN-105: persist to the shared bank credential ledger so issue-card
+    // and open-checking entries live in one place for the v1 GC sweeper.
+    await defaultBankLedger.recordCheckingAccount(pda, acc);
+    console.log(`[STUB] recordCheckingAccount pda=${pda.slice(0, 8)} holder=${acc.holder.slice(0, 8)} opening=${acc.opening_balance} → ledger size=${defaultBankLedger.size()}`);
   },
 };


### PR DESCRIPTION
## Why
FN-105 (follow-up to FN-090) asked: wire `IssueCardDeps.recordCard` to a real ledger — specifically *the same ledger store used by `open-checking`*. v0 had two independent `console.log` stubs, which means the eventual GC sweeper (FN-191's `flagReconciliation` consumer) would have nothing to read.

Note: FN-105 was previously marked "done" on the outer-board master via a fusion misattribution (merge commit `a649b4b8` was actually `feat(FN-006): merge fusion/fn-006` adding `.fusion/tasks/FN-006/probe.txt`). That misattribution is now blocked by the new `fusion-task-gate` (PR #44). The outer task has been reopened to triage so this PR properly closes FN-105.

## What
**New** `keeper/bpps/bank/credential-ledger.ts`:
- Discriminated union of `card.debit.v1` and `account.checking.v1` entries.
- `recordCard`, `recordCheckingAccount`, `lookup`, `list`, `size`, `clear`.
- `defaultBankLedger` — process-wide instance so v0 stubs share state without DI plumbing.

**Updated stubs** in `issue-card.ts` and `open-checking.ts` now call `defaultBankLedger.recordCard(…)` / `defaultBankLedger.recordCheckingAccount(…)` before their existing console.log.

## Tests
- 4 unit tests on `createInMemoryBankLedger`: record both kinds, clear, idempotent overwrite at same PDA, list.
- 3 integration tests confirming both stubs write to the **same** `defaultBankLedger`.

## Validation
- `bun run typecheck` ✓
- `bun run test` ✓ (1037 pass, 0 fail, 16 todo)
- `fusion-task-gate` will validate this PR end-to-end as the first FN-tagged fusion PR through the new required check.