### PR TITLE
feat(FN-052): A2A counterparty verifier reference module

### DIFF
--- a/src/a2a/counterparty-verifier.ts
+++ b/src/a2a/counterparty-verifier.ts
@@ -1,0 +1,352 @@
+/**
+ * A2A Counterparty Verifier — FN-052
+ *
+ * Reference module: how an A2A peer fetches a remote MCP origin's JWKS,
+ * verifies a `model_attestation_jws` compact JWS, checks the `aud` claim,
+ * and projects the result into a `ModelAttestation` value.
+ *
+ * Consumed by FN-060 A2A wire format. All crypto is Ed25519 via @noble/ed25519.
+ *
+ * JWS payload shape (standard JWT claims + model fields):
+ * {
+ *   iss: string;           // issuing MCP origin (e.g. "https://peer.example.com")
+ *   aud: string;           // intended recipient MCP origin — MUST equal expectedAudience
+ *   iat: number;           // issued-at (Unix seconds)
+ *   exp: number;           // expiry (Unix seconds)
+ *   jti?: string;          // optional nonce / replay protection
+ *   model: string;         // model identifier (e.g. "claude-opus-4")
+ *   model_version?: string;
+ *   sig_alg?: string;      // e.g. "EdDSA"
+ * }
+ */
+
+import * as ed from "@noble/ed25519";
+
+/* -------------------------------------------------------------------------- */
+/* Public types                                                                */
+/* -------------------------------------------------------------------------- */
+
+export interface ModelAttestation {
+  readonly iss: string;
+  readonly aud: string;
+  readonly iat: number;
+  readonly exp: number;
+  readonly jti?: string;
+  readonly model: string;
+  readonly model_version?: string;
+  readonly sig_alg?: string;
+}
+
+export type VerifyErrorCode =
+  | "malformed-jws"
+  | "unknown-kid"
+  | "bad-aud"
+  | "expired"
+  | "tampered-signature"
+  | "jwks-fetch-failed";
+
+export interface VerifyError {
+  readonly code: VerifyErrorCode;
+  readonly message: string;
+}
+
+export type VerifyResult =
+  | { readonly ok: true; readonly attestation: ModelAttestation }
+  | { readonly ok: false; readonly error: VerifyError };
+
+/* -------------------------------------------------------------------------- */
+/* JWKS types                                                                  */
+/* -------------------------------------------------------------------------- */
+
+export interface JwkEd25519 {
+  readonly kty: string;
+  readonly crv: string;
+  readonly kid: string;
+  readonly x: string; // base64url-encoded 32-byte public key
+}
+
+export interface Jwks {
+  readonly keys: JwkEd25519[];
+}
+
+/* -------------------------------------------------------------------------- */
+/* Cache                                                                       */
+/* -------------------------------------------------------------------------- */
+
+export interface JwksCacheEntry {
+  etag?: string;
+  jwks: Jwks;
+  fetchedAt: number;
+}
+
+/** Pass a shared Map instance across calls to enable ETag / 304 caching. */
+export type JwksCache = Map<string, JwksCacheEntry>;
+
+/* -------------------------------------------------------------------------- */
+/* Deps interface                                                              */
+/* -------------------------------------------------------------------------- */
+
+export interface VerifierDeps {
+  /** Injected fetch so tests don't hit the network. */
+  readonly fetch: typeof globalThis.fetch;
+  /** Shared JWKS cache across calls. Create once and reuse. */
+  readonly cache: JwksCache;
+  /** Clock injection for expiry checks. Defaults to () => Date.now(). */
+  readonly now?: () => number;
+}
+
+/* -------------------------------------------------------------------------- */
+/* Base64url helpers                                                           */
+/* -------------------------------------------------------------------------- */
+
+function base64urlDecode(input: string): Uint8Array {
+  // Convert base64url → base64, then decode
+  const b64 = input.replace(/-/g, "+").replace(/_/g, "/");
+  const padded = b64.padEnd(b64.length + ((4 - (b64.length % 4)) % 4), "=");
+  const binary = atob(padded);
+  const bytes = new Uint8Array(binary.length);
+  for (let i = 0; i < binary.length; i++) {
+    bytes[i] = binary.charCodeAt(i);
+  }
+  return bytes;
+}
+
+function base64urlDecodeToString(input: string): string | null {
+  try {
+    const bytes = base64urlDecode(input);
+    return new TextDecoder().decode(bytes);
+  } catch {
+    return null;
+  }
+}
+
+/* -------------------------------------------------------------------------- */
+/* JWS parsing                                                                 */
+/* -------------------------------------------------------------------------- */
+
+interface ParsedJws {
+  header: Record<string, unknown>;
+  payload: Record<string, unknown>;
+  signingInput: Uint8Array;
+  signature: Uint8Array;
+}
+
+function parseJwsCompact(jws: string): ParsedJws | null {
+  const parts = jws.split(".");
+  if (parts.length !== 3) return null;
+
+  const [headerB64, payloadB64, sigB64] = parts;
+  if (!headerB64 || !payloadB64 || !sigB64) return null;
+
+  const headerStr = base64urlDecodeToString(headerB64);
+  if (!headerStr) return null;
+
+  const payloadStr = base64urlDecodeToString(payloadB64);
+  if (!payloadStr) return null;
+
+  let header: Record<string, unknown>;
+  let payload: Record<string, unknown>;
+
+  try {
+    header = JSON.parse(headerStr) as Record<string, unknown>;
+  } catch {
+    return null;
+  }
+
+  try {
+    payload = JSON.parse(payloadStr) as Record<string, unknown>;
+  } catch {
+    return null;
+  }
+
+  let signature: Uint8Array;
+  try {
+    signature = base64urlDecode(sigB64);
+  } catch {
+    return null;
+  }
+
+  const signingInput = new TextEncoder().encode(`${headerB64}.${payloadB64}`);
+
+  return { header, payload, signingInput, signature };
+}
+
+/* -------------------------------------------------------------------------- */
+/* JWKS fetch with ETag cache                                                  */
+/* -------------------------------------------------------------------------- */
+
+async function fetchJwksWithCache(
+  url: string,
+  deps: VerifierDeps,
+): Promise<Jwks | { error: string }> {
+  const cached = deps.cache.get(url);
+  const headers: Record<string, string> = {};
+
+  if (cached?.etag) {
+    headers["If-None-Match"] = cached.etag;
+  }
+
+  let response: Response;
+  try {
+    response = await deps.fetch(url, { headers });
+  } catch (err) {
+    if (cached) {
+      // Network failure — serve stale cache rather than failing
+      return cached.jwks;
+    }
+    return { error: `fetch failed: ${String(err)}` };
+  }
+
+  if (response.status === 304) {
+    if (cached) {
+      // Bump fetchedAt to track when the 304 was received
+      const updated: JwksCacheEntry = { jwks: cached.jwks, fetchedAt: (deps.now ?? Date.now)() };
+      if (cached.etag !== undefined) {
+        updated.etag = cached.etag;
+      }
+      deps.cache.set(url, updated);
+      return cached.jwks;
+    }
+    return { error: "received 304 but no cached JWKS available" };
+  }
+
+  if (!response.ok) {
+    return { error: `JWKS endpoint returned HTTP ${response.status}` };
+  }
+
+  let jwks: Jwks;
+  try {
+    jwks = (await response.json()) as Jwks;
+  } catch {
+    return { error: "JWKS response is not valid JSON" };
+  }
+
+  const entry: JwksCacheEntry = { jwks, fetchedAt: (deps.now ?? Date.now)() };
+  const etag = response.headers.get("etag");
+  if (etag !== null) {
+    entry.etag = etag;
+  }
+  deps.cache.set(url, entry);
+
+  return jwks;
+}
+
+/* -------------------------------------------------------------------------- */
+/* Public API                                                                  */
+/* -------------------------------------------------------------------------- */
+
+export interface VerifyCounterpartyAttestationArgs {
+  /** Compact JWS string (header.payload.signature). */
+  readonly jws: string;
+  /** The verifying peer's MCP origin — must match `aud` claim. */
+  readonly expectedAudience: string;
+  /** Full URL to the remote peer's JWKS endpoint. */
+  readonly jwksUrl: string;
+  /** Injected fetch function. */
+  readonly fetch: typeof globalThis.fetch;
+  /** Shared JWKS cache. */
+  readonly cache: JwksCache;
+  /** Clock override for expiry tests. */
+  readonly now?: () => number;
+}
+
+/**
+ * Verify a `model_attestation_jws` from an A2A counterparty.
+ *
+ * Returns `{ ok: true, attestation }` on success or `{ ok: false, error }` on
+ * any failure — never throws.
+ */
+export async function verifyCounterpartyAttestation(
+  args: VerifyCounterpartyAttestationArgs,
+): Promise<VerifyResult> {
+  const nowMs = (args.now ?? Date.now)();
+  const nowSec = Math.floor(nowMs / 1000);
+
+  const deps: VerifierDeps = { fetch: args.fetch, cache: args.cache, now: args.now };
+
+  // 1. Parse the compact JWS
+  const parsed = parseJwsCompact(args.jws);
+  if (!parsed) {
+    return { ok: false, error: { code: "malformed-jws", message: "JWS is not a valid compact serialization" } };
+  }
+
+  const { header, payload, signingInput, signature } = parsed;
+
+  // 2. Extract kid from header
+  const kid = header["kid"];
+  if (typeof kid !== "string" || kid.length === 0) {
+    return { ok: false, error: { code: "malformed-jws", message: "JWS header missing or invalid `kid`" } };
+  }
+
+  // 3. Fetch JWKS (with ETag cache)
+  const jwksResult = await fetchJwksWithCache(args.jwksUrl, deps);
+  if ("error" in jwksResult) {
+    return { ok: false, error: { code: "jwks-fetch-failed", message: jwksResult.error } };
+  }
+
+  // 4. Find the key by kid
+  const jwk = jwksResult.keys.find((k) => k.kid === kid);
+  if (!jwk) {
+    return { ok: false, error: { code: "unknown-kid", message: `No key with kid="${kid}" in JWKS` } };
+  }
+
+  // 5. Decode the public key
+  let pubKey: Uint8Array;
+  try {
+    pubKey = base64urlDecode(jwk.x);
+  } catch {
+    return { ok: false, error: { code: "malformed-jws", message: "JWK `x` is not valid base64url" } };
+  }
+
+  // 6. Verify signature
+  let valid: boolean;
+  try {
+    valid = await ed.verifyAsync(signature, signingInput, pubKey);
+  } catch {
+    return { ok: false, error: { code: "tampered-signature", message: "Signature verification threw an error" } };
+  }
+
+  if (!valid) {
+    return { ok: false, error: { code: "tampered-signature", message: "Signature verification failed" } };
+  }
+
+  // 7. Check aud
+  const aud = payload["aud"];
+  if (typeof aud !== "string" || aud !== args.expectedAudience) {
+    return {
+      ok: false,
+      error: {
+        code: "bad-aud",
+        message: `Expected aud="${args.expectedAudience}", got "${String(aud)}"`,
+      },
+    };
+  }
+
+  // 8. Check exp
+  const exp = payload["exp"];
+  if (typeof exp !== "number" || exp < nowSec) {
+    return { ok: false, error: { code: "expired", message: `JWS expired at ${String(exp)} (now ${nowSec})` } };
+  }
+
+  // 9. Project into ModelAttestation
+  const iss = payload["iss"];
+  const iat = payload["iat"];
+  const model = payload["model"];
+
+  if (typeof iss !== "string" || typeof iat !== "number" || typeof model !== "string") {
+    return { ok: false, error: { code: "malformed-jws", message: "JWS payload missing required fields: iss, iat, model" } };
+  }
+
+  const attestation: ModelAttestation = {
+    iss,
+    aud,
+    iat,
+    exp: exp as number,
+    model,
+    ...(typeof payload["jti"] === "string" ? { jti: payload["jti"] } : {}),
+    ...(typeof payload["model_version"] === "string" ? { model_version: payload["model_version"] } : {}),
+    ...(typeof payload["sig_alg"] === "string" ? { sig_alg: payload["sig_alg"] } : {}),
+  };
+
+  return { ok: true, attestation };
+}

--- a/tests/a2a/counterparty-verifier.test.ts
+++ b/tests/a2a/counterparty-verifier.test.ts
@@ -1,0 +1,236 @@
+/**
+ * Tests for FN-052: A2A Counterparty Verifier
+ *
+ * All tests use injected fetch + cache — no network calls.
+ */
+
+import { describe, test, expect, beforeEach } from "vitest";
+import * as ed from "@noble/ed25519";
+import { sha512 } from "@noble/hashes/sha512";
+import {
+  verifyCounterpartyAttestation,
+  type JwksCache,
+  type Jwks,
+} from "../../src/a2a/counterparty-verifier.js";
+
+// Set up sha512Sync for noble/ed25519 in test environment
+ed.etc.sha512Sync = (...m: Uint8Array[]) => sha512(ed.etc.concatBytes(...m));
+
+/* -------------------------------------------------------------------------- */
+/* Helpers                                                                     */
+/* -------------------------------------------------------------------------- */
+
+function base64urlEncode(bytes: Uint8Array): string {
+  const b64 = btoa(String.fromCharCode(...bytes));
+  return b64.replace(/\+/g, "-").replace(/\//g, "_").replace(/=/g, "");
+}
+
+function base64urlEncodeStr(str: string): string {
+  return base64urlEncode(new TextEncoder().encode(str));
+}
+
+async function makeJws(
+  privKey: Uint8Array,
+  kid: string,
+  payload: Record<string, unknown>,
+): Promise<string> {
+  const header = base64urlEncodeStr(JSON.stringify({ alg: "EdDSA", typ: "JWT", kid }));
+  const body = base64urlEncodeStr(JSON.stringify(payload));
+  const signingInput = new TextEncoder().encode(`${header}.${body}`);
+  const sig = await ed.signAsync(signingInput, privKey);
+  return `${header}.${body}.${base64urlEncode(sig)}`;
+}
+
+function makeJwks(pubKey: Uint8Array, kid: string): Jwks {
+  return {
+    keys: [{ kty: "OKP", crv: "Ed25519", kid, x: base64urlEncode(pubKey) }],
+  };
+}
+
+function makeFetch(jwks: Jwks, etag = "\"v1\""): typeof globalThis.fetch {
+  return async (input: RequestInfo | URL, init?: RequestInit) => {
+    const url = typeof input === "string" ? input : input.toString();
+    if (url.endsWith("/.well-known/jwks.json")) {
+      const ifNoneMatch = (init?.headers as Record<string, string> | undefined)?.["If-None-Match"];
+      if (ifNoneMatch === etag) {
+        return new Response(null, { status: 304, headers: { etag } });
+      }
+      return new Response(JSON.stringify(jwks), {
+        status: 200,
+        headers: { "content-type": "application/json", etag },
+      });
+    }
+    return new Response("not found", { status: 404 });
+  };
+}
+
+const PEER_ORIGIN = "https://peer.example.com";
+const MY_ORIGIN = "https://me.example.com";
+const JWKS_URL = `${PEER_ORIGIN}/.well-known/jwks.json`;
+const NOW_SEC = 1_700_000_000;
+const NOW_MS = NOW_SEC * 1000;
+
+function makeNow(): () => number {
+  return () => NOW_MS;
+}
+
+function basePayload(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    iss: PEER_ORIGIN,
+    aud: MY_ORIGIN,
+    iat: NOW_SEC - 10,
+    exp: NOW_SEC + 300,
+    model: "claude-opus-4",
+    model_version: "4.0",
+    sig_alg: "EdDSA",
+    jti: "test-nonce-1",
+    ...overrides,
+  };
+}
+
+/* -------------------------------------------------------------------------- */
+/* Tests                                                                       */
+/* -------------------------------------------------------------------------- */
+
+describe("verifyCounterpartyAttestation", () => {
+  let privKey: Uint8Array;
+  let pubKey: Uint8Array;
+  const KID = "key-1";
+
+  beforeEach(async () => {
+    privKey = new Uint8Array(32);
+    crypto.getRandomValues(privKey);
+    pubKey = await ed.getPublicKeyAsync(privKey);
+  });
+
+  test("happy path — returns ok:true with projected ModelAttestation", async () => {
+    const jwks = makeJwks(pubKey, KID);
+    const cache: JwksCache = new Map();
+    const jws = await makeJws(privKey, KID, basePayload());
+
+    const result = await verifyCounterpartyAttestation({
+      jws,
+      expectedAudience: MY_ORIGIN,
+      jwksUrl: JWKS_URL,
+      fetch: makeFetch(jwks),
+      cache,
+      now: makeNow(),
+    });
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) throw new Error("expected ok");
+
+    expect(result.attestation.iss).toBe(PEER_ORIGIN);
+    expect(result.attestation.aud).toBe(MY_ORIGIN);
+    expect(result.attestation.model).toBe("claude-opus-4");
+    expect(result.attestation.model_version).toBe("4.0");
+    expect(result.attestation.sig_alg).toBe("EdDSA");
+    expect(result.attestation.jti).toBe("test-nonce-1");
+    expect(result.attestation.exp).toBe(NOW_SEC + 300);
+  });
+
+  test("bad-aud rejection — aud does not match expectedAudience", async () => {
+    const jwks = makeJwks(pubKey, KID);
+    const cache: JwksCache = new Map();
+    const jws = await makeJws(privKey, KID, basePayload({ aud: "https://wrong.example.com" }));
+
+    const result = await verifyCounterpartyAttestation({
+      jws,
+      expectedAudience: MY_ORIGIN,
+      jwksUrl: JWKS_URL,
+      fetch: makeFetch(jwks),
+      cache,
+      now: makeNow(),
+    });
+
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error("expected error");
+    expect(result.error.code).toBe("bad-aud");
+    expect(result.error.message).toContain(MY_ORIGIN);
+  });
+
+  test("expired-jws rejection — exp is in the past", async () => {
+    const jwks = makeJwks(pubKey, KID);
+    const cache: JwksCache = new Map();
+    // exp is 60 seconds before NOW
+    const jws = await makeJws(privKey, KID, basePayload({ exp: NOW_SEC - 60 }));
+
+    const result = await verifyCounterpartyAttestation({
+      jws,
+      expectedAudience: MY_ORIGIN,
+      jwksUrl: JWKS_URL,
+      fetch: makeFetch(jwks),
+      cache,
+      now: makeNow(),
+    });
+
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error("expected error");
+    expect(result.error.code).toBe("expired");
+  });
+
+  test("cache hit (304 Not Modified) — JWKS served from cache", async () => {
+    const jwks = makeJwks(pubKey, KID);
+    const cache: JwksCache = new Map();
+    let fetchCallCount = 0;
+
+    const trackingFetch: typeof globalThis.fetch = async (input, init) => {
+      fetchCallCount++;
+      return makeFetch(jwks)(input, init);
+    };
+
+    const args = {
+      expectedAudience: MY_ORIGIN,
+      jwksUrl: JWKS_URL,
+      fetch: trackingFetch,
+      cache,
+      now: makeNow(),
+    };
+
+    // First call — populates cache with ETag
+    const jws1 = await makeJws(privKey, KID, basePayload({ jti: "nonce-1" }));
+    const r1 = await verifyCounterpartyAttestation({ ...args, jws: jws1 });
+    expect(r1.ok).toBe(true);
+    expect(fetchCallCount).toBe(1);
+
+    // Second call — should send If-None-Match and get 304
+    const jws2 = await makeJws(privKey, KID, basePayload({ jti: "nonce-2" }));
+    const r2 = await verifyCounterpartyAttestation({ ...args, jws: jws2 });
+    expect(r2.ok).toBe(true);
+    expect(fetchCallCount).toBe(2); // fetch was called but returned 304
+
+    // Verify cache has the entry (was served from cache after 304)
+    const cached = cache.get(JWKS_URL);
+    expect(cached).toBeDefined();
+    expect(cached?.jwks).toEqual(jwks);
+  });
+
+  test("tampered-signature rejection — signature bytes altered", async () => {
+    const jwks = makeJwks(pubKey, KID);
+    const cache: JwksCache = new Map();
+    const jws = await makeJws(privKey, KID, basePayload());
+
+    // Tamper: flip a bit in the signature (last segment)
+    const parts = jws.split(".");
+    const sigBytes = Uint8Array.from(atob(
+      (parts[2] ?? "").replace(/-/g, "+").replace(/_/g, "/")
+    ), c => c.charCodeAt(0));
+    sigBytes[0] ^= 0xff; // flip first byte
+    const tamperedSig = btoa(String.fromCharCode(...sigBytes))
+      .replace(/\+/g, "-").replace(/\//g, "_").replace(/=/g, "");
+    const tamperedJws = `${parts[0]}.${parts[1]}.${tamperedSig}`;
+
+    const result = await verifyCounterpartyAttestation({
+      jws: tamperedJws,
+      expectedAudience: MY_ORIGIN,
+      jwksUrl: JWKS_URL,
+      fetch: makeFetch(jwks),
+      cache,
+      now: makeNow(),
+    });
+
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error("expected error");
+    expect(result.error.code).toBe("tampered-signature");
+  });
+});


### PR DESCRIPTION
## Summary

- Adds `src/a2a/counterparty-verifier.ts`: reference module for A2A peer attestation verification
- Fetches `MCP_ORIGIN/.well-known/jwks.json` with ETag / `If-None-Match` conditional-GET caching
- Verifies `model_attestation_jws` compact JWS using Ed25519 via `@noble/ed25519`
- Checks `aud` claim equals the verifying peer's expected MCP origin
- Projects verified payload into a typed `ModelAttestation` value
- Returns a discriminated union `{ ok: true, attestation } | { ok: false, error }` — no throws anywhere

## Test plan

- [x] Happy path: valid JWS with correct `aud`, unexpired `exp` → `ok: true` + full `ModelAttestation`
- [x] Bad-aud rejection: `aud` mismatch → `ok: false, error.code === "bad-aud"`
- [x] Expired JWS: `exp` in the past → `ok: false, error.code === "expired"`
- [x] Cache hit (304 Not Modified): second call sends `If-None-Match`, gets 304, serves JWKS from cache → `ok: true`
- [x] Tampered signature: flipped bit in signature bytes → `ok: false, error.code === "tampered-signature"`

All 5 tests pass (`bun test tests/a2a/counterparty-verifier.test.ts` → 5 pass, 0 fail).
`bun run typecheck` clean. Full `tsc -p tsconfig.json --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)