### PR TITLE
feat(FN-036): harden /on_confirm with bpp_id allowlist + replay dedup

### DIFF
--- a/src/gateway/inbound-bap.test.ts
+++ b/src/gateway/inbound-bap.test.ts
@@ -324,8 +324,11 @@ describe("validateBecknEnvelope + freshness (four defect cases)", () => {
     app.use(express.json());
     const mock = vi.fn().mockResolvedValue({ tx_signature: "dead".repeat(16) });
     mountInboundBap(app, { submitOnChain: mock });
-    const localServer = app.listen(0, "127.0.0.1");
-    const addr = localServer.address() as { port: number };
+    const localServer = await new Promise<http.Server>((resolve) => {
+      const s = app.listen(0, "127.0.0.1", () => resolve(s));
+    });
+    const addr = localServer.address() as { port: number } | null;
+    if (!addr) throw new Error("listen returned null address");
     try {
       const bad = { ...base, context: { ...base.context, version: "1.0.0" } };
       const { status, body } = await new Promise<{ status: number; body: unknown }>((resolve, reject) => {

--- a/src/gateway/inbound-bpp.test.ts
+++ b/src/gateway/inbound-bpp.test.ts
@@ -7,8 +7,14 @@
  *  - /on_confirm with order.state=CANCELLED -> submits FailTask
  *  - /on_confirm with invalid body -> 400 with errors
  *  - fulfillment_uri extraction from tracking.url and artifacts[0].url fallback
+ *
+ * FN-036: Gateway ownership hardening
+ *  - unknown bpp_id rejected with 403 when expectedBpps is set
+ *  - duplicate transaction_id rejected with 409 (replay dedup, always on)
+ *  - missing Authorization header rejected with 401 when requireSignature=true
  */
 
+import { randomUUID } from 'node:crypto';
 import type { AddressInfo } from 'node:net';
 import type { Server } from 'node:http';
 import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
@@ -144,7 +150,7 @@ async function postOnConfirm(body: unknown) {
   });
 }
 
-function buildOnConfirmBody(orderState: string, extra: Record<string, unknown> = {}) {
+function buildOnConfirmBody(orderState: string, extra: Record<string, unknown> = {}, overrideContext: Record<string, unknown> = {}) {
   return {
     context: {
       domain: 'retail',
@@ -154,9 +160,11 @@ function buildOnConfirmBody(orderState: string, extra: Record<string, unknown> =
       bap_uri: 'https://bap.example.com',
       bpp_id: 'bpp.example.com',
       bpp_uri: 'https://bpp.example.com',
-      transaction_id: 'a1b2c3d4-e5f6-7890-abcd-ef1234567890',
-      message_id: 'a1b2c3d4-e5f6-7890-abcd-ef1234567891',
+      // Generate unique IDs per call so replay dedup doesn't reject subsequent tests
+      transaction_id: randomUUID(),
+      message_id: randomUUID(),
       timestamp: '2026-04-30T00:00:00.000Z',
+      ...overrideContext,
     },
     message: {
       order: {
@@ -235,5 +243,170 @@ describe('fulfillment_uri extraction', () => {
     await postOnConfirm(body);
     const [, args] = (deps.submitOnChain as ReturnType<typeof vi.fn>).mock.calls[0] as [string, any];
     expect(args.fulfillment_uri).toBe('');
+  });
+});
+
+// ---------- FN-036: Gateway ownership hardening ----------
+
+describe('FN-036: BPP allowlist (expectedBpps)', () => {
+  let hardenedServer: Server;
+  let hardenedUrl: string;
+
+  beforeAll(async () => {
+    const app = express();
+    app.use(express.json());
+    const hardenedDeps = makeDeps({
+      expectedBpps: new Set(['trusted-bpp.example.com']),
+    });
+    mountOnConfirmCallback(app, hardenedDeps);
+    await new Promise<void>((resolve) => {
+      hardenedServer = app.listen(0, '127.0.0.1', () => resolve());
+    });
+    const addr = hardenedServer.address() as AddressInfo;
+    hardenedUrl = `http://127.0.0.1:${addr.port}`;
+  });
+
+  afterAll(async () => {
+    await new Promise<void>((resolve, reject) => {
+      hardenedServer.close((err) => (err ? reject(err) : resolve()));
+    });
+  });
+
+  it('rejects callback with unknown bpp_id with 403', async () => {
+    const body = buildOnConfirmBody('COMPLETED', {}, { bpp_id: 'unknown-bpp.example.com', bpp_uri: 'https://unknown-bpp.example.com' });
+    const res = await fetch(`${hardenedUrl}/on_confirm`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+    });
+    expect(res.status).toBe(403);
+    const json = await res.json() as any;
+    expect(json.error).toBe('unknown_bpp');
+  });
+
+  it('accepts callback from trusted bpp_id with 200', async () => {
+    const body = buildOnConfirmBody('COMPLETED', {}, { bpp_id: 'trusted-bpp.example.com', bpp_uri: 'https://trusted-bpp.example.com' });
+    const res = await fetch(`${hardenedUrl}/on_confirm`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+    });
+    expect(res.status).toBe(200);
+    const json = await res.json() as any;
+    expect(json.message.ack.status).toBe('ACK');
+  });
+});
+
+describe('FN-036: Replay dedup (seenTransactions)', () => {
+  let dedupServer: Server;
+  let dedupUrl: string;
+  let dedupDeps: InboundBppDeps;
+
+  beforeAll(async () => {
+    const app = express();
+    app.use(express.json());
+    dedupDeps = makeDeps();
+    mountOnConfirmCallback(app, dedupDeps);
+    await new Promise<void>((resolve) => {
+      dedupServer = app.listen(0, '127.0.0.1', () => resolve());
+    });
+    const addr = dedupServer.address() as AddressInfo;
+    dedupUrl = `http://127.0.0.1:${addr.port}`;
+  });
+
+  afterAll(async () => {
+    await new Promise<void>((resolve, reject) => {
+      dedupServer.close((err) => (err ? reject(err) : resolve()));
+    });
+  });
+
+  it('rejects duplicate transaction_id with 409', async () => {
+    const fixedTxnId = randomUUID();
+    const body = buildOnConfirmBody('COMPLETED', {}, { transaction_id: fixedTxnId });
+
+    // First call should succeed
+    const first = await fetch(`${dedupUrl}/on_confirm`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+    });
+    expect(first.status).toBe(200);
+
+    // Second call with same transaction_id must be rejected
+    const second = await fetch(`${dedupUrl}/on_confirm`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+    });
+    expect(second.status).toBe(409);
+    const json = await second.json() as any;
+    expect(json.error).toBe('duplicate_transaction');
+  });
+
+  it('accepts two callbacks with distinct transaction_ids', async () => {
+    const body1 = buildOnConfirmBody('COMPLETED');
+    const body2 = buildOnConfirmBody('CANCELLED');
+
+    const r1 = await fetch(`${dedupUrl}/on_confirm`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body1),
+    });
+    const r2 = await fetch(`${dedupUrl}/on_confirm`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body2),
+    });
+    expect(r1.status).toBe(200);
+    expect(r2.status).toBe(200);
+  });
+});
+
+describe('FN-036: Signature gate (requireSignature)', () => {
+  let sigServer: Server;
+  let sigUrl: string;
+
+  beforeAll(async () => {
+    const app = express();
+    app.use(express.json());
+    mountOnConfirmCallback(app, makeDeps({ requireSignature: true }));
+    await new Promise<void>((resolve) => {
+      sigServer = app.listen(0, '127.0.0.1', () => resolve());
+    });
+    const addr = sigServer.address() as AddressInfo;
+    sigUrl = `http://127.0.0.1:${addr.port}`;
+  });
+
+  afterAll(async () => {
+    await new Promise<void>((resolve, reject) => {
+      sigServer.close((err) => (err ? reject(err) : resolve()));
+    });
+  });
+
+  it('rejects request with no Authorization header with 401', async () => {
+    const body = buildOnConfirmBody('COMPLETED');
+    const res = await fetch(`${sigUrl}/on_confirm`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+    });
+    expect(res.status).toBe(401);
+    const json = await res.json() as any;
+    expect(json.error).toBe('missing_signature');
+  });
+
+  it('accepts request with Authorization header present', async () => {
+    const body = buildOnConfirmBody('COMPLETED');
+    const res = await fetch(`${sigUrl}/on_confirm`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'Authorization': 'Signature keyId="bpp.example.com",signature="stub"',
+      },
+      body: JSON.stringify(body),
+    });
+    expect(res.status).toBe(200);
+    const json = await res.json() as any;
+    expect(json.message.ack.status).toBe('ACK');
   });
 });

--- a/src/gateway/inbound-bpp.ts
+++ b/src/gateway/inbound-bpp.ts
@@ -6,6 +6,24 @@
  *
  * Spec: T-2.8.2.3 (FN-090). Sibling roles: inbound-bap (FN-088),
  * outbound-bap (FN-089).
+ *
+ * ## Gateway ownership hardening (FN-036)
+ *
+ * Three security controls added to mountOnConfirmCallback:
+ *
+ *   1. BPP allowlist  — when `expectedBpps` is provided, callbacks from
+ *      unknown `context.bpp_id` values are rejected with HTTP 403.
+ *
+ *   2. Replay dedup   — ON BY DEFAULT. The seen-transaction set is keyed on
+ *      `context.transaction_id`. Duplicate callbacks are rejected with HTTP 409.
+ *      Pass `seenTransactions` to inject a pre-populated set (e.g. in tests).
+ *      The txn_id is committed to the set *before* `submitOnChain` is called
+ *      to prevent any double-trigger under concurrent requests.
+ *
+ *   3. Signature gate — when `requireSignature: true`, the handler rejects
+ *      requests that lack an `Authorization` header with HTTP 401.
+ *      Full Beckn Ed25519 signature verification is deferred; this is a
+ *      presence-only guard that prevents entirely unsigned inbound traffic.
  */
 
 import { createHash } from 'node:crypto';
@@ -39,6 +57,29 @@ export interface InboundBppDeps {
   chainClient?: import("./chain-client.js").ChainClient;
   /** Look up off-chain order details by terms_hash. */
   loadOrderByTermsHash?: (terms_hash: string) => Promise<object | null>;
+
+  // ---- FN-036: Gateway ownership hardening ----
+
+  /**
+   * Allowlist of trusted BPP identifiers (context.bpp_id values).
+   * When provided, callbacks from BPPs not in this set are rejected 403.
+   * When absent (default), all bpp_ids are accepted.
+   */
+  expectedBpps?: Set<string>;
+
+  /**
+   * Inject a pre-populated seen-transactions set.
+   * Defaults to a fresh Set created at mount time (replay dedup is always on).
+   * Callers can pass their own Set to share state across mount calls or to
+   * pre-seed transactions that must be treated as already seen.
+   */
+  seenTransactions?: Set<string>;
+
+  /**
+   * When true, requests without an `Authorization` header are rejected 401.
+   * Defaults to false. Full Beckn Ed25519 verification is deferred (stub-level).
+   */
+  requireSignature?: boolean;
 }
 
 /** Handle an outbound /confirm produced by an on-chain Confirm AgentTrigger. */
@@ -78,11 +119,36 @@ export function mountOnConfirmCallback(app: Express, deps: InboundBppDeps): void
       return { tx_signature: r.tx_signature };
     });
 
+  // FN-036: replay dedup set — always on; caller may inject a pre-populated set.
+  const seenTransactions: Set<string> = deps.seenTransactions ?? new Set();
+
   app.post('/on_confirm', async (req: Request, res: Response) => {
+    // 1. Schema validation (existing)
     const v = validateBecknRequest('on_confirm', req.body);
     if (!v.ok) {
       return res.status(400).json({ error: 'beckn_validation_failed', details: (v as { ok: false; errors: unknown }).errors });
     }
+
+    // 2. FN-036: Signature presence gate (optional, off by default)
+    if (deps.requireSignature && !req.headers['authorization']) {
+      return res.status(401).json({ error: 'missing_signature', details: 'Authorization header required' });
+    }
+
+    // 3. FN-036: BPP allowlist check (optional, off by default)
+    const bppId: string | undefined = req.body.context?.bpp_id;
+    if (deps.expectedBpps && (!bppId || !deps.expectedBpps.has(bppId))) {
+      return res.status(403).json({ error: 'unknown_bpp', details: `bpp_id not in allowlist: ${bppId ?? '(missing)'}` });
+    }
+
+    // 4. FN-036: Replay dedup (always on — commit before submit to prevent double-trigger)
+    const txnId: string | undefined = req.body.context?.transaction_id;
+    if (txnId) {
+      if (seenTransactions.has(txnId)) {
+        return res.status(409).json({ error: 'duplicate_transaction', details: `transaction_id already processed: ${txnId}` });
+      }
+      seenTransactions.add(txnId);
+    }
+
     try {
       const order = req.body.message?.order;
       const success = order?.state === 'COMPLETED' || order?.state === 'FULFILLED';

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -2,7 +2,7 @@ import { defineConfig } from "vitest/config";
 
 export default defineConfig({
   test: {
-    include: ["test/**/*.test.ts", "tests/**/*.test.ts", "keeper/bpps/__tests__/**/*.test.ts", "keeper/bpps/bank/handlers/**/*.test.ts"],
+    include: ["test/**/*.test.ts", "tests/**/*.test.ts", "src/gateway/**/*.test.ts", "keeper/bpps/__tests__/**/*.test.ts", "keeper/bpps/bank/handlers/**/*.test.ts"],
     // Exclude bun:test-only suites that vitest cannot transform.
     // These suites import from "bun:test" and are pre-existing.
     exclude: [


### PR DESCRIPTION
## Summary

- **BPP allowlist**: Add `expectedBpps?: Set<string>` to `InboundBppDeps`; callbacks from unknown `context.bpp_id` values rejected with HTTP 403
- **Replay dedup (always on)**: Duplicate `context.transaction_id` rejected with HTTP 409; transaction committed to the seen-set *before* `submitOnChain` is called to prevent double-trigger of downstream chain submissions
- **Signature gate**: Add `requireSignature?: boolean`; requests missing `Authorization` header rejected with HTTP 401 (stub-level presence check, full Ed25519 verification deferred)

All three new options are backward-compatible — `expectedBpps` and `requireSignature` are opt-in (default off), replay dedup is always on but safe because `buildOnConfirmBody` in tests now generates a unique `randomUUID()` per call.

Also adds `src/gateway/**/*.test.ts` to the vitest include pattern so gateway tests run in CI.

## Test plan

- [x] All 17 `inbound-bpp.test.ts` tests pass (11 existing + 6 new FN-036 tests)
- [x] `bun run typecheck` passes with zero errors
- [x] New tests: unknown bpp_id → 403, trusted bpp_id → 200
- [x] New tests: duplicate transaction_id → 409, distinct transaction_ids both → 200
- [x] New tests: missing Authorization → 401, Authorization present → 200

🤖 Generated with [Claude Code](https://claude.com/claude-code)