### PR TITLE
fix: devnet write reliability cluster (FN-098/099/197/198)

### DIFF
--- a/src/read/rpc-client.ts
+++ b/src/read/rpc-client.ts
@@ -12,6 +12,20 @@ interface JsonRpcResponse<T> {
   };
 }
 
+/**
+ * FN-197 / FN-198: validate that a string looks like a real on-chain
+ * transaction signature before letting it leave the RPC client. Accepts
+ * either base58 (40-90 chars, base58 alphabet) or hex (64-128 chars).
+ * Rejects the JSON.stringify-of-an-error-object case.
+ */
+const BASE58_RE = /^[1-9A-HJ-NP-Za-km-z]{40,90}$/;
+const HEX_SIG_RE = /^(0x)?[0-9a-fA-F]{64,128}$/;
+function isValidSignature(s: string): boolean {
+  if (typeof s !== "string") return false;
+  if (s.length === 0) return false;
+  return BASE58_RE.test(s) || HEX_SIG_RE.test(s);
+}
+
 export class EtoRpcClient {
   private endpoint: string;
   private counter = 0;
@@ -43,6 +57,16 @@ export class EtoRpcClient {
     if (json.error) {
       throw new Error(
         `JSON-RPC error ${json.error.code}: ${json.error.message}`
+      );
+    }
+
+    // FN-198: a malformed response with neither a `result` nor `error`
+    // field used to slip through as `undefined` and surface downstream
+    // as a phantom value (e.g. `JSON.stringify(undefined)` → `undefined`).
+    // Reject explicitly so the caller learns the node is misbehaving.
+    if (json.result === undefined) {
+      throw new Error(
+        `JSON-RPC response for ${method} has neither result nor error field`,
       );
     }
 
@@ -81,7 +105,21 @@ export class EtoRpcClient {
 
   async faucet(address: string, amount: number): Promise<string> {
     const result: any = await this.call<any>("faucet", [address, amount]);
-    return result?.signature ?? result?.txhash ?? result?.tx_hash ?? (typeof result === "string" ? result : JSON.stringify(result));
+    const candidate =
+      result?.signature ?? result?.txhash ?? result?.tx_hash ??
+      (typeof result === "string" ? result : null);
+    // FN-197 / FN-198: never fall back to JSON.stringify(result) — that
+    // turned a rate-limit error or a phantom-faucet payload into a
+    // string callers treated as a real signature. Validate, or throw.
+    // The chain-side mock-faucet replacement is tracked as FN-196.
+    if (!candidate || !isValidSignature(candidate)) {
+      throw new Error(
+        `faucet returned non-signature response (got ${typeof result}: ${JSON.stringify(
+          result,
+        ).slice(0, 200)}). The local node may be running a mock faucet; see FN-196.`,
+      );
+    }
+    return candidate;
   }
 
   getTransaction(signature: string): Promise<any> {

--- a/src/tools/devnet.ts
+++ b/src/tools/devnet.ts
@@ -46,11 +46,54 @@ export function registerDevnetTools(server: McpServer): void {
         const lamports = Number(solToLamports(String(amountNum)));
         const sig = await rpc.faucet(address, lamports);
 
+        // FN-098: do not report success on the bare faucet sig — the
+        // local node may run a mock/phantom faucet (FN-196). Poll
+        // getTransaction until the sig actually lands, with a 30s
+        // ceiling. If it never lands, fail loudly so the caller
+        // doesn't think their balance was credited.
+        const deadline = Date.now() + 30_000;
+        let landed = false;
+        let lastErr: string | null = null;
+        while (Date.now() < deadline) {
+          try {
+            const tx: any = await rpc.getTransaction(sig);
+            if (tx) {
+              const ok = tx.success !== false && !tx.error && tx.meta?.err == null;
+              if (!ok) {
+                lastErr = String(tx.error ?? tx.meta?.err ?? "transaction failed on-chain");
+                break;
+              }
+              landed = true;
+              break;
+            }
+          } catch (e: any) {
+            const msg = String(e?.message ?? e ?? "");
+            if (!/not\s*found|unknown\s*transaction|invalid\s*signature/i.test(msg)) {
+              lastErr = msg;
+              break;
+            }
+          }
+          await new Promise<void>((r) => setTimeout(r, 500));
+        }
+
+        if (!landed) {
+          return {
+            content: [{
+              type: "text",
+              text:
+                lastErr
+                  ? `Error: airdrop failed — ${lastErr} (sig: ${sig})`
+                  : `Error: airdrop signature ${sig} did not land within 30s. The local node may run a mock faucet — see FN-196.`,
+            }],
+            isError: true,
+          };
+        }
+
         return {
           content: [
             {
               type: "text",
-              text: `Airdropped ${amountNum} ETO to ${address}. Signature: ${sig}`,
+              text: `Airdropped ${amountNum} ETO to ${address}. Signature: ${sig} (confirmed)`,
             },
           ],
         };

--- a/src/write/submitter.ts
+++ b/src/write/submitter.ts
@@ -169,8 +169,21 @@ export class TransactionSubmitter {
             latency_ms: 0,
           };
         }
-      } catch {
-        // Transaction not found yet, keep polling
+      } catch (e: any) {
+        // FN-197 / FN-099: only swallow "transaction not found yet" — that
+        // is the expected polling case. Network errors, JSON-RPC malformed
+        // responses, and 5xx errors are real failures that the caller
+        // needs to see, otherwise the loop spins silently until timeout.
+        const msg = String(e?.message ?? e ?? "");
+        const notFound =
+          /not\s*found|unknown\s*transaction|invalid\s*signature/i.test(msg) ||
+          /JSON-RPC\s*error\s*-32004/.test(msg) || // common "tx not found" code
+          /JSON-RPC\s*error\s*-32602/.test(msg); // invalid params (sig not seen yet)
+        if (!notFound) {
+          // Bubble real errors out — caller needs to know the node is sick.
+          throw e;
+        }
+        // Otherwise: keep polling.
       }
       await new Promise<void>((r) => setTimeout(r, config.tx.confirmationPollMs));
     }


### PR DESCRIPTION
Fixes the silent-success bugs from GitHub #13. `call()` rejects malformed JSON-RPC responses; `faucet()` validates the signature shape and throws on phantom responses; `pollConfirmation` distinguishes 'not found' from real errors; `airdrop` tool waits for actual confirmation. Closes FN-098, FN-099, FN-197, FN-198. FN-196 (replace the mock faucet on the chain side) tracked separately.