### PR TITLE
feat(FN-028): Ed25519 key rotation for audit-trail signing

### DIFF
--- a/src/signing/key-rotation.ts
+++ b/src/signing/key-rotation.ts
@@ -1,0 +1,275 @@
+/**
+ * Ed25519 key rotation primitives for audit-trail / travel-rule signing
+ * (FN-028).
+ *
+ * **Scope.** This module provides three things:
+ *   1. `DidDocument` — a minimal DID document type with a
+ *      `verificationMethod[]` array (multi-key support).
+ *   2. `signWithKid(payload, privateKey, kid)` — signs an arbitrary JSON
+ *      payload as a compact JWS (base64url(header).base64url(payload).sig),
+ *      embedding `kid` in the JOSE header so the verifier can resolve the
+ *      right public key.
+ *   3. `verifyWithDid(jws, didDoc)` — parses the JWS header, resolves
+ *      `kid` → public key from the DID document's `verificationMethod`
+ *      array, verifies the Ed25519 signature, and returns the decoded
+ *      payload. Throws `KeyRotationError` on unknown kid or bad signature.
+ *
+ * **JWS header.** `{ alg: "EdDSA", kid: <kid>, typ: "JWT" }`
+ *
+ * **Public key encoding.** Verification methods use `publicKeyJwk`
+ * (`{ kty: "OKP", crv: "Ed25519", x: base64url(rawPubKey32) }`) — the
+ * JOSE-native form that avoids a multibase/multicodec dependency.
+ *
+ * **Why a standalone module.** The audit-trail and travel-rule documents
+ * are explicitly unsigned in v0 (see the UNSIGNED caveats in each file).
+ * This module ships the rotation primitives so downstream consumers can
+ * wire signing in without any refactor of those files.
+ */
+
+import * as ed from "@noble/ed25519";
+import { sha512 } from "@noble/hashes/sha512";
+
+// Configure synchronous sha512 required by @noble/ed25519 v2.
+ed.etc.sha512Sync = (...m: Uint8Array[]) => sha512(ed.etc.concatBytes(...m));
+
+// ---------------------------------------------------------------------------
+// Errors
+// ---------------------------------------------------------------------------
+
+export type KeyRotationErrorCode =
+  | "UNKNOWN_KID"
+  | "INVALID_JWS"
+  | "INVALID_PUBKEY"
+  | "BAD_SIGNATURE";
+
+export class KeyRotationError extends Error {
+  public override readonly name = "KeyRotationError";
+  public readonly code: KeyRotationErrorCode;
+  public readonly detail?: unknown;
+
+  public constructor(
+    code: KeyRotationErrorCode,
+    message: string,
+    detail?: unknown,
+  ) {
+    super(message);
+    this.code = code;
+    if (detail !== undefined) this.detail = detail;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// DID document types
+// ---------------------------------------------------------------------------
+
+/**
+ * A single Ed25519 verification method entry in a DID document.
+ *
+ * `id` is the key identifier (kid). `publicKeyJwk.x` is the raw 32-byte
+ * public key encoded as base64url (no padding).
+ */
+export interface VerificationMethod {
+  /** Key identifier, e.g. `"did:example:123#key-1"`. Used as the JWS `kid`. */
+  id: string;
+  /** MUST be `"Ed25519VerificationKey2020"`. */
+  type: "Ed25519VerificationKey2020";
+  /** The DID that controls this key. */
+  controller: string;
+  /** Public key in JWK form: `{ kty: "OKP", crv: "Ed25519", x: base64url }`. */
+  publicKeyJwk: {
+    kty: "OKP";
+    crv: "Ed25519";
+    /** Raw 32-byte public key, base64url-encoded (no padding). */
+    x: string;
+  };
+}
+
+/**
+ * Minimal DID document supporting multi-key rotation.
+ *
+ * `verificationMethod` carries all active (and recently-retired) keys so
+ * that JWS tokens signed under any listed kid can still be verified during
+ * a rotation window.
+ */
+export interface DidDocument {
+  "@context": readonly string[];
+  id: string;
+  verificationMethod: readonly VerificationMethod[];
+  /** Authentication references — ids of verificationMethod entries. */
+  authentication?: readonly string[];
+}
+
+// ---------------------------------------------------------------------------
+// JWS helpers
+// ---------------------------------------------------------------------------
+
+function b64uEncode(bytes: Uint8Array): string {
+  // Node 20+ Buffer.from().toString("base64url") strips padding automatically.
+  return Buffer.from(bytes).toString("base64url");
+}
+
+function b64uDecode(s: string): Uint8Array {
+  return new Uint8Array(Buffer.from(s, "base64url"));
+}
+
+function encodeJson(obj: unknown): string {
+  return b64uEncode(new TextEncoder().encode(JSON.stringify(obj)));
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/**
+ * Sign `payload` with `privateKey` and embed `kid` in the JWS header.
+ *
+ * Returns a compact JWS string:
+ *   `base64url(header) + "." + base64url(payload) + "." + base64url(sig)`
+ *
+ * where `header = { alg: "EdDSA", kid, typ: "JWT" }`.
+ *
+ * `payload` can be any JSON-serialisable value. The bytes signed are
+ * `ascii(headerPart + "." + payloadPart)` (standard JWS signing input).
+ */
+export async function signWithKid(
+  payload: unknown,
+  privateKey: Uint8Array,
+  kid: string,
+): Promise<string> {
+  const header = encodeJson({ alg: "EdDSA", kid, typ: "JWT" });
+  const body = encodeJson(payload);
+  const signingInput = new TextEncoder().encode(`${header}.${body}`);
+  const sig = await ed.sign(signingInput, privateKey);
+  return `${header}.${body}.${b64uEncode(sig)}`;
+}
+
+/**
+ * Verify a compact JWS produced by `signWithKid` against a DID document.
+ *
+ * Steps:
+ *   1. Split the JWS into header / payload / signature parts.
+ *   2. Decode and parse the header; extract `kid`.
+ *   3. Find the `verificationMethod` entry in `didDoc` whose `id === kid`.
+ *   4. Decode `publicKeyJwk.x` to the raw 32-byte Ed25519 public key.
+ *   5. Verify the signature over `header + "." + payload` bytes.
+ *   6. Return the decoded payload as `unknown`.
+ *
+ * Throws `KeyRotationError` on:
+ *   - Malformed JWS structure (`INVALID_JWS`)
+ *   - No matching verificationMethod for `kid` (`UNKNOWN_KID`)
+ *   - Malformed or wrong-length public key (`INVALID_PUBKEY`)
+ *   - Signature verification failure (`BAD_SIGNATURE`)
+ */
+export async function verifyWithDid(
+  jws: string,
+  didDoc: DidDocument,
+): Promise<unknown> {
+  const parts = jws.split(".");
+  if (parts.length !== 3) {
+    throw new KeyRotationError(
+      "INVALID_JWS",
+      `JWS must have exactly 3 parts separated by '.'; got ${parts.length}`,
+    );
+  }
+
+  const [headerPart, payloadPart, sigPart] = parts as [string, string, string];
+
+  // Parse header.
+  let header: Record<string, unknown>;
+  try {
+    header = JSON.parse(new TextDecoder().decode(b64uDecode(headerPart))) as Record<string, unknown>;
+  } catch (e) {
+    throw new KeyRotationError("INVALID_JWS", "failed to decode JWS header", e);
+  }
+
+  const kid = header["kid"];
+  if (typeof kid !== "string" || kid.length === 0) {
+    throw new KeyRotationError(
+      "INVALID_JWS",
+      "JWS header must contain a non-empty 'kid' string",
+    );
+  }
+
+  // Resolve kid → verificationMethod.
+  const method = didDoc.verificationMethod.find((vm) => vm.id === kid);
+  if (method === undefined) {
+    throw new KeyRotationError(
+      "UNKNOWN_KID",
+      `kid '${kid}' not found in DID document '${didDoc.id}'`,
+      { kid, availableKids: didDoc.verificationMethod.map((vm) => vm.id) },
+    );
+  }
+
+  // Decode the public key.
+  let pubKey: Uint8Array;
+  try {
+    pubKey = b64uDecode(method.publicKeyJwk.x);
+  } catch (e) {
+    throw new KeyRotationError(
+      "INVALID_PUBKEY",
+      `failed to decode publicKeyJwk.x for kid '${kid}'`,
+      e,
+    );
+  }
+  if (pubKey.length !== 32) {
+    throw new KeyRotationError(
+      "INVALID_PUBKEY",
+      `publicKeyJwk.x for kid '${kid}' decoded to ${pubKey.length} bytes; expected 32`,
+    );
+  }
+
+  // Verify signature over the standard JWS signing input.
+  const signingInput = new TextEncoder().encode(`${headerPart}.${payloadPart}`);
+  let sig: Uint8Array;
+  try {
+    sig = b64uDecode(sigPart);
+  } catch (e) {
+    throw new KeyRotationError("INVALID_JWS", "failed to decode JWS signature", e);
+  }
+
+  const valid = await ed.verify(sig, signingInput, pubKey);
+  if (!valid) {
+    throw new KeyRotationError(
+      "BAD_SIGNATURE",
+      `Ed25519 signature verification failed for kid '${kid}'`,
+    );
+  }
+
+  // Decode and return the payload.
+  let decoded: unknown;
+  try {
+    decoded = JSON.parse(new TextDecoder().decode(b64uDecode(payloadPart)));
+  } catch (e) {
+    throw new KeyRotationError("INVALID_JWS", "failed to decode JWS payload", e);
+  }
+  return decoded;
+}
+
+// ---------------------------------------------------------------------------
+// Helper: build a VerificationMethod from a raw Ed25519 private key
+// ---------------------------------------------------------------------------
+
+/**
+ * Derive the `VerificationMethod` entry for a given private key and kid.
+ *
+ * Useful in tests and for DID document construction: given a raw 32-byte
+ * Ed25519 private key, returns the `VerificationMethod` object that should
+ * be placed in `didDoc.verificationMethod`.
+ */
+export function buildVerificationMethod(
+  kid: string,
+  controller: string,
+  privateKey: Uint8Array,
+): VerificationMethod {
+  const pubKey = ed.getPublicKey(privateKey);
+  return {
+    id: kid,
+    type: "Ed25519VerificationKey2020",
+    controller,
+    publicKeyJwk: {
+      kty: "OKP",
+      crv: "Ed25519",
+      x: Buffer.from(pubKey).toString("base64url"),
+    },
+  };
+}

--- a/tests/unit/key-rotation.test.ts
+++ b/tests/unit/key-rotation.test.ts
@@ -1,0 +1,196 @@
+/**
+ * Tests for Ed25519 key rotation primitives (FN-028).
+ *
+ * Test cases:
+ *   1. Happy path: sign with kid A, verify against DID with keys [A, B].
+ *   2. Rotation case: sign with kid B (new key), verify against DID with [A, B].
+ *   3. Unknown-kid rejection: sign with kid C, verify against DID with [A, B].
+ *   4. Bad-signature rejection: tampered JWS fails verification.
+ *   5. Malformed JWS (wrong number of parts) rejected.
+ *   6. buildVerificationMethod helper round-trips correctly.
+ */
+
+import { describe, test, expect } from "vitest";
+import * as ed from "@noble/ed25519";
+import { sha512 } from "@noble/hashes/sha512";
+import {
+  signWithKid,
+  verifyWithDid,
+  buildVerificationMethod,
+  KeyRotationError,
+  type DidDocument,
+  type VerificationMethod,
+} from "../../src/signing/key-rotation.js";
+
+// Configure synchronous sha512 for @noble/ed25519 v2 (required).
+ed.etc.sha512Sync = (...m: Uint8Array[]) => sha512(ed.etc.concatBytes(...m));
+
+// ---------------------------------------------------------------------------
+// Test fixtures
+// ---------------------------------------------------------------------------
+
+function makeKey(): Uint8Array {
+  const key = new Uint8Array(32);
+  crypto.getRandomValues(key);
+  return key;
+}
+
+function makeDidDoc(methods: readonly VerificationMethod[]): DidDocument {
+  return {
+    "@context": [
+      "https://www.w3.org/ns/did/v1",
+      "https://w3id.org/security/suites/ed25519-2020/v1",
+    ],
+    id: "did:eto:test:123",
+    verificationMethod: methods,
+    authentication: methods.map((m) => m.id),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("signWithKid + verifyWithDid", () => {
+  test("happy path: sign with kid A, verify against DID with keys [A, B]", async () => {
+    const privA = makeKey();
+    const privB = makeKey();
+
+    const vmA = buildVerificationMethod("did:eto:test:123#key-A", "did:eto:test:123", privA);
+    const vmB = buildVerificationMethod("did:eto:test:123#key-B", "did:eto:test:123", privB);
+    const didDoc = makeDidDoc([vmA, vmB]);
+
+    const payload = { sub: "alice", event: "init", slot: 42 };
+    const jws = await signWithKid(payload, privA, "did:eto:test:123#key-A");
+
+    const result = await verifyWithDid(jws, didDoc);
+    expect(result).toEqual(payload);
+  });
+
+  test("rotation case: sign with kid B (new key), verify against DID with [A, B]", async () => {
+    const privA = makeKey();
+    const privB = makeKey();
+
+    const vmA = buildVerificationMethod("did:eto:test:123#key-A", "did:eto:test:123", privA);
+    const vmB = buildVerificationMethod("did:eto:test:123#key-B", "did:eto:test:123", privB);
+    const didDoc = makeDidDoc([vmA, vmB]);
+
+    const payload = { sub: "bob", event: "confirm", slot: 99, amountUsd: 5000 };
+    // Sign with the new (rotated-in) key B
+    const jws = await signWithKid(payload, privB, "did:eto:test:123#key-B");
+
+    const result = await verifyWithDid(jws, didDoc);
+    expect(result).toEqual(payload);
+  });
+
+  test("unknown-kid rejection: sign with kid C, verify against DID with [A, B]", async () => {
+    const privA = makeKey();
+    const privB = makeKey();
+    const privC = makeKey(); // key not in DID doc
+
+    const vmA = buildVerificationMethod("did:eto:test:123#key-A", "did:eto:test:123", privA);
+    const vmB = buildVerificationMethod("did:eto:test:123#key-B", "did:eto:test:123", privB);
+    const didDoc = makeDidDoc([vmA, vmB]);
+
+    const jws = await signWithKid({ data: "secret" }, privC, "did:eto:test:123#key-C");
+
+    await expect(verifyWithDid(jws, didDoc)).rejects.toMatchObject({
+      name: "KeyRotationError",
+      code: "UNKNOWN_KID",
+    });
+  });
+
+  test("bad-signature rejection: tampered payload fails verification", async () => {
+    const privA = makeKey();
+    const vmA = buildVerificationMethod("did:eto:test:123#key-A", "did:eto:test:123", privA);
+    const didDoc = makeDidDoc([vmA]);
+
+    const jws = await signWithKid({ amount: 100 }, privA, "did:eto:test:123#key-A");
+
+    // Tamper: replace the payload part with a different base64url payload
+    const parts = jws.split(".");
+    const tamperedPayload = Buffer.from(JSON.stringify({ amount: 99999 })).toString("base64url");
+    const tamperedJws = `${parts[0]}.${tamperedPayload}.${parts[2]}`;
+
+    await expect(verifyWithDid(tamperedJws, didDoc)).rejects.toMatchObject({
+      name: "KeyRotationError",
+      code: "BAD_SIGNATURE",
+    });
+  });
+
+  test("malformed JWS (wrong number of parts) is rejected", async () => {
+    const privA = makeKey();
+    const vmA = buildVerificationMethod("did:eto:test:123#key-A", "did:eto:test:123", privA);
+    const didDoc = makeDidDoc([vmA]);
+
+    // Only two parts — missing signature
+    const badJws = "header.payload";
+    await expect(verifyWithDid(badJws, didDoc)).rejects.toMatchObject({
+      name: "KeyRotationError",
+      code: "INVALID_JWS",
+    });
+  });
+
+  test("missing kid in header is rejected", async () => {
+    const privA = makeKey();
+    const vmA = buildVerificationMethod("did:eto:test:123#key-A", "did:eto:test:123", privA);
+    const didDoc = makeDidDoc([vmA]);
+
+    // Build a JWS with a header that has no kid
+    const header = Buffer.from(JSON.stringify({ alg: "EdDSA", typ: "JWT" })).toString("base64url");
+    const body = Buffer.from(JSON.stringify({ data: 1 })).toString("base64url");
+    const signingInput = new TextEncoder().encode(`${header}.${body}`);
+    const sig = await ed.sign(signingInput, privA);
+    const fakeJws = `${header}.${body}.${Buffer.from(sig).toString("base64url")}`;
+
+    await expect(verifyWithDid(fakeJws, didDoc)).rejects.toMatchObject({
+      name: "KeyRotationError",
+      code: "INVALID_JWS",
+    });
+  });
+});
+
+describe("buildVerificationMethod", () => {
+  test("returns correct type and controller", () => {
+    const priv = makeKey();
+    const vm = buildVerificationMethod("did:eto:test:1#key-1", "did:eto:test:1", priv);
+    expect(vm.id).toBe("did:eto:test:1#key-1");
+    expect(vm.type).toBe("Ed25519VerificationKey2020");
+    expect(vm.controller).toBe("did:eto:test:1");
+    expect(vm.publicKeyJwk.kty).toBe("OKP");
+    expect(vm.publicKeyJwk.crv).toBe("Ed25519");
+  });
+
+  test("publicKeyJwk.x decodes to the correct 32-byte public key", () => {
+    const priv = makeKey();
+    const expectedPub = ed.getPublicKey(priv);
+    const vm = buildVerificationMethod("did:eto:test:1#key-1", "did:eto:test:1", priv);
+    const decoded = new Uint8Array(Buffer.from(vm.publicKeyJwk.x, "base64url"));
+    expect(decoded).toEqual(expectedPub);
+  });
+
+  test("round-trip: sign with private key, verify using built VM", async () => {
+    const priv = makeKey();
+    const vm = buildVerificationMethod("did:eto:test:1#k", "did:eto:test:1", priv);
+    const didDoc = makeDidDoc([vm]);
+    const payload = { hello: "world" };
+    const jws = await signWithKid(payload, priv, "did:eto:test:1#k");
+    const result = await verifyWithDid(jws, didDoc);
+    expect(result).toEqual(payload);
+  });
+});
+
+describe("KeyRotationError", () => {
+  test("has correct name and code", () => {
+    const err = new KeyRotationError("UNKNOWN_KID", "not found");
+    expect(err.name).toBe("KeyRotationError");
+    expect(err.code).toBe("UNKNOWN_KID");
+    expect(err.message).toBe("not found");
+    expect(err instanceof Error).toBe(true);
+  });
+
+  test("carries detail when provided", () => {
+    const err = new KeyRotationError("INVALID_JWS", "bad format", { parts: 2 });
+    expect(err.detail).toEqual({ parts: 2 });
+  });
+});


### PR DESCRIPTION
## Summary

- Add `src/signing/key-rotation.ts`: standalone Ed25519 key rotation primitives for audit-trail / travel-rule signing
- Multi-key DID document support: `DidDocument` type with `verificationMethod[]` array
- `signWithKid(payload, privateKey, kid)`: produces compact JWS with `{alg:"EdDSA", kid, typ:"JWT"}` header
- `verifyWithDid(jws, didDoc)`: resolves `kid` → pubkey from DID document, verifies Ed25519 signature, returns decoded payload
- `buildVerificationMethod(kid, controller, privateKey)`: helper to construct `VerificationMethod` entries (publicKeyJwk / OKP form)
- `KeyRotationError` with typed error codes: `UNKNOWN_KID`, `INVALID_JWS`, `INVALID_PUBKEY`, `BAD_SIGNATURE`

## Context

The audit-trail (`src/services/indexer/audit-trail.ts`) and travel-rule (`src/services/indexer/travel-rule.ts`) documents are explicitly unsigned in v0. This module ships the rotation primitives so downstream consumers can wire signing in without refactoring those files.

## Test plan

- [ ] Happy path: sign with kid A, verify against DID with verificationMethod = [A, B] → payload returned
- [ ] Rotation case: sign with new kid B, verify against DID with [A, B] → payload returned
- [ ] Unknown-kid rejection: sign with kid C not in DID → `KeyRotationError { code: "UNKNOWN_KID" }`
- [ ] Bad-signature rejection: tampered JWS → `KeyRotationError { code: "BAD_SIGNATURE" }`
- [ ] Malformed JWS (2 parts instead of 3) → `KeyRotationError { code: "INVALID_JWS" }`
- [ ] Missing `kid` in header → `KeyRotationError { code: "INVALID_JWS" }`
- [ ] `buildVerificationMethod` round-trip: pubkey decodes correctly, sign+verify succeeds
- [ ] `KeyRotationError` carries name, code, and optional detail

All 11 tests pass. `bun run typecheck` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)