### PR TITLE
feat(FN-089): validate sendTransaction and ethSendRawTransaction return values as real signatures

### DIFF
--- a/src/read/rpc-client.ts
+++ b/src/read/rpc-client.ts
@@ -22,12 +22,25 @@ interface JsonRpcResponse<T> {
  * a smell — they indicate the node is running a non-SVM mock — so they
  * are rejected. This closes the JSON.stringify-of-an-error-object
  * masking case identified by FN-097.
+ *
+ * FN-089: also applied to `sendTransaction` and `ethSendRawTransaction`
+ * results so misbehaving devnet nodes can't propagate a garbage string
+ * into `pollConfirmation` and produce a spurious timeout.
  */
 const BASE58_RE = /^[1-9A-HJ-NP-Za-km-z]{43,88}$/;
+/** EVM tx hash: 0x followed by exactly 64 hex chars (32 bytes). */
+const HEX_SIG_RE = /^0x[0-9a-fA-F]{64}$/;
+
 function isValidSignature(s: string): boolean {
   if (typeof s !== "string") return false;
   if (s.length === 0) return false;
   return BASE58_RE.test(s);
+}
+
+/** FN-089: validate an EVM tx hash returned by eth_sendRawTransaction. */
+function isValidEvmTxHash(s: string): boolean {
+  if (typeof s !== "string") return false;
+  return HEX_SIG_RE.test(s);
 }
 
 export class EtoRpcClient {
@@ -99,8 +112,17 @@ export class EtoRpcClient {
     return this.call<any>("getAccountInfo", [pubkey]);
   }
 
-  sendTransaction(serializedTx: string): Promise<string> {
-    return this.call<string>("sendTransaction", [serializedTx]);
+  async sendTransaction(serializedTx: string): Promise<string> {
+    const sig = await this.call<string>("sendTransaction", [serializedTx]);
+    // FN-089: validate the returned value is a real base58 signature so that
+    // a misbehaving devnet node can't inject a garbage string into
+    // pollConfirmation and produce a spurious "not found" / timeout.
+    if (!isValidSignature(sig)) {
+      throw new Error(
+        `sendTransaction returned non-signature response (got ${typeof sig}: ${JSON.stringify(sig).slice(0, 200)})`,
+      );
+    }
+    return sig;
   }
 
   getTransactionCount(): Promise<number> {
@@ -208,8 +230,16 @@ export class EtoRpcClient {
     return this.call<string>("eth_estimateGas", [tx]);
   }
 
-  ethSendRawTransaction(signedTx: string): Promise<string> {
-    return this.call<string>("eth_sendRawTransaction", [signedTx]);
+  async ethSendRawTransaction(signedTx: string): Promise<string> {
+    const hash = await this.call<string>("eth_sendRawTransaction", [signedTx]);
+    // FN-089: validate the returned value is a real EVM tx hash (0x + 64 hex
+    // chars) so a misbehaving node can't propagate a garbage string into callers.
+    if (!isValidEvmTxHash(hash)) {
+      throw new Error(
+        `eth_sendRawTransaction returned non-hash response (got ${typeof hash}: ${JSON.stringify(hash).slice(0, 200)})`,
+      );
+    }
+    return hash;
   }
 
   ethGetTransactionReceipt(hash: string): Promise<any> {

--- a/tests/unit/rpc-client-send-tx.test.ts
+++ b/tests/unit/rpc-client-send-tx.test.ts
@@ -1,0 +1,140 @@
+/**
+ * Unit tests for `EtoRpcClient.sendTransaction()` and
+ * `EtoRpcClient.ethSendRawTransaction()` response validation (FN-089).
+ *
+ * Mirrors the FN-197/198 faucet validation pattern: a misbehaving devnet node
+ * returning a non-signature string must be caught here, before the value
+ * propagates into `submitter.pollConfirmation` and surfaces as a spurious
+ * "not found" / timeout.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../../src/config.js", () => ({
+  config: {
+    etoRpcUrl: "http://stub",
+    tx: {
+      blockhashRefreshMs: 20_000,
+      blockhashValidityMs: 60_000,
+      defaultTimeoutMs: 30_000,
+      maxRetries: 3,
+      confirmationPollMs: 1,
+      maxPollErrors: 3,
+    },
+    logLevel: "error",
+  },
+}));
+
+vi.mock("../../src/utils/logger.js", () => ({
+  log: () => {},
+}));
+
+import { EtoRpcClient } from "../../src/read/rpc-client.js";
+
+function stubFetch(jsonBody: unknown, ok = true): void {
+  const fakeResponse = {
+    ok,
+    status: ok ? 200 : 500,
+    statusText: ok ? "OK" : "Internal Server Error",
+    json: async () => jsonBody,
+  } as unknown as Response;
+  vi.stubGlobal("fetch", vi.fn(async () => fakeResponse));
+}
+
+/** Valid 88-char base58 signature (Solana mainnet length). */
+const REAL_SIG_88 = "5J7s" + "k".repeat(84); // 88 chars, all base58 alphabet
+
+/** Valid EVM tx hash: 0x + 64 hex chars. */
+const REAL_EVM_HASH = "0x" + "a".repeat(64);
+
+describe("EtoRpcClient.sendTransaction — FN-089 signature validation", () => {
+  let client: EtoRpcClient;
+
+  beforeEach(() => {
+    client = new EtoRpcClient("http://stub");
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it("resolves to a valid base58 signature when the node returns one", async () => {
+    stubFetch({ jsonrpc: "2.0", id: 1, result: REAL_SIG_88 });
+    await expect(client.sendTransaction("encoded-tx")).resolves.toBe(REAL_SIG_88);
+  });
+
+  it("rejects when the node returns a short non-signature string", async () => {
+    stubFetch({ jsonrpc: "2.0", id: 1, result: "not-a-real-sig" });
+    await expect(client.sendTransaction("encoded-tx")).rejects.toThrow(
+      /sendTransaction returned non-signature/,
+    );
+  });
+
+  it("rejects when the node returns an error-shaped object (FN-097 masking case)", async () => {
+    stubFetch({ jsonrpc: "2.0", id: 1, result: { code: -32600, message: "rate limit" } });
+    await expect(client.sendTransaction("encoded-tx")).rejects.toThrow(
+      /sendTransaction returned non-signature/,
+    );
+  });
+
+  it("rejects when the node returns a hex string (non-SVM mock smell)", async () => {
+    stubFetch({ jsonrpc: "2.0", id: 1, result: "0".repeat(64) });
+    await expect(client.sendTransaction("encoded-tx")).rejects.toThrow(
+      /sendTransaction returned non-signature/,
+    );
+  });
+
+  it("propagates the call()-level guard when result is undefined", async () => {
+    stubFetch({ jsonrpc: "2.0", id: 1 });
+    await expect(client.sendTransaction("encoded-tx")).rejects.toThrow(
+      /has neither result nor error field/,
+    );
+  });
+});
+
+describe("EtoRpcClient.ethSendRawTransaction — FN-089 hash validation", () => {
+  let client: EtoRpcClient;
+
+  beforeEach(() => {
+    client = new EtoRpcClient("http://stub");
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it("resolves to a valid 0x+64hex hash when the node returns one", async () => {
+    stubFetch({ jsonrpc: "2.0", id: 1, result: REAL_EVM_HASH });
+    await expect(client.ethSendRawTransaction("0xsignedtx")).resolves.toBe(REAL_EVM_HASH);
+  });
+
+  it("rejects when the node returns a bare hex string without 0x prefix", async () => {
+    stubFetch({ jsonrpc: "2.0", id: 1, result: "a".repeat(64) });
+    await expect(client.ethSendRawTransaction("0xsignedtx")).rejects.toThrow(
+      /eth_sendRawTransaction returned non-hash/,
+    );
+  });
+
+  it("rejects when the node returns a truncated hash", async () => {
+    stubFetch({ jsonrpc: "2.0", id: 1, result: "0x" + "a".repeat(32) });
+    await expect(client.ethSendRawTransaction("0xsignedtx")).rejects.toThrow(
+      /eth_sendRawTransaction returned non-hash/,
+    );
+  });
+
+  it("rejects an error-shaped object (masking case)", async () => {
+    stubFetch({ jsonrpc: "2.0", id: 1, result: { error: "nonce too low" } });
+    await expect(client.ethSendRawTransaction("0xsignedtx")).rejects.toThrow(
+      /eth_sendRawTransaction returned non-hash/,
+    );
+  });
+
+  it("propagates the call()-level guard when result is undefined", async () => {
+    stubFetch({ jsonrpc: "2.0", id: 1 });
+    await expect(client.ethSendRawTransaction("0xsignedtx")).rejects.toThrow(
+      /has neither result nor error field/,
+    );
+  });
+});


### PR DESCRIPTION
## Summary

- Applies `isValidSignature` (BASE58_RE) to `sendTransaction` results, mirroring the FN-197/198 faucet validation pattern
- Adds `isValidEvmTxHash` (HEX_SIG_RE: `0x` + 64 hex chars) applied to `ethSendRawTransaction` results
- A misbehaving devnet node returning a non-signature string is now caught at the RPC boundary, preventing it from propagating into `pollConfirmation` as a spurious timeout

## Test plan

- [ ] `tests/unit/rpc-client-send-tx.test.ts` (10 new tests) covers: valid base58 sig, valid EVM hash, error-shaped objects, too-short strings, hex-without-prefix, missing result field
- [ ] Existing `tests/unit/rpc-client-faucet.test.ts` still passes unchanged
- [ ] Full test suite passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)