### PR TITLE
feat(FN-034): caller-binding auth on bank BPP wire/offramp/onramp/open-savings

### DIFF
--- a/keeper/bpps/bank/handlers/fee.correctness.test.ts
+++ b/keeper/bpps/bank/handlers/fee.correctness.test.ts
@@ -240,6 +240,7 @@ const ONRAMP_TOKEN_PDA = 'b'.repeat(64);
  */
 function makeOnrampRequest(gross_eusd_atomic: number): OnrampRequest {
   return {
+    caller_pubkey: ONRAMP_RECIPIENT, // FN-034: caller MUST equal recipient
     recipient: ONRAMP_RECIPIENT,
     recipient_token_account_pda: ONRAMP_TOKEN_PDA,
     usd_amount_cents: gross_eusd_atomic / 10_000,
@@ -274,6 +275,7 @@ const DOMESTIC_DEST: OfframpRequest['destination'] = {
 
 function makeOfframpRequest(eusd_amount_atomic: number): OfframpRequest {
   return {
+    caller_pubkey: OFFRAMP_HOLDER, // FN-034: caller MUST equal holder
     holder: OFFRAMP_HOLDER,
     holder_token_account_pda: OFFRAMP_HOLDER_TOKEN_PDA,
     eusd_amount_atomic,

--- a/keeper/bpps/bank/handlers/offramp.test.ts
+++ b/keeper/bpps/bank/handlers/offramp.test.ts
@@ -33,6 +33,7 @@ const INTL_DEST: OfframpRequest['destination'] = {
 
 function makeRequest(overrides: Partial<OfframpRequest> = {}): OfframpRequest {
   return {
+    caller_pubkey: HOLDER, // FN-034: caller MUST equal holder
     holder: HOLDER,
     holder_token_account_pda: HOLDER_TOKEN_PDA,
     eusd_amount_atomic: 100_000_000,
@@ -151,6 +152,34 @@ describe('executeOfframp — invalid_pubkey', () => {
     const deps = makeDeps();
     await expect(executeOfframp(makeRequest({ holder_token_account_pda: '00' }), deps))
       .rejects.toMatchObject({ reason: 'invalid_pubkey' });
+  });
+});
+
+describe('executeOfframp — caller-binding (FN-034)', () => {
+  it('rejects when caller_pubkey != holder with caller_mismatch', async () => {
+    const deps = makeDeps();
+    const attacker = 'f'.repeat(64);
+    await expect(
+      executeOfframp(makeRequest({ caller_pubkey: attacker }), deps),
+    ).rejects.toMatchObject({ reason: 'caller_mismatch' });
+  });
+
+  it('rejects without invoking burnOnChain / pushUsd / remitToTreasury', async () => {
+    const deps = makeDeps();
+    const attacker = 'f'.repeat(64);
+    await expect(
+      executeOfframp(makeRequest({ caller_pubkey: attacker }), deps),
+    ).rejects.toBeInstanceOf(OfframpRejected);
+    expect(deps.burnOnChain).not.toHaveBeenCalled();
+    expect(deps.pushUsd).not.toHaveBeenCalled();
+    expect(deps.remitToTreasury).not.toHaveBeenCalled();
+  });
+
+  it('rejects when caller_pubkey is not a valid hex64 with invalid_pubkey', async () => {
+    const deps = makeDeps();
+    await expect(
+      executeOfframp(makeRequest({ caller_pubkey: 'tooshort' }), deps),
+    ).rejects.toMatchObject({ reason: 'invalid_pubkey' });
   });
 });
 

--- a/keeper/bpps/bank/handlers/offramp.ts
+++ b/keeper/bpps/bank/handlers/offramp.ts
@@ -37,6 +37,13 @@ import {
 } from './fee.js';
 
 export interface OfframpRequest {
+  /**
+   * FN-034: authenticated caller pubkey (hex). MUST equal `holder` —
+   * any mismatch is rejected with `caller_mismatch` before any side-effect
+   * runs. Without this binding, an unauthenticated caller could burn eUSD
+   * and push USD on behalf of any subject.
+   */
+  caller_pubkey: string;
   holder: string;                     // hex pubkey burning eUSD
   holder_token_account_pda: string;   // hex — TokenAccount being burned from
   eusd_amount_atomic: number;         // atomic eUSD units (1 eUSD = 1_000_000)
@@ -84,7 +91,7 @@ export interface OfframpDeps {
 }
 
 export class OfframpRejected extends Error {
-  constructor(public reason: 'invalid_pubkey' | 'invalid_amount' | 'destination_invalid' | 'burn_failed' | 'push_failed_post_burn') {
+  constructor(public reason: 'invalid_pubkey' | 'caller_mismatch' | 'invalid_amount' | 'destination_invalid' | 'burn_failed' | 'push_failed_post_burn') {
     super('offramp rejected: ' + reason);
   }
 }
@@ -97,8 +104,13 @@ function atomicEusdToUsdCents(atomic: number): number {
 }
 
 export async function executeOfframp(req: OfframpRequest, deps: OfframpDeps): Promise<OfframpOutcome> {
+  if (!HEX64.test(req.caller_pubkey)) throw new OfframpRejected('invalid_pubkey');
   if (!HEX64.test(req.holder)) throw new OfframpRejected('invalid_pubkey');
   if (!HEX64.test(req.holder_token_account_pda)) throw new OfframpRejected('invalid_pubkey');
+  // FN-034: caller-binding. Reject before any side-effect when the caller
+  // is not the holder; otherwise an unauth'd caller could burn another
+  // subject's eUSD and direct the USD push.
+  if (req.caller_pubkey !== req.holder) throw new OfframpRejected('caller_mismatch');
   if (!Number.isInteger(req.eusd_amount_atomic) || req.eusd_amount_atomic <= 0) throw new OfframpRejected('invalid_amount');
   if (!req.destination.account_holder_name) throw new OfframpRejected('destination_invalid');
   // At least one routing pair must be present

--- a/keeper/bpps/bank/handlers/onramp.test.ts
+++ b/keeper/bpps/bank/handlers/onramp.test.ts
@@ -21,6 +21,7 @@ const TOKEN_PDA = 'b'.repeat(64);
 
 function makeRequest(overrides: Partial<OnrampRequest> = {}): OnrampRequest {
   return {
+    caller_pubkey: RECIPIENT, // FN-034: caller MUST equal recipient
     recipient: RECIPIENT,
     recipient_token_account_pda: TOKEN_PDA,
     usd_amount_cents: 10_000,        // $100.00
@@ -137,6 +138,34 @@ describe('executeOnramp — invalid_pubkey', () => {
     const deps = makeDeps();
     await expect(executeOnramp(makeRequest({ recipient_token_account_pda: 'bad' }), deps))
       .rejects.toMatchObject({ reason: 'invalid_pubkey' });
+  });
+});
+
+describe('executeOnramp — caller-binding (FN-034)', () => {
+  it('rejects when caller_pubkey != recipient with caller_mismatch', async () => {
+    const deps = makeDeps();
+    const attacker = 'f'.repeat(64);
+    await expect(
+      executeOnramp(makeRequest({ caller_pubkey: attacker }), deps),
+    ).rejects.toMatchObject({ reason: 'caller_mismatch' });
+  });
+
+  it('rejects without invoking verifyUsdPull / mintOnChain / remitToTreasury', async () => {
+    const deps = makeDeps();
+    const attacker = 'f'.repeat(64);
+    await expect(
+      executeOnramp(makeRequest({ caller_pubkey: attacker }), deps),
+    ).rejects.toBeInstanceOf(OnrampRejected);
+    expect(deps.verifyUsdPull).not.toHaveBeenCalled();
+    expect(deps.mintOnChain).not.toHaveBeenCalled();
+    expect(deps.remitToTreasury).not.toHaveBeenCalled();
+  });
+
+  it('rejects when caller_pubkey is not a valid hex64 with invalid_pubkey', async () => {
+    const deps = makeDeps();
+    await expect(
+      executeOnramp(makeRequest({ caller_pubkey: 'tooshort' }), deps),
+    ).rejects.toMatchObject({ reason: 'invalid_pubkey' });
   });
 });
 

--- a/keeper/bpps/bank/handlers/onramp.ts
+++ b/keeper/bpps/bank/handlers/onramp.ts
@@ -26,6 +26,13 @@ import {
 } from './fee.js';
 
 export interface OnrampRequest {
+  /**
+   * FN-034: authenticated caller pubkey (hex). MUST equal `recipient` —
+   * any mismatch is rejected with `caller_mismatch` before any side-effect
+   * runs. Without this binding, an unauthenticated caller could direct a
+   * mint of eUSD into any subject's TokenAccount.
+   */
+  caller_pubkey: string;
   recipient: string;                     // hex pubkey — receives the eUSD
   recipient_token_account_pda: string;   // hex — TokenAccount PDA
   usd_amount_cents: number;              // amount in USD cents (1000 = $10.00)
@@ -64,7 +71,7 @@ export interface OnrampDeps {
 }
 
 export class OnrampRejected extends Error {
-  constructor(public reason: 'invalid_pubkey' | 'invalid_amount' | 'usd_pull_failed' | 'mint_failed') {
+  constructor(public reason: 'invalid_pubkey' | 'caller_mismatch' | 'invalid_amount' | 'usd_pull_failed' | 'mint_failed') {
     super('onramp rejected: ' + reason);
   }
 }
@@ -78,8 +85,13 @@ function usdCentsToAtomicEusd(cents: number): number {
 }
 
 export async function executeOnramp(req: OnrampRequest, deps: OnrampDeps): Promise<OnrampOutcome> {
+  if (!HEX64.test(req.caller_pubkey)) throw new OnrampRejected('invalid_pubkey');
   if (!HEX64.test(req.recipient)) throw new OnrampRejected('invalid_pubkey');
   if (!HEX64.test(req.recipient_token_account_pda)) throw new OnrampRejected('invalid_pubkey');
+  // FN-034: caller-binding. Reject before any side-effect when the caller
+  // is not the recipient; otherwise an unauth'd caller could direct a
+  // mint into any subject's account.
+  if (req.caller_pubkey !== req.recipient) throw new OnrampRejected('caller_mismatch');
   if (!Number.isInteger(req.usd_amount_cents) || req.usd_amount_cents <= 0) throw new OnrampRejected('invalid_amount');
 
   const eusd_gross = usdCentsToAtomicEusd(req.usd_amount_cents);

--- a/keeper/bpps/bank/handlers/open-savings.test.ts
+++ b/keeper/bpps/bank/handlers/open-savings.test.ts
@@ -21,6 +21,7 @@ const ISSUER = 'c'.repeat(64);
 
 function makeRequest(overrides: Partial<OpenSavingsRequest> = {}): OpenSavingsRequest {
   return {
+    caller_pubkey: SUBJECT, // FN-034: caller MUST equal subject
     subject: SUBJECT,
     linked_checking_account_pda: CHECKING_PDA,
     bank_issuer: ISSUER,
@@ -123,6 +124,34 @@ describe('openSavings — atomicity on failure', () => {
 // Validation errors
 // ---------------------------------------------------------------------------
 
+describe('openSavings — caller-binding (FN-034)', () => {
+  it('rejects when caller_pubkey != subject with caller_mismatch', async () => {
+    const deps = makeDeps();
+    const attacker = 'f'.repeat(64);
+    await expect(
+      openSavings(makeRequest({ caller_pubkey: attacker }), deps),
+    ).rejects.toMatchObject({ reason: 'caller_mismatch' });
+  });
+
+  it('rejects without invoking verifyCheckingCredential / recordSavingsAccount / issueSavingsCredential', async () => {
+    const deps = makeDeps();
+    const attacker = 'f'.repeat(64);
+    await expect(
+      openSavings(makeRequest({ caller_pubkey: attacker }), deps),
+    ).rejects.toBeInstanceOf(OpenSavingsRejected);
+    expect(deps.verifyCheckingCredential).not.toHaveBeenCalled();
+    expect(deps.recordSavingsAccount).not.toHaveBeenCalled();
+    expect(deps.issueSavingsCredential).not.toHaveBeenCalled();
+  });
+
+  it('rejects when caller_pubkey is not a valid hex64 with invalid_pda', async () => {
+    const deps = makeDeps();
+    await expect(
+      openSavings(makeRequest({ caller_pubkey: 'tooshort' }), deps),
+    ).rejects.toMatchObject({ reason: 'invalid_pda' });
+  });
+});
+
 describe('openSavings — invalid_pda', () => {
   it('throws invalid_pda for short subject', async () => {
     const deps = makeDeps();
@@ -203,8 +232,9 @@ describe('openSavings — PDA derivation', () => {
   });
 
   it('produces different PDAs when subject differs', async () => {
-    const result1 = await openSavings(makeRequest({ subject: 'a'.repeat(64) }), makeDeps());
-    const result2 = await openSavings(makeRequest({ subject: '1'.repeat(64) }), makeDeps());
+    // FN-034: caller_pubkey must equal subject, so override both together.
+    const result1 = await openSavings(makeRequest({ caller_pubkey: 'a'.repeat(64), subject: 'a'.repeat(64) }), makeDeps());
+    const result2 = await openSavings(makeRequest({ caller_pubkey: '1'.repeat(64), subject: '1'.repeat(64) }), makeDeps());
     expect(result1.savings_account_pda).not.toBe(result2.savings_account_pda);
   });
 });

--- a/keeper/bpps/bank/handlers/open-savings.ts
+++ b/keeper/bpps/bank/handlers/open-savings.ts
@@ -17,6 +17,13 @@
 import { createHash } from 'node:crypto';
 
 export interface OpenSavingsRequest {
+  /**
+   * FN-034: authenticated caller pubkey (hex). MUST equal `subject` —
+   * any mismatch is rejected with `caller_mismatch` before any side-effect
+   * runs. Without this binding, an unauthenticated caller could mint an
+   * `account.savings.v1` credential to any subject.
+   */
+  caller_pubkey: string;
   /** Subject pubkey (hex) — receives the credential and owns the account. */
   subject: string;
   /** Pubkey of the holder's existing CheckingAccount, required reference. */
@@ -66,16 +73,21 @@ export interface OpenSavingsDeps {
 }
 
 export class OpenSavingsRejected extends Error {
-  constructor(public reason: 'no_checking_credential' | 'invalid_pda' | 'invalid_tier' | 'invalid_apy') {
+  constructor(public reason: 'no_checking_credential' | 'invalid_pda' | 'caller_mismatch' | 'invalid_tier' | 'invalid_apy') {
     super('open-savings rejected: ' + reason);
   }
 }
 
 export async function openSavings(req: OpenSavingsRequest, deps: OpenSavingsDeps): Promise<OpenSavingsResult> {
   // Validate inputs
+  if (!/^[0-9a-fA-F]{64}$/.test(req.caller_pubkey)) throw new OpenSavingsRejected('invalid_pda');
   if (!/^[0-9a-fA-F]{64}$/.test(req.subject)) throw new OpenSavingsRejected('invalid_pda');
   if (!/^[0-9a-fA-F]{64}$/.test(req.linked_checking_account_pda)) throw new OpenSavingsRejected('invalid_pda');
   if (!/^[0-9a-fA-F]{64}$/.test(req.bank_issuer)) throw new OpenSavingsRejected('invalid_pda');
+  // FN-034: caller-binding. Reject before any side-effect when the caller
+  // is not the subject; otherwise an unauth'd caller could mint an
+  // account.savings credential bound to any subject.
+  if (req.caller_pubkey !== req.subject) throw new OpenSavingsRejected('caller_mismatch');
   const tier = req.tier ?? 'standard';
   if (!(['standard', 'premium', 'private'] as const).includes(tier)) throw new OpenSavingsRejected('invalid_tier');
   const apy_bps = req.apy_bps ?? 400;

--- a/keeper/bpps/bank/handlers/wire.test.ts
+++ b/keeper/bpps/bank/handlers/wire.test.ts
@@ -32,6 +32,7 @@ const INTL_RECIPIENT = {
 
 function makeRequest(overrides: Partial<WireRequest> = {}): WireRequest {
   return {
+    caller_pubkey: HOLDER, // FN-034: caller MUST equal holder
     holder: HOLDER,
     checking_account_pda: CHECKING_PDA,
     amount: 10_000_000,  // 10 eUSD
@@ -140,6 +141,38 @@ describe('executeWire — invalid_pubkey', () => {
     const deps = makeDeps();
     await expect(executeWire(makeRequest({ holder: 'bad' }), deps))
       .rejects.toBeInstanceOf(WireRejected);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// FN-034 — caller-binding (SECURITY HIGH)
+// ---------------------------------------------------------------------------
+
+describe('executeWire — caller-binding (FN-034)', () => {
+  it('rejects when caller_pubkey != holder with caller_mismatch', async () => {
+    const deps = makeDeps();
+    const attacker = 'f'.repeat(64);
+    await expect(
+      executeWire(makeRequest({ caller_pubkey: attacker }), deps),
+    ).rejects.toMatchObject({ reason: 'caller_mismatch' });
+  });
+
+  it('rejects without invoking lockEscrow / releaseEscrow / refundEscrow', async () => {
+    const deps = makeDeps();
+    const attacker = 'f'.repeat(64);
+    await expect(
+      executeWire(makeRequest({ caller_pubkey: attacker }), deps),
+    ).rejects.toBeInstanceOf(WireRejected);
+    expect(deps.lockEscrow).not.toHaveBeenCalled();
+    expect(deps.releaseEscrow).not.toHaveBeenCalled();
+    expect(deps.refundEscrow).not.toHaveBeenCalled();
+  });
+
+  it('rejects when caller_pubkey is not a valid hex64 with invalid_pubkey', async () => {
+    const deps = makeDeps();
+    await expect(
+      executeWire(makeRequest({ caller_pubkey: 'tooshort' }), deps),
+    ).rejects.toMatchObject({ reason: 'invalid_pubkey' });
   });
 });
 
@@ -293,8 +326,9 @@ describe('executeWire — wire_id determinism', () => {
   });
 
   it('produces different wire_id when holder differs', async () => {
-    const r1 = await executeWire(makeRequest({ holder: 'a'.repeat(64) }), makeDeps());
-    const r2 = await executeWire(makeRequest({ holder: '1'.repeat(64) }), makeDeps());
+    // FN-034: caller_pubkey must equal holder, so override both together.
+    const r1 = await executeWire(makeRequest({ caller_pubkey: 'a'.repeat(64), holder: 'a'.repeat(64) }), makeDeps());
+    const r2 = await executeWire(makeRequest({ caller_pubkey: '1'.repeat(64), holder: '1'.repeat(64) }), makeDeps());
     expect(r1.wire_id).not.toBe(r2.wire_id);
   });
 });

--- a/keeper/bpps/bank/handlers/wire.ts
+++ b/keeper/bpps/bank/handlers/wire.ts
@@ -14,6 +14,13 @@ import { createHash } from 'node:crypto';
 export type WireKind = 'domestic' | 'international';
 
 export interface WireRequest {
+  /**
+   * FN-034: authenticated caller pubkey (hex). MUST equal `holder` —
+   * any mismatch is rejected with `caller_mismatch` before any side-effect
+   * runs. Without this binding, an unauthenticated caller could move money
+   * for any subject.
+   */
+  caller_pubkey: string;
   /** Holder pubkey (hex). */
   holder: string;
   /** Holder's CheckingAccount PDA (hex). */
@@ -56,7 +63,7 @@ export interface WireDeps {
 }
 
 export class WireRejected extends Error {
-  constructor(public reason: 'invalid_pubkey' | 'invalid_amount' | 'recipient_invalid' | 'lock_failed' | 'release_failed') {
+  constructor(public reason: 'invalid_pubkey' | 'caller_mismatch' | 'invalid_amount' | 'recipient_invalid' | 'lock_failed' | 'release_failed') {
     super('wire rejected: ' + reason);
   }
 }
@@ -65,8 +72,13 @@ const HEX64 = /^[0-9a-fA-F]{64}$/;
 
 export async function executeWire(req: WireRequest, deps: WireDeps): Promise<WireOutcome> {
   // Validation
+  if (!HEX64.test(req.caller_pubkey)) throw new WireRejected('invalid_pubkey');
   if (!HEX64.test(req.holder)) throw new WireRejected('invalid_pubkey');
   if (!HEX64.test(req.checking_account_pda)) throw new WireRejected('invalid_pubkey');
+  // FN-034: caller-binding. Reject before any side-effect when the caller
+  // is not the holder; otherwise an unauth'd caller could move money for
+  // any subject.
+  if (req.caller_pubkey !== req.holder) throw new WireRejected('caller_mismatch');
   if (!Number.isInteger(req.amount) || req.amount <= 0) throw new WireRejected('invalid_amount');
   if (req.kind === 'domestic' && !req.recipient.routing_number) throw new WireRejected('recipient_invalid');
   if (req.kind === 'international' && !req.recipient.swift_bic) throw new WireRejected('recipient_invalid');

--- a/tests/bank/accounts.test.ts
+++ b/tests/bank/accounts.test.ts
@@ -194,6 +194,7 @@ describe("bank account lifecycle (E11)", () => {
 
     const result = await executeWire(
       {
+        caller_pubkey: HOLDER_PUBKEY,
         holder: HOLDER_PUBKEY,
         checking_account_pda: state.checkingPda!,
         amount: Number(WIRE_AMOUNT),
@@ -229,6 +230,7 @@ describe("bank account lifecycle (E11)", () => {
     await expect(
       executeWire(
         {
+          caller_pubkey: HOLDER_PUBKEY,
           holder: HOLDER_PUBKEY,
           checking_account_pda: state.checkingPda!,
           amount: overAmount,
@@ -257,6 +259,7 @@ describe("bank account lifecycle (E11)", () => {
 
     const result = await openSavings(
       {
+        caller_pubkey: HOLDER_PUBKEY,
         subject: HOLDER_PUBKEY,
         linked_checking_account_pda: state.checkingPda!,
         bank_issuer: BANK_ISSUER_PUBKEY,
@@ -283,6 +286,7 @@ describe("bank account lifecycle (E11)", () => {
     await expect(
       openSavings(
         {
+          caller_pubkey: HOLDER_PUBKEY,
           subject: HOLDER_PUBKEY,
           linked_checking_account_pda: state.checkingPda!,
           bank_issuer: BANK_ISSUER_PUBKEY,


### PR DESCRIPTION
## Summary

Security fix (HIGH) for the bank BPP handlers `wire.ts`, `offramp.ts`, `onramp.ts`, `open-savings.ts`. Each handler now requires a `caller_pubkey` on its request and rejects (`caller_mismatch`) before any side-effect when the authenticated caller does not equal the holder/subject/recipient. Without this binding, an unauthenticated caller could move money for, burn eUSD on behalf of, mint eUSD into, or open a savings credential bound to ANY subject.

## Per-handler binding

| Handler        | Required equality                  | New reason         |
| -------------- | ---------------------------------- | ------------------ |
| `executeWire`  | `caller_pubkey === holder`         | `caller_mismatch`  |
| `executeOfframp` | `caller_pubkey === holder`       | `caller_mismatch`  |
| `executeOnramp` | `caller_pubkey === recipient`     | `caller_mismatch`  |
| `openSavings`  | `caller_pubkey === subject`        | `caller_mismatch`  |

The check sits immediately after the existing pubkey validation and before any dep is invoked (lockEscrow / burnOnChain / mintOnChain / verifyCheckingCredential, etc.).

## Tests

12 new caller-binding tests across the 4 handlers (3 per handler) assert:
1. Mismatch rejects with `caller_mismatch`
2. No side-effect deps are invoked on rejection
3. An invalid hex64 `caller_pubkey` is rejected with `invalid_pubkey` (or `invalid_pda` for open-savings, to match its existing reason set)

Existing tests have been threaded with a happy-path `caller_pubkey` so they continue to pass.

## Reviewer notes

- **Spec discrepancy.** The ticket references an existing caller-binding pattern in `issue-card.ts` and `open-checking.ts`. That pattern does not exist on master — those two handlers have the same gap and need a follow-up PR. This PR designs a minimal fresh pattern.
- **Gateway wire-up out of scope.** This PR is the handler-level binding only. Populating `caller_pubkey` from the authenticated BAP identity (Beckn `context.bap_id` or a signed payload) is the gateway's responsibility. The binding is necessary but not sufficient until the gateway is wired; until then, `caller_pubkey` is just user-supplied input. A follow-up gateway PR must enforce that the field comes from authenticated context.

## Test plan

- [x] `bun run typecheck` passes (covers `src/issuers/**/*`)
- [x] `bun run test` passes (1149 tests)
- [x] In-scope handler suites pass: `wire.test.ts`, `offramp.test.ts`, `onramp.test.ts`, `open-savings.test.ts`, `fee.correctness.test.ts`, `tests/bank/accounts.test.ts` (252 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)