### PR TITLE
feat(FN-075): plumb verified BAP callerPubkey from gateway to BPP handlers

### DIFF
--- a/src/gateway/inbound-bap.test.ts
+++ b/src/gateway/inbound-bap.test.ts
@@ -365,3 +365,113 @@ describe("validateBecknEnvelope + freshness (four defect cases)", () => {
     }
   });
 });
+
+// ---------- FN-075: Caller pubkey plumbing on /search and /select ----------
+
+describe('FN-075: verifyBapSignature — callerPubkey plumbing on /search', () => {
+  const SIGNER_PUBKEY = 'b'.repeat(64); // canonical lowercase hex
+
+  function buildBapServer(deps: InboundBapDeps) {
+    return new Promise<{ server: http.Server; url: string }>((resolve) => {
+      const app = express();
+      app.use(express.json());
+      mountInboundBap(app, deps);
+      const s = app.listen(0, '127.0.0.1', () => {
+        const addr = s.address() as { port: number };
+        resolve({ server: s, url: `http://127.0.0.1:${addr.port}` });
+      });
+    });
+  }
+
+  it('happy path: valid signature → callerPubkey in on-chain args, submitOnChain called', async () => {
+    const submitMock = vi.fn().mockResolvedValue({ tx_signature: 'aaaa'.repeat(16) });
+    const { server, url } = await buildBapServer({
+      submitOnChain: submitMock,
+      verifyBapSignature: () => SIGNER_PUBKEY,
+    });
+
+    const res = await fetch(`${url}/search`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(validSearchBody),
+    });
+
+    expect(res.status).toBe(202);
+    expect(submitMock).toHaveBeenCalledOnce();
+    const [, args] = submitMock.mock.calls[0] as [string, Record<string, unknown>];
+    expect(args.caller_pubkey).toBe(SIGNER_PUBKEY);
+
+    await new Promise<void>((r, j) => server.close((e) => (e ? j(e) : r())));
+  });
+
+  it('bad signature → 401, submitOnChain NOT called', async () => {
+    const submitMock = vi.fn().mockResolvedValue({ tx_signature: 'aaaa'.repeat(16) });
+    const { server, url } = await buildBapServer({
+      submitOnChain: submitMock,
+      verifyBapSignature: () => null,
+    });
+
+    const res = await fetch(`${url}/search`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(validSearchBody),
+    });
+
+    expect(res.status).toBe(401);
+    const json = await res.json() as Record<string, unknown>;
+    expect(json.error).toBe('invalid_signature');
+    expect(submitMock).not.toHaveBeenCalled();
+
+    await new Promise<void>((r, j) => server.close((e) => (e ? j(e) : r())));
+  });
+
+  it('body bap_id differs from signer: callerPubkey reflects signer, body bap_id unchanged', async () => {
+    const submitMock = vi.fn().mockResolvedValue({ tx_signature: 'aaaa'.repeat(16) });
+    const { server, url } = await buildBapServer({
+      submitOnChain: submitMock,
+      verifyBapSignature: () => SIGNER_PUBKEY,
+    });
+
+    const bodyWithDifferentBapId = {
+      ...validSearchBody,
+      context: { ...validSearchBody.context, bap_id: 'other-bap.example.com' },
+    };
+    const res = await fetch(`${url}/search`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(bodyWithDifferentBapId),
+    });
+
+    expect(res.status).toBe(202);
+    expect(submitMock).toHaveBeenCalledOnce();
+    const [, args] = submitMock.mock.calls[0] as [string, Record<string, unknown>];
+    // callerPubkey is the signer — not the body bap_id
+    expect(args.caller_pubkey).toBe(SIGNER_PUBKEY);
+    // body bap_id is passed through unchanged (handler enforces equality)
+    expect(args.bap_id).toBe('other-bap.example.com');
+
+    await new Promise<void>((r, j) => server.close((e) => (e ? j(e) : r())));
+  });
+
+  it('dev-bypass (no verifyBapSignature): caller_pubkey absent, no pubkey forged', async () => {
+    const submitMock = vi.fn().mockResolvedValue({ tx_signature: 'aaaa'.repeat(16) });
+    const { server, url } = await buildBapServer({
+      submitOnChain: submitMock,
+      // verifyBapSignature intentionally absent
+    });
+
+    const res = await fetch(`${url}/search`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(validSearchBody),
+    });
+
+    expect(res.status).toBe(202);
+    expect(submitMock).toHaveBeenCalledOnce();
+    const [, args] = submitMock.mock.calls[0] as [string, Record<string, unknown>];
+    // Must NOT have a forged pubkey — undefined means no verification ran
+    expect(args.caller_pubkey).toBeUndefined();
+
+    await new Promise<void>((r, j) => server.close((e) => (e ? j(e) : r())));
+  });
+});

--- a/src/gateway/inbound-bap.ts
+++ b/src/gateway/inbound-bap.ts
@@ -23,6 +23,23 @@
  *
  * The existing `beckn_validation_failed` path (Ajv errors) is unchanged; the
  * NACK shape is used only for the four envelope codes above.
+ *
+ * ## Caller pubkey plumbing (FN-075)
+ *
+ * `callerPubkey` is the verified BAP signing key extracted by the
+ * deps-injected `verifyBapSignature` function and threaded into on-chain
+ * args so downstream bank BPP handlers can enforce caller-message-authorship.
+ *
+ * Canonical encoding: lowercase hex (matches `assertCallerEquals` in
+ * `keeper/bpps/bank/auth.ts`).
+ *
+ * Dev-bypass (fail-closed): when no `verifyBapSignature` is injected,
+ * `callerPubkey` is omitted from on-chain args. Handlers calling
+ * `assertCallerEquals(undefined, …)` reject with `unauthorized_caller`.
+ * The gateway MUST NOT forge a `callerPubkey` in any code path.
+ *
+ * When `verifyBapSignature` is present and returns `null`, the request is
+ * rejected with HTTP 401 before schema validation and on-chain submission.
  */
 
 import { createHash } from "crypto";
@@ -248,6 +265,23 @@ export interface InboundBapDeps {
   chainClient?: import("./chain-client.js").ChainClient;
   /** Resolve catalog responses for a SearchIntent. STUBBED today. */
   pollCatalogResponses?: (intent_hash: string, max: number) => Promise<unknown[]>;
+
+  // ---- FN-075: Caller pubkey plumbing ----
+
+  /**
+   * Extract the verified BAP signing pubkey from the inbound HTTP request.
+   *
+   * Implementations SHOULD inspect the `Authorization: Signature …` header,
+   * verify the Beckn Ed25519 signature, and return the signer's lowercase hex
+   * pubkey on success, or `null` when verification fails.
+   *
+   * When absent (default), `callerPubkey` is omitted from on-chain args —
+   * the gateway does NOT forge a pubkey (fail-closed).
+   *
+   * When present and returns `null`, the request is rejected with HTTP 401
+   * before schema validation or on-chain submission.
+   */
+  verifyBapSignature?: (req: Request) => string | null;
 }
 
 export function mountInboundBap(app: Express, deps: InboundBapDeps): void {
@@ -266,6 +300,18 @@ export function mountInboundBap(app: Express, deps: InboundBapDeps): void {
   deps = { ...deps, submitOnChain: resolvedSubmit };
 
   app.post("/search", async (req: Request, res: Response) => {
+    // FN-075: extract caller pubkey before any validation or submission.
+    // Bad signature → 401, no handler invocation.
+    let callerPubkey: string | undefined;
+    if (deps.verifyBapSignature !== undefined) {
+      const verified = deps.verifyBapSignature(req);
+      if (verified === null) {
+        res.status(401).json({ error: "invalid_signature", details: "BAP signature verification failed" });
+        return;
+      }
+      callerPubkey = verified.toLowerCase();
+    }
+
     const now = Date.now();
     const envResult = validateBecknEnvelope((req.body as Record<string, unknown> | undefined)?.context, now);
     if (!envResult.ok) {
@@ -286,7 +332,7 @@ export function mountInboundBap(app: Express, deps: InboundBapDeps): void {
       return;
     }
     try {
-      const onchain_args = becknSearchToOnChainArgs(req.body);
+      const onchain_args = becknSearchToOnChainArgs(req.body, callerPubkey);
       const { tx_signature } = await deps.submitOnChain("search", onchain_args);
       // ACK is async per Beckn spec — return 202 with the in-flight transaction id
       res.status(202).json({
@@ -300,6 +346,18 @@ export function mountInboundBap(app: Express, deps: InboundBapDeps): void {
   });
 
   app.post("/select", async (req: Request, res: Response) => {
+    // FN-075: extract caller pubkey before any validation or submission.
+    // Bad signature → 401, no handler invocation.
+    let callerPubkey: string | undefined;
+    if (deps.verifyBapSignature !== undefined) {
+      const verified = deps.verifyBapSignature(req);
+      if (verified === null) {
+        res.status(401).json({ error: "invalid_signature", details: "BAP signature verification failed" });
+        return;
+      }
+      callerPubkey = verified.toLowerCase();
+    }
+
     const now = Date.now();
     const envResult = validateBecknEnvelope((req.body as Record<string, unknown> | undefined)?.context, now);
     if (!envResult.ok) {
@@ -317,7 +375,7 @@ export function mountInboundBap(app: Express, deps: InboundBapDeps): void {
       return;
     }
     try {
-      const onchain_args = becknSelectToOnChainArgs(req.body);
+      const onchain_args = becknSelectToOnChainArgs(req.body, callerPubkey);
       const { tx_signature } = await deps.submitOnChain("select", onchain_args);
       res.status(202).json({
         message: { ack: { status: "ACK" } },
@@ -330,8 +388,14 @@ export function mountInboundBap(app: Express, deps: InboundBapDeps): void {
   });
 }
 
-/** Translate Beckn /search payload → on-chain Search instruction args. */
-export function becknSearchToOnChainArgs(body: unknown): Record<string, unknown> {
+/**
+ * Translate Beckn /search payload → on-chain Search instruction args.
+ *
+ * `callerPubkey` (FN-075) is the verified BAP signing key extracted by the
+ * gateway; it is threaded into the on-chain args so the program can bind
+ * the search intent to the verified caller.
+ */
+export function becknSearchToOnChainArgs(body: unknown, callerPubkey?: string): Record<string, unknown> {
   // The on-chain `BecknProgram::Search` (FN-050) takes:
   //   { network_id, bap_id, intent_hash, tag_filter, max_responses, deadline_slot }
   // We derive intent_hash = sha256(canonical_json(message.intent)), use the
@@ -349,10 +413,12 @@ export function becknSearchToOnChainArgs(body: unknown): Record<string, unknown>
     tag_filter: extractTags(intent),
     max_responses: typeof intent.max_responses === "number" ? intent.max_responses : 10,
     deadline_slot: typeof ctx.ttl_slot === "number" ? ctx.ttl_slot : 0,
+    // FN-075: verified BAP signing key — undefined when no verifier injected
+    caller_pubkey: callerPubkey,
   };
 }
 
-export function becknSelectToOnChainArgs(body: unknown): Record<string, unknown> {
+export function becknSelectToOnChainArgs(body: unknown, callerPubkey?: string): Record<string, unknown> {
   const b = body as Record<string, unknown>;
   const ctx = (b.context ?? {}) as Record<string, unknown>;
   const msg = (b.message ?? {}) as Record<string, unknown>;
@@ -363,6 +429,8 @@ export function becknSelectToOnChainArgs(body: unknown): Record<string, unknown>
     // bridge's responsibility to map provider.id → CatalogResponse PDA
     catalog_response_pda: provider.id,
     network: deriveNetworkId(typeof ctx.domain === "string" ? ctx.domain : undefined),
+    // FN-075: verified BAP signing key — undefined when no verifier injected
+    caller_pubkey: callerPubkey,
   };
 }
 

--- a/src/gateway/inbound-bpp.test.ts
+++ b/src/gateway/inbound-bpp.test.ts
@@ -12,6 +12,12 @@
  *  - unknown bpp_id rejected with 403 when expectedBpps is set
  *  - duplicate transaction_id rejected with 409 (replay dedup, always on)
  *  - missing Authorization header rejected with 401 when requireSignature=true
+ *
+ * FN-075: Caller pubkey plumbing
+ *  - happy path: valid signature → callerPubkey present in on-chain args
+ *  - bad signature → 401, submitOnChain NOT called
+ *  - body fields differ from signer: callerPubkey reflects signer, body unchanged
+ *  - dev-bypass (no verifyBapSignature): callerPubkey absent, no pubkey forged
  */
 
 import { randomUUID } from 'node:crypto';
@@ -408,5 +414,118 @@ describe('FN-036: Signature gate (requireSignature)', () => {
     expect(res.status).toBe(200);
     const json = await res.json() as any;
     expect(json.message.ack.status).toBe('ACK');
+  });
+});
+
+// ---------- FN-075: Caller pubkey plumbing ----------
+
+describe('FN-075: verifyBapSignature — callerPubkey plumbing on /on_confirm', () => {
+  const SIGNER_PUBKEY = 'a'.repeat(64); // canonical lowercase hex
+
+  function buildServer(deps: Partial<InboundBppDeps>) {
+    const app = express();
+    app.use(express.json());
+    mountOnConfirmCallback(app, makeDeps(deps));
+    return new Promise<{ server: Server; url: string }>((resolve) => {
+      const s = app.listen(0, '127.0.0.1', () => {
+        const addr = s.address() as AddressInfo;
+        resolve({ server: s, url: `http://127.0.0.1:${addr.port}` });
+      });
+    });
+  }
+
+  it('happy path: valid signature → callerPubkey in on-chain args, submitOnChain called', async () => {
+    const submitMock = vi.fn(async () => ({ tx_signature: 'stub_sig' }));
+    const { server, url } = await buildServer({
+      verifyBapSignature: () => SIGNER_PUBKEY,
+      submitOnChain: submitMock,
+    });
+
+    const body = buildOnConfirmBody('COMPLETED');
+    const res = await fetch(`${url}/on_confirm`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'Authorization': `Signature keyId="${SIGNER_PUBKEY}",signature="valid"`,
+      },
+      body: JSON.stringify(body),
+    });
+
+    expect(res.status).toBe(200);
+    expect(submitMock).toHaveBeenCalledOnce();
+    const [, args] = submitMock.mock.calls[0] as [string, any];
+    expect(args.caller_pubkey).toBe(SIGNER_PUBKEY);
+
+    await new Promise<void>((r, j) => server.close((e) => (e ? j(e) : r())));
+  });
+
+  it('bad signature → 401, submitOnChain NOT called', async () => {
+    const submitMock = vi.fn(async () => ({ tx_signature: 'stub_sig' }));
+    const { server, url } = await buildServer({
+      verifyBapSignature: () => null, // verification always fails
+      submitOnChain: submitMock,
+    });
+
+    const body = buildOnConfirmBody('COMPLETED');
+    const res = await fetch(`${url}/on_confirm`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+    });
+
+    expect(res.status).toBe(401);
+    const json = await res.json() as any;
+    expect(json.error).toBe('invalid_signature');
+    expect(submitMock).not.toHaveBeenCalled();
+
+    await new Promise<void>((r, j) => server.close((e) => (e ? j(e) : r())));
+  });
+
+  it('body bap_id differs from signer: callerPubkey reflects signer, body unchanged', async () => {
+    const submitMock = vi.fn(async () => ({ tx_signature: 'stub_sig' }));
+    const { server, url } = await buildServer({
+      verifyBapSignature: () => SIGNER_PUBKEY,
+      submitOnChain: submitMock,
+    });
+
+    const body = buildOnConfirmBody('COMPLETED', {}, { bap_id: 'different-bap.example.com' });
+    const res = await fetch(`${url}/on_confirm`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+    });
+
+    expect(res.status).toBe(200);
+    expect(submitMock).toHaveBeenCalledOnce();
+    const [, args] = submitMock.mock.calls[0] as [string, any];
+    // callerPubkey is the signer — not the body bap_id
+    expect(args.caller_pubkey).toBe(SIGNER_PUBKEY);
+    // bap_id from body is passed through unchanged (handler enforces equality)
+    expect(args.bap_id).toBe('different-bap.example.com');
+
+    await new Promise<void>((r, j) => server.close((e) => (e ? j(e) : r())));
+  });
+
+  it('dev-bypass (no verifyBapSignature): caller_pubkey absent, no pubkey forged', async () => {
+    const submitMock = vi.fn(async () => ({ tx_signature: 'stub_sig' }));
+    const { server, url } = await buildServer({
+      // verifyBapSignature intentionally absent — simulates dev/no-sig mode
+      submitOnChain: submitMock,
+    });
+
+    const body = buildOnConfirmBody('COMPLETED');
+    const res = await fetch(`${url}/on_confirm`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+    });
+
+    expect(res.status).toBe(200);
+    expect(submitMock).toHaveBeenCalledOnce();
+    const [, args] = submitMock.mock.calls[0] as [string, any];
+    // Must NOT have a forged pubkey — undefined means no verification ran
+    expect(args.caller_pubkey).toBeUndefined();
+
+    await new Promise<void>((r, j) => server.close((e) => (e ? j(e) : r())));
   });
 });

--- a/src/gateway/inbound-bpp.ts
+++ b/src/gateway/inbound-bpp.ts
@@ -24,6 +24,27 @@
  *      requests that lack an `Authorization` header with HTTP 401.
  *      Full Beckn Ed25519 signature verification is deferred; this is a
  *      presence-only guard that prevents entirely unsigned inbound traffic.
+ *
+ * ## Caller pubkey plumbing (FN-075)
+ *
+ * `callerPubkey` is the verified BAP signing key surfaced to downstream bank
+ * BPP handlers as `AuthenticatedRequest<T>.callerPubkey`. It is produced
+ * exclusively by the deps-injected `verifyBapSignature` function, which
+ * inspects the inbound HTTP request (e.g. the Beckn `Authorization: Signature`
+ * header) and returns the signer's lowercase hex pubkey, or `null` on failure.
+ *
+ * Canonical encoding: lowercase hex (matches `assertCallerEquals` in
+ * `keeper/bpps/bank/auth.ts`).
+ *
+ * Dev-bypass (fail-closed): when no `verifyBapSignature` is injected,
+ * `callerPubkey` is `undefined`. Handlers that call
+ * `assertCallerEquals(undefined, …)` reject with `unauthorized_caller`.
+ * The gateway MUST NOT forge a `callerPubkey` in any code path.
+ *
+ * Contract for BPP handler authors: `callerPubkey` passed in the task outcome
+ * args is the ONLY trusted principal. Body-supplied pubkeys (`subject`,
+ * `holder`, `funder`) are untrusted until the handler asserts equality with
+ * `callerPubkey` via `assertCallerEquals`.
  */
 
 import { createHash } from 'node:crypto';
@@ -80,6 +101,23 @@ export interface InboundBppDeps {
    * Defaults to false. Full Beckn Ed25519 verification is deferred (stub-level).
    */
   requireSignature?: boolean;
+
+  // ---- FN-075: Caller pubkey plumbing ----
+
+  /**
+   * Extract the verified BAP signing pubkey from the inbound HTTP request.
+   *
+   * Implementations SHOULD inspect the `Authorization: Signature …` header,
+   * verify the Beckn Ed25519 signature, and return the signer's lowercase hex
+   * pubkey on success, or `null` when verification fails.
+   *
+   * When absent (default), `callerPubkey` is `undefined` — the gateway does
+   * NOT forge a pubkey. Handlers will reject with `unauthorized_caller`.
+   *
+   * When present and returns `null`, the request is rejected with HTTP 401
+   * before any handler is invoked.
+   */
+  verifyBapSignature?: (req: Request) => string | null;
 }
 
 /** Handle an outbound /confirm produced by an on-chain Confirm AgentTrigger. */
@@ -129,18 +167,32 @@ export function mountOnConfirmCallback(app: Express, deps: InboundBppDeps): void
       return res.status(400).json({ error: 'beckn_validation_failed', details: (v as { ok: false; errors: unknown }).errors });
     }
 
-    // 2. FN-036: Signature presence gate (optional, off by default)
+    // 2. FN-075: Extract verified caller pubkey (before FN-036 guards so a
+    //    bad signature short-circuits before any allowlist / dedup logic runs).
+    //    When verifyBapSignature is present and returns null → 401, no dispatch.
+    //    When verifyBapSignature is absent → callerPubkey remains undefined
+    //    (fail-closed: handlers will reject via assertCallerEquals).
+    let callerPubkey: string | undefined;
+    if (deps.verifyBapSignature !== undefined) {
+      const verified = deps.verifyBapSignature(req);
+      if (verified === null) {
+        return res.status(401).json({ error: 'invalid_signature', details: 'BAP signature verification failed' });
+      }
+      callerPubkey = verified.toLowerCase();
+    }
+
+    // 3. FN-036: Signature presence gate (optional, off by default)
     if (deps.requireSignature && !req.headers['authorization']) {
       return res.status(401).json({ error: 'missing_signature', details: 'Authorization header required' });
     }
 
-    // 3. FN-036: BPP allowlist check (optional, off by default)
+    // 4. FN-036: BPP allowlist check (optional, off by default)
     const bppId: string | undefined = req.body.context?.bpp_id;
     if (deps.expectedBpps && (!bppId || !deps.expectedBpps.has(bppId))) {
       return res.status(403).json({ error: 'unknown_bpp', details: `bpp_id not in allowlist: ${bppId ?? '(missing)'}` });
     }
 
-    // 4. FN-036: Replay dedup (always on — commit before submit to prevent double-trigger)
+    // 5. FN-036: Replay dedup (always on — commit before submit to prevent double-trigger)
     const txnId: string | undefined = req.body.context?.transaction_id;
     if (txnId) {
       if (seenTransactions.has(txnId)) {
@@ -152,7 +204,7 @@ export function mountOnConfirmCallback(app: Express, deps: InboundBppDeps): void
     try {
       const order = req.body.message?.order;
       const success = order?.state === 'COMPLETED' || order?.state === 'FULFILLED';
-      const args = becknOnConfirmToTaskOutcome(req.body);
+      const args = becknOnConfirmToTaskOutcome(req.body, callerPubkey);
       const { tx_signature } = await resolvedSubmit(success ? 'CompleteTask' : 'FailTask', args);
       res.status(200).json({ message: { ack: { status: 'ACK' } }, tx_signature });
     } catch (err) {
@@ -161,7 +213,7 @@ export function mountOnConfirmCallback(app: Express, deps: InboundBppDeps): void
   });
 }
 
-function becknOnConfirmToTaskOutcome(body: any) {
+function becknOnConfirmToTaskOutcome(body: any, callerPubkey?: string) {
   const order = body.message?.order ?? {};
   const fulfillment_uri = order?.fulfillment?.tracking?.url
     ?? order?.fulfillment?.artifacts?.[0]?.url
@@ -173,6 +225,8 @@ function becknOnConfirmToTaskOutcome(body: any) {
     fulfillment_uri,
     state: order.state ?? 'UNKNOWN',
     received_at_iso: new Date().toISOString(),
+    // FN-075: verified BAP signing key — undefined when no verifier injected
+    caller_pubkey: callerPubkey,
   };
 }
 


### PR DESCRIPTION
## Summary

- Add `verifyBapSignature?: (req: Request) => string | null` to `InboundBapDeps` and `InboundBppDeps` — a deps-injected seam for Beckn Ed25519 signature verification
- Extract verified signer's lowercase hex pubkey and thread it as `caller_pubkey` into on-chain args on `/search`, `/select`, and `/on_confirm` routes
- Bad signature → HTTP 401 before any handler dispatch or schema validation; dev-bypass is fail-closed (absent verifier leaves `caller_pubkey` undefined so `assertCallerEquals(undefined, …)` rejects with `unauthorized_caller`)
- Document the contract at the top of both gateway modules and in `InboundBppDeps` JSDoc for bank/keeper handler authors

## Test plan

- [x] `src/gateway/inbound-bpp.test.ts` — 4 new FN-075 tests: happy path (`caller_pubkey` in args matches signer), bad sig → 401 + `submitOnChain` not called, body `bap_id` differs from signer (body unchanged, `caller_pubkey` reflects signer), dev-bypass (no verifier, `caller_pubkey` absent)
- [x] `src/gateway/inbound-bap.test.ts` — same 4 scenarios for `/search`
- [x] All 1301 existing tests pass (`bun run test`)
- [x] Typecheck clean (`bun run typecheck`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)