### PR TITLE
feat(FN-090): thread commitment param through sendTransaction and getTransaction

### DIFF
--- a/src/read/rpc-client.ts
+++ b/src/read/rpc-client.ts
@@ -99,8 +99,16 @@ export class EtoRpcClient {
     return this.call<any>("getAccountInfo", [pubkey]);
   }
 
-  sendTransaction(serializedTx: string): Promise<string> {
-    return this.call<string>("sendTransaction", [serializedTx]);
+  sendTransaction(
+    serializedTx: string,
+    config?: { commitment?: "submitted" | "confirmed" | "finalized" },
+  ): Promise<string> {
+    // FN-090: forward commitment per Solana JSON-RPC spec so the node
+    // uses the caller's desired commitment level rather than defaulting
+    // to "confirmed". Without this, a tx visible only at "finalized"
+    // would never be found by the polling loop (Issue #13, root-cause #4).
+    const params: any[] = config ? [serializedTx, config] : [serializedTx];
+    return this.call<string>("sendTransaction", params);
   }
 
   getTransactionCount(): Promise<number> {
@@ -126,8 +134,16 @@ export class EtoRpcClient {
     return candidate;
   }
 
-  getTransaction(signature: string): Promise<any> {
-    return this.call<any>("getTransaction", [signature]);
+  getTransaction(
+    signature: string,
+    config?: { commitment?: "submitted" | "confirmed" | "finalized" },
+  ): Promise<any> {
+    // FN-090: forward commitment so the node returns the tx at the
+    // requested commitment level. Without this, a finalized tx that
+    // hasn't been indexed at the default level causes the poll loop to
+    // time out as "not found" even though the tx is on-chain.
+    const params: any[] = config ? [signature, config] : [signature];
+    return this.call<any>("getTransaction", params);
   }
 
   getBlock(height: number): Promise<any> {

--- a/src/write/submitter.ts
+++ b/src/write/submitter.ts
@@ -65,14 +65,18 @@ export class TransactionSubmitter {
 
     while (retries <= config.tx.maxRetries) {
       try {
-        // Submit
-        const signature = await rpc.sendTransaction(params.signedTxBase64);
+        // Submit — FN-090: forward commitment so the node processes the tx
+        // at the requested level. Omit config object when no commitment is
+        // set to preserve backward-compatible call shape.
+        const commitmentCfg = params.commitment ? { commitment: params.commitment } : undefined;
+        const signature = await rpc.sendTransaction(params.signedTxBase64, commitmentCfg);
 
         // Poll for confirmation
         const result = await this.pollConfirmation(
           signature,
           timeout - (Date.now() - startTime),
           params.vm,
+          commitmentCfg,
         );
         result.retries = retries;
         result.latency_ms = Date.now() - startTime;
@@ -128,6 +132,7 @@ export class TransactionSubmitter {
     signature: string,
     remainingMs: number,
     _vm: string,
+    commitmentCfg?: { commitment?: "submitted" | "confirmed" | "finalized" },
   ): Promise<TransactionResult> {
     const deadline = Date.now() + Math.max(remainingMs, 5000);
     // FN-197: count consecutive non-"not found" RPC failures. A single
@@ -139,7 +144,10 @@ export class TransactionSubmitter {
 
     while (Date.now() < deadline) {
       try {
-        const tx: any = await rpc.getTransaction(signature);
+        // FN-090: forward commitment so the node returns the tx at the
+        // requested level, preventing poll timeouts for txs visible only
+        // at a higher commitment level than the node default.
+        const tx: any = await rpc.getTransaction(signature, commitmentCfg);
         consecutiveErrors = 0;
         if (tx) {
           // The receipt arrives whether the tx succeeded or failed; check

--- a/tests/unit/commitment-forwarding.test.ts
+++ b/tests/unit/commitment-forwarding.test.ts
@@ -1,0 +1,118 @@
+import { describe, test, expect, vi, beforeEach, afterEach } from "vitest";
+
+// FN-090: verify that SubmitParams.commitment is forwarded through
+// EtoRpcClient.sendTransaction and EtoRpcClient.getTransaction as the
+// second positional JSON-RPC param (per Solana spec). Without this,
+// polling times out when the devnet node only surfaces a tx at a higher
+// commitment level than the node default (Issue #13, root-cause #4).
+
+vi.mock("../../src/config.js", () => ({
+  config: {
+    etoRpcUrl: "http://localhost:8899",
+    tx: {
+      defaultTimeoutMs: 30_000,
+      maxRetries: 0,
+      confirmationPollMs: 50,
+      maxPollErrors: 3,
+    },
+  },
+}));
+
+vi.mock("../../src/utils/logger.js", () => ({
+  log: vi.fn(),
+}));
+
+import { EtoRpcClient } from "../../src/read/rpc-client.js";
+
+function mockFetch(resultsByMethod: Record<string, any>) {
+  return vi.fn(async (_url: string, init?: RequestInit) => {
+    const body = JSON.parse((init?.body as string) ?? "{}");
+    const result = resultsByMethod[body.method];
+    if (result === undefined) {
+      throw new Error(`Unmocked method: ${body.method}`);
+    }
+    return {
+      ok: true,
+      json: async () => ({ jsonrpc: "2.0", id: body.id, result }),
+    } as Response;
+  });
+}
+
+describe("EtoRpcClient commitment forwarding (FN-090)", () => {
+  let fetchSpy: ReturnType<typeof vi.spyOn>;
+  let capturedBodies: any[];
+
+  beforeEach(() => {
+    capturedBodies = [];
+    fetchSpy = vi.spyOn(globalThis, "fetch").mockImplementation(
+      async (_url, init) => {
+        const body = JSON.parse((init?.body as string) ?? "{}");
+        capturedBodies.push(body);
+        // Return a minimal valid response for each method
+        const resultsByMethod: Record<string, any> = {
+          sendTransaction: "5CwFakeSignature111111111111111111111111111111111111111111111",
+          getTransaction: null, // null = not found yet (normal polling case)
+        };
+        const result = resultsByMethod[body.method] ?? null;
+        return {
+          ok: true,
+          json: async () => ({ jsonrpc: "2.0", id: body.id, result }),
+        } as Response;
+      },
+    );
+  });
+
+  afterEach(() => {
+    fetchSpy.mockRestore();
+  });
+
+  test("sendTransaction omits config param when no commitment provided", async () => {
+    const client = new EtoRpcClient("http://localhost:8899");
+    await client.sendTransaction("AAAA==").catch(() => {}); // may throw due to invalid sig shape
+    const call = capturedBodies.find((b) => b.method === "sendTransaction");
+    expect(call).toBeDefined();
+    // params should be [serializedTx] only — no second element
+    expect(call.params).toHaveLength(1);
+    expect(call.params[0]).toBe("AAAA==");
+  });
+
+  test("sendTransaction forwards commitment as second params element", async () => {
+    const client = new EtoRpcClient("http://localhost:8899");
+    await client
+      .sendTransaction("AAAA==", { commitment: "finalized" })
+      .catch(() => {}); // may throw due to invalid sig shape
+    const call = capturedBodies.find((b) => b.method === "sendTransaction");
+    expect(call).toBeDefined();
+    expect(call.params).toHaveLength(2);
+    expect(call.params[1]).toEqual({ commitment: "finalized" });
+  });
+
+  test("getTransaction omits config param when no commitment provided", async () => {
+    const client = new EtoRpcClient("http://localhost:8899");
+    // Use a valid base58 signature to pass signature validation
+    const validSig = "5v4R4nFakeSignatureForTestingOnly111111111111111111111111111";
+    await client.getTransaction(validSig).catch(() => {});
+    const call = capturedBodies.find((b) => b.method === "getTransaction");
+    expect(call).toBeDefined();
+    expect(call.params).toHaveLength(1);
+    expect(call.params[0]).toBe(validSig);
+  });
+
+  test("getTransaction forwards commitment as second params element", async () => {
+    const client = new EtoRpcClient("http://localhost:8899");
+    const validSig = "5v4R4nFakeSignatureForTestingOnly111111111111111111111111111";
+    await client.getTransaction(validSig, { commitment: "confirmed" }).catch(() => {});
+    const call = capturedBodies.find((b) => b.method === "getTransaction");
+    expect(call).toBeDefined();
+    expect(call.params).toHaveLength(2);
+    expect(call.params[1]).toEqual({ commitment: "confirmed" });
+  });
+
+  test("getTransaction forwards 'submitted' commitment level", async () => {
+    const client = new EtoRpcClient("http://localhost:8899");
+    const validSig = "5v4R4nFakeSignatureForTestingOnly111111111111111111111111111";
+    await client.getTransaction(validSig, { commitment: "submitted" }).catch(() => {});
+    const call = capturedBodies.find((b) => b.method === "getTransaction");
+    expect(call.params[1]).toEqual({ commitment: "submitted" });
+  });
+});


### PR DESCRIPTION
## Summary
- Adds optional `config?: { commitment? }` param to `EtoRpcClient.sendTransaction` and `EtoRpcClient.getTransaction` per Solana JSON-RPC spec
- Threads `SubmitParams.commitment` through `TransactionSubmitter._submit` → `pollConfirmation` → both RPC calls, so the devnet node uses the caller's commitment level
- Fixes Issue #13 root-cause #4: polling timed out as "not found" when the tx was only visible at a higher commitment level than the node default

## Test plan
- [ ] `bun run typecheck` passes
- [ ] 5 new regression tests in `tests/unit/commitment-forwarding.test.ts` pass — assert JSON-RPC `params[1]` is forwarded correctly for both `sendTransaction` and `getTransaction`
- [ ] Existing `submitter-coalesce.test.ts` suite unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)