### PR TITLE
feat(FN-112, FN-117): collapse SigningRuntimeChain imports to template barrel

### DIFF
--- a/keeper/bpps/__tests__/handler.complete-task.test.ts
+++ b/keeper/bpps/__tests__/handler.complete-task.test.ts
@@ -25,6 +25,22 @@ import {
 } from "../../templates/bpp/index.js";
 
 /* -------------------------------------------------------------------------- */
+/* Shared signing chain (FN-112): one import from the template barrel,        */
+/* per-BPP aliases preserved as const so call sites are unchanged.            */
+/* -------------------------------------------------------------------------- */
+import { SigningRuntimeChain, makeStubSigner } from "../../templates/bpp/index.js";
+const TextSigningChain = SigningRuntimeChain;
+const CodeSigningChain = SigningRuntimeChain;
+const WebSigningChain = SigningRuntimeChain;
+const ImageSigningChain = SigningRuntimeChain;
+const DataSigningChain = SigningRuntimeChain;
+const makeTextStub = makeStubSigner;
+const makeCodeStub = makeStubSigner;
+const makeWebStub = makeStubSigner;
+const makeImageStub = makeStubSigner;
+const makeDataStub = makeStubSigner;
+
+/* -------------------------------------------------------------------------- */
 /* text:summarize                                                             */
 /* -------------------------------------------------------------------------- */
 import {
@@ -32,10 +48,6 @@ import {
   DEV_AUTHORITY_PUBKEY as TEXT_AUTHORITY,
 } from "../text-summarize/config.js";
 import { createTextSummarizeHandler } from "../text-summarize/handler.js";
-import {
-  SigningRuntimeChain as TextSigningChain,
-  makeStubSigner as makeTextStub,
-} from "../text-summarize/chain-adapter.js";
 import type { SummarizeResult } from "../text-summarize/summarizer.js";
 
 /* -------------------------------------------------------------------------- */
@@ -46,10 +58,6 @@ import {
   DEV_AUTHORITY_PUBKEY as CODE_AUTHORITY,
 } from "../code-audit-solidity/config.js";
 import { createSolidityAuditHandler } from "../code-audit-solidity/handler.js";
-import {
-  SigningRuntimeChain as CodeSigningChain,
-  makeStubSigner as makeCodeStub,
-} from "../code-audit-solidity/chain-adapter.js";
 
 /* -------------------------------------------------------------------------- */
 /* web:research                                                               */
@@ -59,10 +67,6 @@ import {
   DEV_AUTHORITY_PUBKEY as WEB_AUTHORITY,
 } from "../web-research/config.js";
 import { createWebResearchHandler } from "../web-research/handler.js";
-import {
-  SigningRuntimeChain as WebSigningChain,
-  makeStubSigner as makeWebStub,
-} from "../web-research/chain-adapter.js";
 import { FakeSearchProvider, defaultFakeCorpus } from "../web-research/search-provider.js";
 import type { LlmCompleteRequest } from "../web-research/planner.js";
 import type { FetchedPage } from "../web-research/fetcher.js";
@@ -75,10 +79,6 @@ import {
   DEV_AUTHORITY_PUBKEY as IMAGE_AUTHORITY,
 } from "../image-generate/config.js";
 import { createImageGenerateHandler } from "../image-generate/handler.js";
-import {
-  SigningRuntimeChain as ImageSigningChain,
-  makeStubSigner as makeImageStub,
-} from "../image-generate/chain-adapter.js";
 import type { BppIpfsPinner, PinResult, PinOpts } from "../image-generate/ipfs.js";
 
 /* -------------------------------------------------------------------------- */
@@ -89,10 +89,6 @@ import {
   DEV_AUTHORITY_PUBKEY as DATA_AUTHORITY,
 } from "../data-analyze/config.js";
 import { createDataAnalyzeHandler } from "../data-analyze/handler.js";
-import {
-  SigningRuntimeChain as DataSigningChain,
-  makeStubSigner as makeDataStub,
-} from "../data-analyze/chain-adapter.js";
 import { profileCsv } from "../data-analyze/profiler.js";
 import type { FetchedCsv } from "../data-analyze/fetcher.js";
 import type { AnalyzeResult } from "../data-analyze/analyzer.js";

--- a/keeper/templates/bpp/chain.ts
+++ b/keeper/templates/bpp/chain.ts
@@ -1,0 +1,31 @@
+/**
+ * FN-112 / FN-117 — shared signing-chain barrel re-export.
+ *
+ * The canonical `SigningRuntimeChain` lives in
+ * `keeper/bpps/text-summarize/chain-adapter.ts` (FN-075). The other
+ * reference BPPs (`code-audit-solidity`, `web-research`, `data-analyze`)
+ * already re-export from there; `image-generate` keeps its own
+ * byte-identical copy by convention.
+ *
+ * This module exists so test files and downstream consumers can write
+ *   import { SigningRuntimeChain, makeStubSigner } from
+ *     "../../keeper/templates/bpp/index.js";
+ * instead of reaching into a per-BPP shim. Eliminates the 5 aliased
+ * imports in `keeper/bpps/__tests__/handler.complete-task.test.ts` and
+ * the per-BPP-named imports in the 6 unit test files listed in FN-117.
+ *
+ * Single source of truth: do NOT add an independent class here. If the
+ * signing logic changes, change `text-summarize/chain-adapter.ts` and
+ * the change propagates everywhere via this barrel.
+ */
+export {
+  SigningRuntimeChain,
+  makeStubSigner,
+  canonicalJson,
+  type Signer,
+  type SignedEnvelope,
+  type SignedCompletePayload,
+  type SignedFailPayload,
+  type SignedCallRecord,
+  type SigningRuntimeChainOpts,
+} from "../../bpps/text-summarize/chain-adapter.js";

--- a/keeper/templates/bpp/index.ts
+++ b/keeper/templates/bpp/index.ts
@@ -17,3 +17,4 @@ export * from "./types.js";
 export * from "./register.js";
 export * from "./credential-gate.js";
 export * from "./runtime.js";
+export * from "./chain.js";

--- a/tests/unit/bank-bpp.test.ts
+++ b/tests/unit/bank-bpp.test.ts
@@ -19,7 +19,7 @@ import { BANK_CAPABILITY_KEYS, buildBankCatalog, canonicalCatalogJson, catalogHa
 import { buildConfig } from "../../keeper/bpps/bank/config.js";
 import { createBankHandler } from "../../keeper/bpps/bank/handler.js";
 import { InMemoryCatalogCommitRecorder, publishBankCatalog } from "../../keeper/bpps/bank/catalog-publisher.js";
-import { makeStubSigner } from "../../keeper/bpps/bank/chain-adapter.js";
+import { makeStubSigner } from "../../keeper/templates/bpp/index.js";
 import { zBankCapability, zBankCatalog, zCatalogCommitPayload } from "../../keeper/bpps/bank/types.js";
 import { zBppConfig } from "../../keeper/templates/bpp/types.js";
 import {

--- a/tests/unit/code-audit-solidity-bpp.test.ts
+++ b/tests/unit/code-audit-solidity-bpp.test.ts
@@ -897,7 +897,7 @@ import {
 import {
   SigningRuntimeChain,
   makeStubSigner,
-} from "../../keeper/bpps/code-audit-solidity/chain-adapter.js";
+} from "../../keeper/templates/bpp/index.js";
 import type { AuditInput, AuditOutput } from "../../keeper/bpps/code-audit-solidity/types.js";
 import { PER_FILE_MAX_BYTES as MAX_BYTES_2 } from "../../keeper/bpps/code-audit-solidity/types.js";
 

--- a/tests/unit/data-analyze-bpp.test.ts
+++ b/tests/unit/data-analyze-bpp.test.ts
@@ -54,7 +54,7 @@ import {
   canonicalJson,
   makeStubSigner,
   SigningRuntimeChain,
-} from "../../keeper/bpps/data-analyze/chain-adapter.js";
+} from "../../keeper/templates/bpp/index.js";
 import type {
   AnalyzeInput,
   AnalyzeOutput,

--- a/tests/unit/image-generate-bpp.test.ts
+++ b/tests/unit/image-generate-bpp.test.ts
@@ -62,7 +62,7 @@ import {
   canonicalJson,
   makeStubSigner,
   SigningRuntimeChain,
-} from "../../keeper/bpps/image-generate/chain-adapter.js";
+} from "../../keeper/templates/bpp/index.js";
 import type {
   ImageGenerateInput,
   ImageGenerateOutput,

--- a/tests/unit/text-summarize-bpp.test.ts
+++ b/tests/unit/text-summarize-bpp.test.ts
@@ -48,7 +48,7 @@ import {
   canonicalJson,
   makeStubSigner,
   SigningRuntimeChain,
-} from "../../keeper/bpps/text-summarize/chain-adapter.js";
+} from "../../keeper/templates/bpp/index.js";
 import type { SummarizeInput, SummarizeOutput } from "../../keeper/bpps/text-summarize/index.js";
 
 /* -------------------------------------------------------------------------- */

--- a/tests/unit/web-research-bpp.test.ts
+++ b/tests/unit/web-research-bpp.test.ts
@@ -569,7 +569,7 @@ import {
   SigningRuntimeChain,
   makeStubSigner,
   canonicalJson,
-} from "../../keeper/bpps/web-research/chain-adapter.js";
+} from "../../keeper/templates/bpp/index.js";
 import { InMemoryChain } from "../../keeper/templates/bpp/index.js";
 
 const cannedReportLlm: PlannerLlmClient = {


### PR DESCRIPTION
Closes outer eto FN-112 (cross-BPP test) + FN-117 (6 unit tests). Adds `templates/bpp/chain.ts` re-export from canonical text-summarize impl, exposes via barrel, redirects 7 test files. typecheck + 1037 tests pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Refactored internal module dependencies by consolidating signing chain utilities into a centralized template barrel, reducing per-BPP module imports across the codebase while maintaining compatibility with existing code.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->