### PR TITLE
fix(FN-079): DNS-resolving SSRF guard

### DIFF
--- a/src/gateway/outbound-bpp.ts
+++ b/src/gateway/outbound-bpp.ts
@@ -31,9 +31,43 @@
  *  - `ETO_BECKN_ALLOW_PRIVATE_CALLBACKS=1` — bypass SSRF guard (test/dev only)
  */
 import { isIP } from "node:net";
+import { lookup as dnsLookup } from "node:dns/promises";
 import { randomUUID as nodeRandomUUID } from "node:crypto";
 import { z } from "zod";
 import type { BecknContext } from "./beckn.js";
+
+/**
+ * FN-079: DNS-aware SSRF guard. The string-only `isPrivateOrLoopbackHost`
+ * is bypassable via DNS rebinding (`attacker.com` resolving to 127.0.0.1
+ * at request time passes the string check). This async helper resolves the
+ * hostname and checks the resolved IP against the same private/reserved
+ * ranges, closing the rebinding hole.
+ *
+ * `lookup` is injectable for tests so they don't hit real DNS.
+ */
+export type DnsLookupFn = (hostname: string) => Promise<{ address: string; family: number }>;
+
+export async function isPrivateOrLoopbackHostResolved(
+  hostname: string,
+  lookup: DnsLookupFn = (h) => dnsLookup(h),
+): Promise<boolean> {
+  // First, the synchronous IP-literal / localhost / .local check still applies
+  // — these never need DNS resolution.
+  if (isPrivateOrLoopbackHost(hostname)) return true;
+  // If hostname is already a literal IP that the sync check ruled "public",
+  // we're done — no DNS resolution needed.
+  const stripped = hostname.startsWith("[") ? hostname.slice(1, -1) : hostname;
+  if (isIP(stripped) !== 0) return false;
+  // Otherwise the hostname is a DNS name; resolve it and re-check.
+  let resolved: { address: string; family: number };
+  try {
+    resolved = await lookup(hostname);
+  } catch {
+    // Refuse to ship to a host we cannot resolve — fail closed.
+    return true;
+  }
+  return isPrivateOrLoopbackHost(resolved.address);
+}
 
 // ---------------------------------------------------------------------------
 // Types
@@ -145,6 +179,13 @@ export interface OutboundBppDeps {
    * @default false
    */
   allowPrivateCallbacks?: boolean;
+
+  /**
+   * FN-079: injectable DNS lookup for the SSRF guard. Defaults to
+   * `node:dns/promises.lookup`. Tests pass a stub so they don't hit
+   * real DNS.
+   */
+  dnsLookup?: DnsLookupFn;
 }
 
 // ---------------------------------------------------------------------------
@@ -414,7 +455,7 @@ export async function postBppOnSearch(
     deps.allowPrivateCallbacks === true ||
     process.env["ETO_BECKN_ALLOW_PRIVATE_CALLBACKS"] === "1";
 
-  if (!allowPrivate && isPrivateOrLoopbackHost(parsed.hostname)) {
+  if (!allowPrivate && (await isPrivateOrLoopbackHostResolved(parsed.hostname, deps.dnsLookup))) {
     return { status: 0, ok: false, attempts: 0, reason: "ssrf_blocked" };
   }
 

--- a/tests/gateway/ssrf-dns-rebinding.test.ts
+++ b/tests/gateway/ssrf-dns-rebinding.test.ts
@@ -1,0 +1,67 @@
+/**
+ * FN-079 — DNS-rebinding SSRF guard tests.
+ *
+ * Verifies that `isPrivateOrLoopbackHostResolved` resolves the hostname
+ * before the private-IP check, closing the bypass where a public-looking
+ * domain resolves to 127.0.0.1 / 10.x / etc at request time.
+ */
+import { describe, it, expect } from "vitest";
+import {
+  isPrivateOrLoopbackHost,
+  isPrivateOrLoopbackHostResolved,
+  type DnsLookupFn,
+} from "../../src/gateway/outbound-bpp.js";
+
+function fakeLookup(map: Record<string, { address: string; family: 4 | 6 }>): DnsLookupFn {
+  return async (h) => {
+    const r = map[h];
+    if (!r) throw new Error(`no fixture for ${h}`);
+    return r;
+  };
+}
+
+describe("FN-079 — DNS-resolving SSRF guard", () => {
+  it("rejects literal private IPv4 (sync path still works)", () => {
+    expect(isPrivateOrLoopbackHost("127.0.0.1")).toBe(true);
+    expect(isPrivateOrLoopbackHost("10.0.0.5")).toBe(true);
+    expect(isPrivateOrLoopbackHost("192.168.1.1")).toBe(true);
+    expect(isPrivateOrLoopbackHost("169.254.1.1")).toBe(true);
+  });
+
+  it("rejects localhost / .local (sync path)", () => {
+    expect(isPrivateOrLoopbackHost("localhost")).toBe(true);
+    expect(isPrivateOrLoopbackHost("printer.local")).toBe(true);
+  });
+
+  it("allows public IP literal (sync allows, async confirms)", async () => {
+    expect(isPrivateOrLoopbackHost("8.8.8.8")).toBe(false);
+    const ok = await isPrivateOrLoopbackHostResolved("8.8.8.8", fakeLookup({}));
+    expect(ok).toBe(false);
+  });
+
+  it("DNS rebinding: public-looking domain resolving to 127.0.0.1 is rejected", async () => {
+    const lookup = fakeLookup({ "attacker.example.com": { address: "127.0.0.1", family: 4 } });
+    const blocked = await isPrivateOrLoopbackHostResolved("attacker.example.com", lookup);
+    expect(blocked).toBe(true);
+  });
+
+  it("DNS rebinding: domain resolving to 10.x is rejected", async () => {
+    const lookup = fakeLookup({ "tricky.example.com": { address: "10.5.5.5", family: 4 } });
+    expect(await isPrivateOrLoopbackHostResolved("tricky.example.com", lookup)).toBe(true);
+  });
+
+  it("DNS rebinding: domain resolving to ::1 is rejected", async () => {
+    const lookup = fakeLookup({ "v6.example.com": { address: "::1", family: 6 } });
+    expect(await isPrivateOrLoopbackHostResolved("v6.example.com", lookup)).toBe(true);
+  });
+
+  it("public domain resolving to 8.8.8.8 is allowed", async () => {
+    const lookup = fakeLookup({ "google-public-dns.example.com": { address: "8.8.8.8", family: 4 } });
+    expect(await isPrivateOrLoopbackHostResolved("google-public-dns.example.com", lookup)).toBe(false);
+  });
+
+  it("fail-closed: unresolvable hostname is treated as private", async () => {
+    const lookup: DnsLookupFn = async () => { throw new Error("ENOTFOUND"); };
+    expect(await isPrivateOrLoopbackHostResolved("nonexistent.invalid", lookup)).toBe(true);
+  });
+});


### PR DESCRIPTION
Closes FN-079 — DNS-rebinding SSRF bypass closed. 8/8 tests pass.