### PR TITLE
feat(FN-051): extend ModelAttestation verified branch with session_signed source

### DIFF
--- a/.changeset/FN-016-bijective-svm-to-evm.md
+++ b/.changeset/FN-016-bijective-svm-to-evm.md
@@ -1,0 +1,80 @@
+---
+"eto-mcp": minor
+---
+
+## FN-016: Replace lossy SVM→EVM derivation with registry-backed bijection
+
+### What was removed
+
+The `pubkeyToEvmAddress` function in `src/utils/address.ts` and `src/wasm/index.ts`
+previously truncated the 32-byte SVM pubkey to its last 20 bytes
+(`pubkey[12..32]`), producing an EVM address. This is **not injective** — up to
+2^96 different SVM pubkeys map to the same EVM address — making round-trip
+reconstruction impossible and silently routing funds to the wrong account.
+
+The old `evmAddressToPubkey` inverse used `SHA256("evm:" || addr_bytes)` to
+produce a derived SVM pubkey, which bore no relationship to the input SVM key.
+
+Both broken derivations have been replaced.
+
+### What replaces it (FN-015 Option B — Registry-backed bijection)
+
+The EVM address for a `LocalSigner` wallet is derived once at wallet-creation
+time via `signer.getEvmSigningAddress()`:
+
+```
+evmKey       = HKDF-SHA256(ikm=ed25519_private_key, info="eto-evm-secp256k1-v1")
+secp_pubkey  = secp256k1.getPublicKey(evmKey, uncompressed)
+evm_address  = "0x" + keccak256(secp_pubkey[1:])[12:]
+```
+
+This is the address recovered by `ecrecover` on any signed EVM transaction from
+this wallet. The SVM↔EVM pair is immediately stored in:
+
+1. The in-memory `InMemoryRegistry` inside the wallet's `WalletStore`
+2. The encrypted sidecar file (`~/.eto/wallets/<scope>.enc`) under a new
+   optional `evmAddress` field on each wallet record
+
+Lookups go through the new `resolveAddressesAsync(addr, registry)` function.
+
+### Migration impact for persisted wallets
+
+**Devnet / testnet wallets created before this change:**
+
+Wallet files that do not contain an `evmAddress` field (pre-FN-016 format) are
+automatically migrated on first load: the correct EVM address is recomputed from
+the stored Ed25519 private key and saved back to disk. No manual re-import is
+needed.
+
+The **EVM address bytes will change** for wallets that were previously
+identified by the old `slice(12,32)` derivation. Any external system that
+recorded the old EVM address (off-chain address book, explorer, audit log) must
+be updated to use the new address. On-chain balances under the old address are
+NOT automatically migrated — if funds were sent to the old (incorrect) EVM
+address, they must be transferred manually.
+
+**Mainnet / production wallets:** No mainnet deployment exists at this point
+(devnet only). If mainnet wallets are created before FN-016 is deployed, they
+must be migrated following the same process.
+
+### New public API surface
+
+| Symbol | Location | Description |
+|---|---|---|
+| `WalletRegistry` | `src/utils/address.ts` | Interface for SVM↔EVM lookups |
+| `resolveAddressesAsync` | `src/utils/address.ts` | Registry-backed bijective resolver |
+| `WalletStore.recordCrossVmMapping()` | `src/signing/wallet-store.ts` | Record SVM↔EVM at wallet creation |
+| `WalletStore.lookupBySvm()` | `src/signing/wallet-store.ts` | EVM for a given SVM |
+| `WalletStore.lookupByEvm()` | `src/signing/wallet-store.ts` | SVM for a given EVM |
+| `WalletStore.asRegistry()` | `src/signing/wallet-store.ts` | Expose as `WalletRegistry` |
+| `LocalSignerFactory.getRegistryForCurrentScope()` | `src/signing/local-signer.ts` | Get registry for active scope |
+
+### Related issues and follow-ups
+
+- **GitHub issue:** https://github.com/etofdn/eto-mcp/issues/16
+- **FN-017:** Implement `evmAddressToPubkey` as a registry-backed inverse.
+- **FN-018 / FN-019:** Round-trip property tests (`SVM→EVM→SVM`).
+- **FN-020:** Update `resolve_cross_vm_address` tool description.
+- **FN-009 (new):** Fix `FrostSigner.getEvmAddress()` which still uses the
+  old `slice(12,32)` derivation (open question — signing service cannot derive
+  a secp256k1 key from FROST shares).

--- a/.changeset/fn-058-skill-cert-caller-binding.md
+++ b/.changeset/fn-058-skill-cert-caller-binding.md
@@ -1,0 +1,46 @@
+# FN-058: Caller-binding signature on skill-cert issuer
+
+## Summary
+
+Closes a SECURITY HIGH credential-squatting / race-front-run bug in
+`src/issuers/skill-cert.ts`: the issuer accepted any caller's claim that a
+given `subjectAgentCard` belonged to them, then minted an on-chain skill
+credential bound to that pubkey. Because the binding store is first-write-
+wins, an attacker who learned a whitelisted `(skill, victim)` tuple
+(public on the allowlist surface) could front-run the legitimate owner and
+permanently lock them out of their own skill credential.
+
+## Fix
+
+Adds the caller-binding-signature convention already in use by
+`civic.ts` and `worldcoin.ts`:
+
+- New `AgentCardSignatureVerifier` interface in `skill-cert.types.ts`,
+  injected via `SkillCertIssuerDeps.signatureVerifier` (defaults to a
+  Node-`crypto` Ed25519 implementation, `ed25519SkillCertSignatureVerifier`).
+- New required request fields `agentCardSignature` (base64 Ed25519 signature)
+  and `issuanceNonce` (caller-supplied freshness string).
+- New canonical preimage helper `skillCertSignaturePreimage` returning
+  `sha256("eto:skill-cert:v1" || skill || subjectAgentCard || issuanceNonce)`.
+- New error code `INVALID_AGENT_CARD_SIGNATURE` (HTTP 401).
+- Signature verification runs **between request shape validation and the
+  idempotency / whitelist / chain steps**. A request whose signature does
+  not validate against `subjectAgentCard` is rejected 401 before any
+  side effect (no binding-store read, no whitelist call, no on-chain tx).
+
+## Wire compatibility
+
+This is a breaking change for callers of the `skill-cert` issuer — every
+request body now requires `agentCardSignature` and `issuanceNonce`. The
+five reference BPPs that consume this issuer must sign their issuance
+requests with their AgentCard keypair before re-running their bootstrap
+flow. The on-chain credential schema (`schemaIdForSkill`) and PDA layout
+are unchanged.
+
+## Tests
+
+- Adds happy-path test using a real Ed25519 keypair.
+- Adds front-run test where `subjectAgentCard != signer` and asserts 401
+  rejection BEFORE any binding-store / whitelist / chain interaction.
+- Adds preimage-binding tests (wrong skill in preimage, empty signature,
+  empty nonce) all returning 401 with no side effects.

--- a/README.md
+++ b/README.md
@@ -263,9 +263,10 @@ injectable `KytEventSource` and emits a deterministic JSON-LD audit
 feed shaped as a `VerifiableCredential` of type
 `["VerifiableCredential", "AuditTrailFeed"]`. Events are sorted by
 `(slot, txSignature)` for byte-stable output, and the
-`credentialSubject.summary` carries per-stage counters. v0 is
-**unsigned** (issuer DID `did:eto:indexer:audit-trail:v0` is a
-placeholder); the production source will subscribe to
+`credentialSubject.summary` carries per-stage counters. Signing is opt-in via the injected `VcSigner` (FN-084); the default
+`NoOpVcSigner` preserves the historical unsigned shape (no `proof`
+key, issuer DID `did:eto:indexer:audit-trail:v0`). The production
+source will subscribe to
 `singularity:kyt:*` and `singularity:revocation:root_updated` log
 lines via Solana JSON-RPC `logsSubscribe`. Consumed downstream by the
 1099 issuer (FN-132) and travel-rule generator (FN-133). Tests use the
@@ -304,8 +305,52 @@ are resolved via the injected `AmountResolver`. v0 ships the in-memory
 reference implementations (`InMemoryPartyDirectory`,
 `InMemoryAmountResolver`); production wiring (backed by the issuer
 registry and `EtoRpcClient` transaction lookups) is a follow-up task.
-v0 reports are **unsigned** (issuer DID `did:eto:indexer:travel-rule:v0`
-is a placeholder). Per spec §9.3: `parties[0]` (BAP) is the originator;
+Signing is opt-in via the injected `VcSigner` (FN-084); the default
+`NoOpVcSigner` preserves the historical unsigned shape (issuer DID
+`did:eto:indexer:travel-rule:v0`, no `proof` key on the document). Per
+spec §9.3: `parties[0]` (BAP) is the originator;
 `parties[1]` (BPP) is the beneficiary. Entries are sorted by
 `(slot, txSignature)` for byte-stable output; the injectable `clock`
 allows tests to pin `issuanceDate` for deterministic assertions.
+
+### Audit / travel-rule signing (`@eto/mcp` → `src/services/indexer/vc-signer.ts`)
+
+FN-084. Compliance-grade `Ed25519Signature2020` proof blocks for the
+audit-trail and travel-rule JSON-LD documents per the W3C VC Data
+Integrity 1.0 spec. Signing is **opt-in**: the default `NoOpVcSigner`
+emits the historical unsigned shape (no `proof` key, byte-stable
+against pre-FN-084 fixtures). To enable signing, set
+`AUDIT_SIGNING_KEY_PATH` and inject `createVcSignerFromEnv({ issuerDid })`
+into `AuditTrailIndexerDeps.signer` / `TravelRuleReportGeneratorDeps.signer`.
+
+**Env var.**
+
+- `AUDIT_SIGNING_KEY_PATH` — filesystem path to a 32-byte Ed25519 seed.
+  The file may be raw 32 bytes, hex (with or without `0x` prefix), or
+  base64 / base64url. Anything else throws `expected 32-byte Ed25519
+  seed`. The loaded secret is never logged or echoed back in error
+  messages.
+
+**Proof block shape.** Attached as `feed.proof` /
+`report.proof` when a non-NoOp signer is configured:
+
+```jsonc
+{
+  "type": "Ed25519Signature2020",
+  "created": "2026-05-02T12:34:56.000Z",
+  "verificationMethod": "did:eto:issuer:bank-prod#key-1",
+  "proofPurpose": "assertionMethod",
+  "proofValue": "<base64url(Ed25519(sha256(JCS(vcWithoutProof))))>"
+}
+```
+
+**Hash input (spec §11.4).** `claim_hash = sha256(JCS(vcWithoutProof))`.
+The `proof` block itself is **excluded** from the JCS preimage; the
+indexer wiring strips it before calling `signer.sign(...)` and only
+attaches the returned proof afterwards.
+
+**Backwards compatibility.** When `AUDIT_SIGNING_KEY_PATH` is unset (or
+no `signer` is injected), the default `NoOpVcSigner` returns a sentinel
+proof with `proofValue === ""`; the indexers detect this and OMIT the
+`proof` key entirely so output is byte-identical to v0. All existing
+fixture-based tests pass unchanged.

--- a/README.md
+++ b/README.md
@@ -272,6 +272,29 @@ lines via Solana JSON-RPC `logsSubscribe`. Consumed downstream by the
 1099 issuer (FN-132) and travel-rule generator (FN-133). Tests use the
 shipped `InMemoryKytEventSource` reference implementation.
 
+#### Audit-trail persistence (FN-083)
+
+A Postgres-backed `PostgresKytEventSource` is available as a drop-in
+replacement for `InMemoryKytEventSource`. Configure it via the
+`AUDIT_DB_URL` environment variable (a standard `postgres://…` connection
+string). When `AUDIT_DB_URL` is unset the `createKytEventSourceFromEnv`
+factory returns an empty `InMemoryKytEventSource` as a safe fallback.
+
+**Migration** (run once against the target database):
+
+```sh
+psql "$AUDIT_DB_URL" -f scripts/migrations/001_kyt_events.sql
+```
+
+The migration is idempotent (`CREATE TABLE IF NOT EXISTS`) and creates
+two tables — `kyt_events` and `revocation_events` — that together hold
+every `KytTrace` and `RevocationRootUpdated` event observed on-chain.
+
+**FATF R.11 retention.** FATF Recommendation 11 requires virtual-asset
+service providers to retain transfer records for at least **five years**.
+These tables satisfy that requirement. Do not DELETE or TRUNCATE them in
+production.
+
 ### 1099 issuance flow sketch (`@eto/mcp` → `keeper/bpps/bank/handlers/tax-1099-sketch.ts`)
 
 T-3.13.1.3 / FN-132. Manually-triggered bank-as-BPP flow that, given a

--- a/bun.lock
+++ b/bun.lock
@@ -11,11 +11,13 @@
         "ajv": "^8.20.0",
         "ajv-formats": "^3.0.1",
         "express": "^5.2.1",
+        "pg": "^8.13.0",
         "zod": "^3.25.76",
       },
       "devDependencies": {
         "@types/express": "^5.0.0",
         "@types/node": "^20.12.0",
+        "@types/pg": "^8.11.0",
         "bs58": "^6.0.0",
         "typescript": "^5.4.0",
         "vitest": "^1.6.0",
@@ -144,6 +146,8 @@
     "@types/http-errors": ["@types/http-errors@2.0.5", "", {}, "sha512-r8Tayk8HJnX0FztbZN7oVqGccWgw98T/0neJphO91KkmOzug1KkofZURD4UaD5uH8AqcFLfdPErnBod0u71/qg=="],
 
     "@types/node": ["@types/node@20.19.39", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-orrrD74MBUyK8jOAD/r0+lfa1I2MO6I+vAkmAWzMYbCcgrN4lCrmK52gRFQq/JRxfYPfonkr4b0jcY7Olqdqbw=="],
+
+    "@types/pg": ["@types/pg@8.20.0", "", { "dependencies": { "@types/node": "*", "pg-protocol": "*", "pg-types": "^2.2.0" } }, "sha512-bEPFOaMAHTEP1EzpvHTbmwR8UsFyHSKsRisLIHVMXnpNefSbGA1bD6CVy+qKjGSqmZqNqBDV2azOBo8TgkcVow=="],
 
     "@types/qs": ["@types/qs@6.15.0", "", {}, "sha512-JawvT8iBVWpzTrz3EGw9BTQFg3BQNmwERdKE22vlTxawwtbyUSlMppvZYKLZzB5zgACXdXxbD3m1bXaMqP/9ow=="],
 
@@ -337,11 +341,35 @@
 
     "pathval": ["pathval@1.1.1", "", {}, "sha512-Dp6zGqpTdETdR63lehJYPeIOqpiNBNtc7BpWSLrOje7UaIsE5aY92r/AunQA7rsXvet3lrJ3JnZX29UPTKXyKQ=="],
 
+    "pg": ["pg@8.20.0", "", { "dependencies": { "pg-connection-string": "^2.12.0", "pg-pool": "^3.13.0", "pg-protocol": "^1.13.0", "pg-types": "2.2.0", "pgpass": "1.0.5" }, "optionalDependencies": { "pg-cloudflare": "^1.3.0" }, "peerDependencies": { "pg-native": ">=3.0.1" }, "optionalPeers": ["pg-native"] }, "sha512-ldhMxz2r8fl/6QkXnBD3CR9/xg694oT6DZQ2s6c/RI28OjtSOpxnPrUCGOBJ46RCUxcWdx3p6kw/xnDHjKvaRA=="],
+
+    "pg-cloudflare": ["pg-cloudflare@1.3.0", "", {}, "sha512-6lswVVSztmHiRtD6I8hw4qP/nDm1EJbKMRhf3HCYaqud7frGysPv7FYJ5noZQdhQtN2xJnimfMtvQq21pdbzyQ=="],
+
+    "pg-connection-string": ["pg-connection-string@2.12.0", "", {}, "sha512-U7qg+bpswf3Cs5xLzRqbXbQl85ng0mfSV/J0nnA31MCLgvEaAo7CIhmeyrmJpOr7o+zm0rXK+hNnT5l9RHkCkQ=="],
+
+    "pg-int8": ["pg-int8@1.0.1", "", {}, "sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw=="],
+
+    "pg-pool": ["pg-pool@3.13.0", "", { "peerDependencies": { "pg": ">=8.0" } }, "sha512-gB+R+Xud1gLFuRD/QgOIgGOBE2KCQPaPwkzBBGC9oG69pHTkhQeIuejVIk3/cnDyX39av2AxomQiyPT13WKHQA=="],
+
+    "pg-protocol": ["pg-protocol@1.13.0", "", {}, "sha512-zzdvXfS6v89r6v7OcFCHfHlyG/wvry1ALxZo4LqgUoy7W9xhBDMaqOuMiF3qEV45VqsN6rdlcehHrfDtlCPc8w=="],
+
+    "pg-types": ["pg-types@2.2.0", "", { "dependencies": { "pg-int8": "1.0.1", "postgres-array": "~2.0.0", "postgres-bytea": "~1.0.0", "postgres-date": "~1.0.4", "postgres-interval": "^1.1.0" } }, "sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA=="],
+
+    "pgpass": ["pgpass@1.0.5", "", { "dependencies": { "split2": "^4.1.0" } }, "sha512-FdW9r/jQZhSeohs1Z3sI1yxFQNFvMcnmfuj4WBMUTxOrAyLMaTcE1aAMBiTlbMNaXvBCQuVi0R7hd8udDSP7ug=="],
+
     "picocolors": ["picocolors@1.1.1", "", {}, "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="],
 
     "pkg-types": ["pkg-types@1.3.1", "", { "dependencies": { "confbox": "^0.1.8", "mlly": "^1.7.4", "pathe": "^2.0.1" } }, "sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ=="],
 
     "postcss": ["postcss@8.5.13", "", { "dependencies": { "nanoid": "^3.3.11", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-qif0+jGGZoLWdHey3UFHHWP0H7Gbmsk8T5VEqyYFbWqPr1XqvLGBbk/sl8V5exGmcYJklJOhOQq1pV9IcsiFag=="],
+
+    "postgres-array": ["postgres-array@2.0.0", "", {}, "sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA=="],
+
+    "postgres-bytea": ["postgres-bytea@1.0.1", "", {}, "sha512-5+5HqXnsZPE65IJZSMkZtURARZelel2oXUEO8rH83VS/hxH5vv1uHquPg5wZs8yMAfdv971IU+kcPUczi7NVBQ=="],
+
+    "postgres-date": ["postgres-date@1.0.7", "", {}, "sha512-suDmjLVQg78nMK2UZ454hAG+OAW+HQPZ6n++TNDUX+L0+uUlLywnoxJKDou51Zm+zTCjrCl0Nq6J9C5hP9vK/Q=="],
+
+    "postgres-interval": ["postgres-interval@1.2.0", "", { "dependencies": { "xtend": "^4.0.0" } }, "sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ=="],
 
     "pretty-format": ["pretty-format@29.7.0", "", { "dependencies": { "@jest/schemas": "^29.6.3", "ansi-styles": "^5.0.0", "react-is": "^18.0.0" } }, "sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ=="],
 
@@ -387,6 +415,8 @@
 
     "source-map-js": ["source-map-js@1.2.1", "", {}, "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA=="],
 
+    "split2": ["split2@4.2.0", "", {}, "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg=="],
+
     "stackback": ["stackback@0.0.2", "", {}, "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw=="],
 
     "statuses": ["statuses@2.0.2", "", {}, "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw=="],
@@ -430,6 +460,8 @@
     "why-is-node-running": ["why-is-node-running@2.3.0", "", { "dependencies": { "siginfo": "^2.0.0", "stackback": "0.0.2" }, "bin": { "why-is-node-running": "cli.js" } }, "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w=="],
 
     "wrappy": ["wrappy@1.0.2", "", {}, "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="],
+
+    "xtend": ["xtend@4.0.2", "", {}, "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ=="],
 
     "yocto-queue": ["yocto-queue@1.2.2", "", {}, "sha512-4LCcse/U2MHZ63HAJVE+v71o7yOdIe4cZ70Wpf8D/IyjDKYQLV5GD46B+hSTjJsvV5PztjvHoU580EftxjDZFQ=="],
 

--- a/claude-mcp-config.md
+++ b/claude-mcp-config.md
@@ -25,7 +25,8 @@ Or add manually to `~/.claude/claude_desktop_config.json`:
       "env": {
         "ETO_RPC_URL": "http://localhost:8899",
         "NETWORK": "testnet",
-        "AUTH_DEV_BYPASS": "true"
+        "AUTH_DEV_BYPASS": "true",
+        "AUDIT_DB_URL": ""  // optional: postgres://user:pass@host/dbname for durable audit-trail storage (FN-083); omit or leave empty for in-memory fallback
       }
     }
   }

--- a/docs/agent-identity-model.md
+++ b/docs/agent-identity-model.md
@@ -1,0 +1,310 @@
+# ETO Agent Identity Model — `human × model × environment`
+
+> Tracking issue: [etofdn/eto-mcp#11](https://github.com/etofdn/eto-mcp/issues/11)
+> Upstream task: **FN-058** (this spec).
+> Downstream: **FN-059** (authority-inheritance enforcement), **FN-060** (A2A coordination), **FN-061** (model-attestation research). Part of the **FN-054** A2A milestone.
+>
+> Status: **normative spec, no runtime wiring yet.** A reference TypeScript shape lives at [`src/models/agent-identity.ts`](../src/models/agent-identity.ts); no MCP tool currently emits or consumes it. FN-059 is the first task that will wire it into a request handler.
+
+---
+
+## §1 — Why a multi-axis identity
+
+Today's session model in `src/gateway/session.ts` answers a single question:
+*"Is this caller's bearer token validly signed for some `sub`?"* That binds a
+request to a **human authority** (the user behind `sub`) and to a bounded
+**session scope** (`exp`, `caps`, `wallet_id`). It is silent on two questions
+that A2A coordination ([FN-054](#)) forces us to answer:
+
+1. **Which AI model produced this action?** Two MCP sessions can share the same
+   `sub` while running on completely different model providers (Claude, GPT,
+   self-hosted Llama). Trust decisions about *autonomous-agent* behavior — rate
+   limits, capability gating, audit logs — need to attribute actions to a
+   model, not just a person.
+2. **Where is the agent executing?** "The same human" running ETO from the
+   stdio CLI on their laptop, from a hosted SSE deployment, and from a CI
+   runner is three different *execution surfaces*. The cryptographic anchor
+   (the wallet keys actually doing the signing) and the network-reachable
+   endpoint are surface-specific.
+
+The agent identity model therefore tuples four orthogonal axes:
+
+```
+AgentIdentity = {
+  human_authority,    // who authorized this agent
+  model_attestation,  // what AI is steering it
+  environment,        // where it's running + crypto anchor
+  session_scope,      // bounded MCP session window
+}
+```
+
+Each axis has its own source-of-truth, its own threat model, and its own
+verification roadmap. They compose: an A2A counterpart that wants to trust an
+incoming message MUST evaluate all four, and MAY make different trust
+decisions on each.
+
+---
+
+## §2 — The four fields
+
+### §2.1 — `human_authority`
+
+| | |
+|---|---|
+| **Definition** | The human (or human-controlled service account) that consented to this agent acting on their behalf. |
+| **Type (TS)** | `HumanAuthority` |
+| **Source-of-truth (today)** | `SessionPayload.sub` + `SessionPayload.auth_strategy` from `src/gateway/session.ts`, surfaced via `authenticate()` in `src/gateway/auth.ts`. |
+| **Concrete values today** | `sub` = thirdweb-issued wallet address (SIWE / inapp_email / inapp_oauth strategies), the literal `"dev-user"` (dev-bypass), or the synthetic `"__stdio__"` scope when running over stdio without auth. |
+| **Trust assumption** | The session token's HMAC signature attests that *some* trusted auth backend issued this `sub`. The strength of that attestation is a function of `auth_strategy`: `siwe` ≥ `inapp_oauth` ≥ `inapp_email` ≫ `dev`. `__stdio__` carries no human attestation at all and MUST be treated as local-only. |
+| **Threat model** | Compromise of `SESSION_SIGNING_KEY` lets an attacker forge any `sub`. Compromise of an upstream IdP (thirdweb) lets an attacker take over a single user's `sub`. Cross-tenant impersonation is out of scope for this spec (see [§7 Non-goals](#7-non-goals)). |
+
+### §2.2 — `model_attestation`
+
+| | |
+|---|---|
+| **Definition** | A claim about which AI model/provider produced the agent's tool calls, and whether that claim is cryptographically verified. |
+| **Type (TS)** | `ModelAttestation` with discriminator `attestation_status: "verified" \| "self_declared" \| "absent"`. |
+| **Source-of-truth (forward)** | A provider-signed JWT/JWS attesting `{ model_id, provider, issued_at, audience }`, verified against the provider's published JWKS. Tracked by **FN-061**. |
+| **Source-of-truth (today)** | None. The MCP server cannot today verify what model is on the other end of the protocol; the field is `attestation_status: "self_declared"` carrying whatever the agent advertises in a `User-Agent`-style header, or `attestation_status: "absent"` if nothing was sent. |
+| **Trust assumption** | When `attestation_status === "verified"`: trust the provider's JWKS. When `"self_declared"`: treat the model claim as a **hint for telemetry only**, never for capability gating. When `"absent"`: do not branch on model identity at all. |
+| **Threat model** | Self-declared values can be spoofed trivially. Verified values inherit the provider's KMS posture; signature replay across audiences is mitigated by `aud` binding to the MCP server's origin. |
+
+This is the axis that explicitly *does not work today*. The interim path
+(see [§5](#5-interim-implementation-works-today)) is to record the
+self-declared claim and propagate `attestation_status: "self_declared"` so
+downstream code can refuse to trust it.
+
+### §2.3 — `environment`
+
+| | |
+|---|---|
+| **Definition** | The execution surface the agent is running on, plus the cryptographic wallet anchor it controls. |
+| **Type (TS)** | `Environment` |
+| **Source-of-truth** | `currentScope()` from `src/signing/session-context.ts` (`__stdio__` / `__dev__` / thirdweb sub) for the surface; `localSignerFactory` (`src/signing/local-signer.ts`) for the SVM (Ed25519 base58) and EVM (secp256k1 0x-hex) addresses derived from the active wallet. |
+| **Concrete values** | `surface ∈ { "stdio", "sse", "dev" }`, `server_instance` = `last_restart_iso` from `session_info`, `wallet_anchor = { id, svm, evm }` from the active wallet. |
+| **Trust assumption** | The wallet anchor is the **strongest** signal in this entire model: anyone presenting a signature over a fresh challenge from `wallet_anchor.svm` or `wallet_anchor.evm` proves possession of the corresponding private key. A2A trust SHOULD prefer wallet-anchor proofs over `human_authority` claims when they disagree. |
+| **Threat model** | A surface label (`"sse"`) is unauthenticated metadata. A wallet address is authenticated metadata only after a fresh signature challenge — never trust a wallet address presented in a payload alone. |
+
+### §2.4 — `session_scope`
+
+| | |
+|---|---|
+| **Definition** | The bounded MCP session window inside which this identity is valid. |
+| **Type (TS)** | `SessionScope` |
+| **Source-of-truth** | `SessionPayload.{ jti, exp, caps }` plus the persistence-key `scope` string from `currentScope()`. |
+| **Concrete values** | `{ scope, jti, expires_at_iso, capabilities[] }`. |
+| **Trust assumption** | A token with `exp < now` is invalid regardless of how strong every other axis is. Capabilities (`caps[]`) are the authoritative authorization list; identity in this spec does NOT confer capability — it only attributes. |
+| **Threat model** | Token replay before `exp` is mitigated by HMAC binding + the `revoked_jtis` denylist in `src/gateway/session.ts`. Capability escalation is gated by `requireCapability()`, not by anything in this spec. |
+
+---
+
+## §3 — Authority inheritance rule
+
+> **Rule.** Two `AgentIdentity` values `A` and `B` MAY transitively trust each
+> other for the *intersection* of `A.session_scope.capabilities` and
+> `B.session_scope.capabilities`, **iff** all of the following hold:
+>
+> 1. `A.human_authority.sub === B.human_authority.sub`, AND
+> 2. Both `A.human_authority` and `B.human_authority` carry an
+>    `auth_strategy` other than `"dev"` and a scope other than `"__stdio__"`
+>    (i.e. both are anchored to a real human-authenticated backend), AND
+> 3. Neither `session_scope` is expired.
+>
+> The rule is **silent on `model_attestation`**: two agents inherit authority
+> across model providers, because the human is the same human. The rule is
+> **silent on `environment`**: a user can fan out work from their laptop to a
+> hosted runner under the same `sub`, and inheritance still holds.
+
+### §3.1 — Worked example
+
+Alice signs in with thirdweb SIWE on her laptop. The MCP server issues
+session token `T_laptop` with `sub = 0xAlice`, `auth_strategy = "siwe"`,
+`caps = [a2a:write, transfer:write, …]`. Her IDE runs Claude.
+
+Alice also has a hosted runner that authenticated as `0xAlice` through the
+same thirdweb provider; it holds session token `T_runner` with the same `sub`
+but `caps = [a2a:write, a2a:read]` only (narrowed by capability scoping at
+issuance). It runs GPT.
+
+A2A message flow: the runner agent (GPT) sends an A2A message to a counterpart
+that holds `T_laptop` (Claude). The receiver evaluates inheritance:
+
+- `sub` matches (`0xAlice` ↔ `0xAlice`) ✓
+- both `auth_strategy = "siwe"` ✓
+- both unexpired ✓
+
+→ The receiver MAY treat the message as Alice-authorized. The action it can
+ultimately *perform* is gated by **its own** `capabilities[]`, not the
+sender's: inheritance attributes intent, it does not lend caps. If the
+receiver only has `a2a:read`, it cannot turn an inherited request into a
+`transfer:write`.
+
+### §3.2 — When inheritance does NOT apply
+
+- `__stdio__` ↔ anything: stdio carries no human attestation, so it cannot
+  inherit from or to an authenticated session. Stdio agents are local trust
+  only.
+- `__dev__` / `auth_strategy = "dev"`: dev-bypass MUST NOT inherit into
+  production-strategy sessions even on a `sub` collision.
+- `model_attestation`-based gating: a counterpart MAY *additionally* require
+  `model_attestation.attestation_status === "verified"` for a specific
+  capability. That check is layered ON TOP of the rule above; it does not
+  weaken it.
+
+---
+
+## §4 — Verification roadmap for `model_attestation`
+
+The eventual flow ([FN-061](#) tracks the research):
+
+1. The agent runtime obtains a short-lived JWT from its model provider with
+   payload approximately:
+   ```json
+   {
+     "iss": "https://provider.example/v1",
+     "sub": "model:claude-3-7-sonnet-20250219",
+     "aud": "https://mcp.eto.example",
+     "iat": 1735689600,
+     "exp": 1735690200,
+     "model_id": "claude-3-7-sonnet-20250219",
+     "provider": "anthropic"
+   }
+   ```
+2. The agent attaches the JWT in an `X-Model-Attestation` header (or MCP
+   transport equivalent) on each outbound MCP request.
+3. The MCP server verifies the JWT against the provider's published JWKS
+   (cached, with rotation). `aud` MUST equal the server's canonical origin.
+4. On success: emit `ModelAttestation` with `attestation_status: "verified"`,
+   carrying `provider`, `model_id`, and the signature's `kid`.
+5. On any failure (signature, `aud`, `exp`, unknown provider): emit
+   `attestation_status: "absent"`. Do NOT downgrade to `"self_declared"` —
+   self-declared is for the case where there was *no* attestation attempted.
+
+**Open design questions** flagged for FN-061:
+
+- Signature algorithm — RFC 9458/9461 / JWS `EdDSA` vs. `ES256`.
+- Key discovery — direct JWKS URL vs. a registry like
+  [`oauth-for-ai-agents`](https://github.com/etofdn/eto-mcp/issues/11)-style
+  IdP federation.
+- Revocation — short `exp` (≤ 60 s) is the working assumption; explicit
+  revocation lists are deferred.
+- Tenant binding — whether `aud` alone is enough, or a per-deployment nonce
+  is required to defeat replay across ETO instances.
+
+---
+
+## §5 — Interim implementation (works today)
+
+Until FN-061 lands, every `AgentIdentity` we can construct has
+`model_attestation.attestation_status` of `"self_declared"` or `"absent"`.
+Construction reuses the existing `session_info` MCP tool's response shape
+*as data input only* — no new tool, no change to `session_info` itself
+(that's FN-059's job).
+
+A pure builder is exported as
+[`buildInterimAgentIdentity`](../src/models/agent-identity.ts) with this
+contract:
+
+```ts
+buildInterimAgentIdentity({
+  // session_info-shaped payload:
+  scope,                       // currentScope()
+  active_wallet_id,            // wallet.ts
+  wallets: [{ id, label, svm, evm }, ...],
+  auth_strategy,               // SessionPayload.auth_strategy | null
+  token_expires_at,            // ISO string | null
+  last_restart_iso,            // server boot ISO
+  // optional caller-provided hints:
+  declared_model?: { provider, model_id }, // becomes self_declared attestation
+  capabilities?: string[],     // SessionPayload.caps | undefined
+  jti?: string,                // SessionPayload.jti | undefined
+}): AgentIdentity
+```
+
+The builder:
+
+1. Maps `scope` + `auth_strategy` into `human_authority`, computing
+   `human_authority.kind` as `"thirdweb"` (real `sub`),
+   `"stdio"` (`scope === "__stdio__"`), `"dev"` (`auth_strategy === "dev"`
+   or `scope === "__dev__"`), or `"unknown"`.
+2. Maps the active wallet's `{svm, evm}` into `environment.wallet_anchor`,
+   and `last_restart_iso` into `environment.server_instance`. Surface is
+   inferred from `scope` (`"__stdio__"` → `"stdio"`, `"__dev__"` → `"dev"`,
+   anything else → `"sse"`).
+3. If `declared_model` is provided, emits
+   `attestation_status: "self_declared"` carrying it. Otherwise emits
+   `attestation_status: "absent"`.
+4. Maps `token_expires_at`, `capabilities`, `jti`, and `scope` into
+   `session_scope`.
+
+**The builder MUST throw** if `scope` is missing — there is no meaningful
+identity without a session-scope persistence key.
+
+**Trust degradation.** Any consumer of an interim `AgentIdentity` MUST
+treat `model_attestation` as untrusted telemetry. Specifically:
+
+- Authority inheritance ([§3](#3--authority-inheritance-rule)) is permitted
+  on `human_authority` alone, since that field is HMAC-attested today.
+- Capability gating MUST NOT branch on `model_attestation` until `verified`
+  is reachable.
+
+---
+
+## §6 — Type reference
+
+The canonical TS surface is in [`src/models/agent-identity.ts`](../src/models/agent-identity.ts).
+Field-level JSDoc cites the section numbers in this document.
+
+```ts
+interface AgentIdentity {
+  human_authority: HumanAuthority;     // §2.1
+  model_attestation: ModelAttestation; // §2.2
+  environment: Environment;            // §2.3
+  session_scope: SessionScope;         // §2.4
+}
+```
+
+---
+
+## §7 — Non-goals
+
+This spec deliberately does NOT cover:
+
+- **Revocation transport.** Token revocation lives in
+  `src/gateway/session.ts`'s `revokeJti` denylist and is independent of
+  this identity shape.
+- **Attestation transport.** How `X-Model-Attestation` arrives at the server
+  (HTTP header vs. MCP-protocol extension) is FN-061's call.
+- **Cross-tenant delegation.** "Alice's agent acts on behalf of Bob" is not a
+  case of authority inheritance; it requires a delegation credential and is
+  out of scope.
+- **A2A wire format.** How an `AgentIdentity` is serialized into an A2A
+  envelope is FN-060's call.
+- **MCP tool changes.** `session_info` and `SessionPayload` are unchanged.
+  FN-059 is the first task that will wire `AgentIdentity` into a handler.
+
+---
+
+## §8 — Open questions
+
+| # | Question | Resolved by |
+|---|---|---|
+| Q1 | Should `human_authority.kind === "stdio"` ever participate in inheritance with another stdio session on the same host? | FN-059 |
+| Q2 | What is the exact JWS algorithm and JWKS discovery story for `model_attestation`? | FN-061 |
+| Q3 | Does `environment.surface` need a fourth value (`"http-bridge"`) for the SSE-bridge variant? | FN-060 |
+| Q4 | Should `session_scope.capabilities` be re-projected into a coarser A2A capability vocabulary, or carried verbatim? | FN-060 |
+| Q5 | Is `wallet_anchor` allowed to carry multiple wallets (the user's full set), or must it be the single active wallet at issuance? | FN-059 |
+
+---
+
+## §9 — Cross-references
+
+- Upstream tracking issue: [etofdn/eto-mcp#11](https://github.com/etofdn/eto-mcp/issues/11)
+- A2A milestone: **FN-054**
+- Authority-inheritance enforcement: **FN-059** (consumes this spec)
+- A2A coordination wire format: **FN-060**
+- Model-attestation research: **FN-061**
+- Session and capability primitives: [`src/gateway/session.ts`](../src/gateway/session.ts), [`src/gateway/auth.ts`](../src/gateway/auth.ts)
+- Scope context: [`src/signing/session-context.ts`](../src/signing/session-context.ts)
+- Wallet anchor: [`src/signing/local-signer.ts`](../src/signing/local-signer.ts)
+- Today's identity-adjacent tool: [`src/tools/session.ts`](../src/tools/session.ts) (`session_info`)

--- a/docs/memo-schema-registry.md
+++ b/docs/memo-schema-registry.md
@@ -1,0 +1,225 @@
+# ETO Memo Schema Registry
+
+> Tracking issue: [etofdn/eto-mcp#11](https://github.com/etofdn/eto-mcp/issues/11) (item 4/10).
+> Companion to [`docs/schema-registry.md`](./schema-registry.md). This registry
+> covers **memo schemas** — typed JSON envelopes anchored in SPL Memo Program v2
+> instruction data — and is intentionally separate from the **credential schema
+> registry**, which catalogs W3C Verifiable Credential payloads gated on-chain
+> by `schema_hash`.
+
+## §1 — Why a typed memo layer
+
+Today `transfer_native` and the `batch` transfer tool accept a free-form
+`memo: string` (see `src/tools/transfer.ts`), which is wired straight into a
+single SPL Memo v2 instruction in the transfer transaction. The same memo is
+recoverable later via `query_memos` and `get_account_transactions`. This is
+sufficient for human-readable annotations but breaks down once agents start
+exchanging structured records on-chain:
+
+- **No type discrimination.** A consumer cannot tell an evaluation score from a
+  payment receipt from a coordination-log entry without ad-hoc string sniffing
+  ("does it start with `score:`?").
+- **No versioning.** Producers cannot evolve their record shape without
+  silently breaking older readers.
+- **No validation contract.** Each consumer re-implements its own parser, and
+  malformed entries surface as opaque errors instead of being skipped cleanly.
+
+This registry defines a small typed-envelope convention so that three concrete
+record kinds — and any future ones — can be produced and consumed safely:
+
+| Kind                | Purpose                                                                 |
+|---------------------|-------------------------------------------------------------------------|
+| `eval_score`        | One agent scoring another against a named metric (LLM-judge, oracle)   |
+| `payment`           | Structured payment metadata (purpose, invoice id, optional task ref)   |
+| `coordination_log`  | A2A coordination event (`task_offered`, `task_accepted`, …)            |
+
+The runtime implementation (validators, helper functions, tool wiring) is
+explicitly out of scope for this document; see the follow-up implementation
+task referenced from issue #11.
+
+## §2 — Envelope shape
+
+Every typed memo is a single UTF-8 JSON object with **no leading whitespace**
+and no trailing newline. The wire format is:
+
+```json
+{
+  "type": "eval_score",
+  "schema": "eto.memo.eval_score.v1",
+  "v": 1,
+  "ts": "2026-05-02T17:00:00Z",
+  "payload": { "...": "..." }
+}
+```
+
+Required top-level fields:
+
+| Field      | Type    | Notes                                                                   |
+|------------|---------|-------------------------------------------------------------------------|
+| `type`     | string  | Short kind discriminator. Must equal the `<type>` segment of `schema`. |
+| `schema`   | string  | Full registry label (see §3). Identifies the payload schema.            |
+| `v`        | integer | Major schema version, ≥ 1. Equals the `vN` suffix of `schema`.          |
+| `ts`       | string  | RFC 3339 / ISO 8601 UTC timestamp (e.g. `2026-05-02T17:00:00Z`).        |
+| `payload`  | object  | The typed body, validated by the schema named in `schema`.              |
+
+`additionalProperties` on the envelope is **false**; producers MUST NOT add
+extra top-level fields. Extensibility happens inside `payload` (per its own
+schema, additive within a major version).
+
+### Size budget
+
+A single SPL Memo v2 instruction in a typical SVM transfer transaction has
+roughly **566 bytes** of usable instruction data after accounting for the
+transfer instruction, signature, blockhash, and program ids. This budget
+shrinks further if multiple instructions are packed in the same tx.
+
+Guidance for producers:
+
+- Keep the full encoded envelope ≤ **400 bytes** to leave headroom for SDK
+  variations and future cosigner accounts.
+- For records that exceed the budget (e.g. eval evidence with logs attached),
+  store the bulk content off-chain (S3, IPFS, R2) and put a content digest +
+  pointer URI inside the payload. The on-chain memo then anchors integrity
+  without paying transaction-size for the whole record. v1 schemas already
+  reserve `evidence_uri` on `eval_score` for exactly this pattern.
+- Producers SHOULD reject oversize envelopes client-side rather than rely on
+  the validator to truncate.
+
+## §3 — Naming convention
+
+```
+eto.memo.<type>[.<sub>].v<N>
+```
+
+- `<type>` — required kind discriminator. Matches the envelope `type` field.
+- `<sub>` — optional refinement (reserved for future use, e.g.
+  `payment.escrow.v1`). v1 schemas in this registry do not use a sub-segment.
+- `<N>` — major version, integer ≥ 1. Additive changes within a major version
+  are non-breaking; breaking changes mint `v(N+1)`.
+
+The `eto.memo.*` prefix is **deliberately distinct** from `eto.beckn.schema.*`
+used by the credential registry (`docs/schema-registry.md`) to prevent label
+collision. Memo schemas are **not** hashed onto chain; they are identified by
+label string only. If hash-binding is desired later, see §8.
+
+Pre-image strings are case-sensitive ASCII.
+
+## §4 — Registered schemas (v1)
+
+| Label                            | Producer                                  | Consumer                                    | Schema file                                       |
+|----------------------------------|-------------------------------------------|---------------------------------------------|---------------------------------------------------|
+| `eto.memo.eval_score.v1`         | evaluator agent (LLM-judge / oracle)      | reputation aggregator, dashboards           | [`spec/memo-schemas/eval_score.v1.json`](../spec/memo-schemas/eval_score.v1.json) |
+| `eto.memo.payment.v1`            | wallet UX, escrow agent, A2A SDK          | accounting, invoice reconciliation          | [`spec/memo-schemas/payment.v1.json`](../spec/memo-schemas/payment.v1.json)       |
+| `eto.memo.coordination_log.v1`   | A2A SDK coordination layer                | orchestration UI, audit trail               | [`spec/memo-schemas/coordination_log.v1.json`](../spec/memo-schemas/coordination_log.v1.json) |
+
+## §5 — Validation approach
+
+Validation uses [Ajv](https://ajv.js.org/) (already a project dependency in
+`package.json`, `^8.20.0`) compiled against JSON Schema **Draft 2020-12**, with
+`ajv-formats` providing `date-time` validation for the `ts` field.
+
+Two-stage validation:
+
+1. **Envelope** — validate top-level shape (`type`, `schema`, `v`, `ts`,
+   `payload`) against a single shared envelope schema.
+2. **Payload** — look up the per-schema validator by the envelope's `schema`
+   label and validate `payload` against the schema file under
+   `spec/memo-schemas/`.
+
+Producer/consumer contract:
+
+- **Producers MUST validate before submission.** A failing validation aborts
+  the transfer; it does not silently strip the memo.
+- **Consumers MUST validate on read** and MUST treat invalid records as
+  opaque. A malformed memo, an unknown `schema`, or a future-version memo
+  must never throw out of the entire `query_memos` call — it returns alongside
+  valid records with a `{ ok: false, reason }` shape.
+
+Suggested TypeScript helper signatures (runtime task will implement):
+
+```ts
+export interface MemoEnvelope<T = unknown> {
+  type: string;
+  schema: string;
+  v: number;
+  ts: string; // RFC 3339 UTC
+  payload: T;
+}
+
+export function encodeMemo<T>(
+  type: string,
+  payload: T,
+  opts?: { schema?: string; v?: number; ts?: string },
+): string;
+
+export type DecodeResult =
+  | { ok: true; envelope: MemoEnvelope }
+  | { ok: false; reason: string; raw: string };
+
+export function decodeMemo(raw: string): DecodeResult;
+```
+
+`encodeMemo` is the single sanctioned way for SDK callers to produce typed
+memos; it MUST run Ajv against both envelope and payload before returning the
+serialized string. `decodeMemo` MUST never throw — all parse/validate failures
+land in the `{ ok: false }` branch.
+
+## §6 — Versioning rules
+
+- **Additive within a major version.** New optional fields can be added to a
+  payload schema's `properties` without bumping `vN`. Required fields, type
+  changes, and removed fields are breaking and require `v(N+1)`.
+- **One major version per file.** Each `vN` lives in its own
+  `<type>.v<N>.json` file under `spec/memo-schemas/`. Older versions remain
+  in the repo so historical memos remain decodable.
+- **Consumer compatibility.** A consumer that knows versions up to `vK`
+  SHOULD accept any envelope with `v ≤ K` and SHOULD ignore (treat as opaque)
+  envelopes with `v > K`. Consumers MUST NOT crash on unknown future versions.
+- **Label immutability.** Once published, a label like `eto.memo.eval_score.v1`
+  is frozen. Never reuse the label for a different shape.
+
+## §7 — Adding a new schema
+
+1. Pick a `type` discriminator and label per §3 (e.g. `eto.memo.attestation.v1`).
+2. Add a JSON Schema Draft 2020-12 file at
+   `spec/memo-schemas/<type>.v<N>.json` validating the **payload only** (the
+   envelope is validated separately). Set `$schema`, `$id`, `title`,
+   `type: "object"`, `required`, and `additionalProperties: false`.
+3. Add a row to §4 (Producer / Consumer / Schema file).
+4. Add a one-line description to `spec/memo-schemas/README.md`.
+5. Verify the schema compiles under Ajv 2020 in strict mode (see Step 4 of
+   FN-057 for the exact one-liner).
+6. If breaking an existing schema, mint `v(N+1)` rather than mutating the
+   existing file.
+7. Open a PR; CI re-runs the Ajv compile check.
+
+## §8 — Open questions / out of scope for v1
+
+- **Cryptographic schema commitments.** v1 identifies schemas by label string
+  only. We do not bind a `sha256(canonical-JSON-of-schema)` digest into the
+  envelope or anchor it on-chain. If a future BPP wants strong schema
+  integrity (analogous to the credential registry's on-chain `schema_hash`),
+  add a `schema_digest` field to the envelope and define canonicalization
+  rules (likely RFC 8785 JCS).
+- **Cross-program memo discovery.** Today only `query_memos` /
+  `get_account_transactions` surface memos, scoped to a single SVM account.
+  Cross-program indexing (e.g. tying a `coordination_log` memo on one wallet
+  to a `payment` memo on another) is left to higher-level orchestration.
+- **Bridging to the credential registry.** A `payment` memo that doubles as a
+  receipt VC will need a defined mapping from `eto.memo.payment.v1` →
+  `eto.beckn.schema.<receipt>.v1`. The two registries deliberately do not
+  share a namespace, but a runtime adapter could project one into the other.
+- **Compression / binary framing.** All v1 envelopes are uncompressed UTF-8
+  JSON. If size pressure grows, candidates include CBOR (RFC 8949) or simple
+  field aliasing; both would mint `v2` or a sibling envelope kind.
+- **Multi-instruction memos.** v1 assumes one envelope per memo instruction.
+  Splitting a large record across multiple memo instructions in a single tx
+  is left to a future spec.
+
+## See also
+
+- [`docs/schema-registry.md`](./schema-registry.md) — Beckn **credential**
+  schema registry. Credential schemas are W3C VC payload shapes gated on-chain
+  by `schema_hash = SHA-256(label)` and consumed by the IssuerNetwork. Memo
+  schemas (this document) live in SPL Memo instruction data and are validated
+  off-chain only.

--- a/docs/schema-registry.md
+++ b/docs/schema-registry.md
@@ -2,6 +2,8 @@
 
 > Tracking issue: [etofdn/eto-mcp#11](https://github.com/etofdn/eto-mcp/issues/11)
 > Closes: FN-179, FN-193, FN-203 (FN-057 follow-through).
+>
+> **See also:** [`docs/memo-schema-registry.md`](./memo-schema-registry.md) catalogs the disjoint **memo schema** registry (`eto.memo.*`) used to type SPL Memo v2 records anchored by `transfer_native` / `batch` and surfaced via `query_memos`. This document covers **credential schemas** (`eto.beckn.schema.*`), which are W3C VC payloads gated on-chain by `schema_hash = SHA-256(label)`. The two registries share a versioning philosophy but live under disjoint namespaces and have different identity / validation models (on-chain hash gating vs off-chain Ajv validation).
 
 This document catalogs every Beckn-mapped credential schema referenced by the
 eto-mcp codebase, their pre-image label (the string that hashes into the on-chain

--- a/docs/schema-registry.md
+++ b/docs/schema-registry.md
@@ -3,6 +3,8 @@
 > Tracking issue: [etofdn/eto-mcp#11](https://github.com/etofdn/eto-mcp/issues/11)
 > Closes: FN-179, FN-193, FN-203 (FN-057 follow-through).
 >
+> **See also:** [`docs/agent-identity-model.md`](./agent-identity-model.md) — the agent identity model (`human × model × environment × session_scope`) that downstream A2A trust decisions evaluate. Disjoint from this credential registry.
+>
 > **See also:** [`docs/memo-schema-registry.md`](./memo-schema-registry.md) catalogs the disjoint **memo schema** registry (`eto.memo.*`) used to type SPL Memo v2 records anchored by `transfer_native` / `batch` and surfaced via `query_memos`. This document covers **credential schemas** (`eto.beckn.schema.*`), which are W3C VC payloads gated on-chain by `schema_hash = SHA-256(label)`. The two registries share a versioning philosophy but live under disjoint namespaces and have different identity / validation models (on-chain hash gating vs off-chain Ajv validation).
 
 This document catalogs every Beckn-mapped credential schema referenced by the

--- a/docs/sdk-py-mcp-audit.md
+++ b/docs/sdk-py-mcp-audit.md
@@ -1,0 +1,109 @@
+# Python `mcp` SDK Compatibility Audit
+
+**Audit target:** [`mcp` 1.27.0](https://pypi.org/project/mcp/) (released 2026-04-02)  
+**ETO MCP surface:** `src/sse-server.ts`, `src/server.ts`, `src/tools/wallet.ts` (representative)  
+**TS SDK:** `@modelcontextprotocol/sdk` (McpServer, SSEServerTransport, mcpAuthRouter)  
+**Skeleton spec:** `docs/sdk-py-skeleton-spec.md` does not yet exist; this audit stands alone.  
+**Date:** 2026-05-04
+
+---
+
+## Summary Verdict
+
+**GREEN** — the Python `mcp` client is compatible with the ETO MCP SSE surface for immediate adoption.
+
+One **YELLOW** deprecation note (SSE transport lifecycle) and one **YELLOW** server-side cleanup
+item (missing `isError` on error returns) are documented below. Neither blocks Python client adoption;
+both are server-side improvements, not Python SDK gaps.
+
+---
+
+## Surface Comparison
+
+| Dimension | ETO MCP (TS server) | Python `mcp` 1.27.0 client | Match? |
+|---|---|---|---|
+| **Transport** | `SSEServerTransport` at `GET /sse`, `POST /message?sessionId=…` (`sse-server.ts:189-228`) | `mcp.client.sse.sse_client` — connects to `/sse`, extracts `sessionId` from endpoint event, POSTs to `/message` | YES |
+| **JSON-RPC envelope** | Standard JSON-RPC 2.0 via `@modelcontextprotocol/sdk` | `ClientSession` sends/receives standard JSON-RPC 2.0 frames over the SSE channel | YES |
+| **Tool call request** | `tools/call` method, params `{name, arguments}` | `ClientSession.call_tool(name, arguments)` emits identical frame | YES |
+| **Tool result shape** | `{content: [{type:"text", text:…}]}` (`wallet.ts:75, 82`) | `CallToolResult` — `content: list[TextContent | ImageContent | …]`, `isError: bool` | YES (see note 1) |
+| **Content block types** | `TextContent` (`type:"text"`) | `TextContent`, `ImageContent`, `EmbeddedResource` — same discriminated union | YES |
+| **Error propagation** | Error path returns `{content:[{type:"text",text:"Error: …"}]}` with no `isError:true` (`wallet.ts:82-85`) | `CallToolResult.isError` defaults `False`; client reads `.content` regardless | PARTIAL (note 1) |
+| **Streaming / progress** | No server-initiated progress tokens on current tools; SSE channel stays open for push | `ClientSession` supports `progress_token` via `report_progress()`; no-op if server omits | YES (no-op compat) |
+| **OAuth 2.1 / Bearer auth** | `mcpAuthRouter` issues tokens; `GET /sse` and `POST /message` require `Authorization: Bearer …`; RFC 9728 `/.well-known/oauth-protected-resource` metadata; WWW-Authenticate challenge at `sse-server.ts:78-105` | `OAuthClientProvider` + `TokenStorage` protocol; RFC 9728 discovery; `httpx.Auth` integration on `sse_client(headers=…, auth=…)` | YES |
+| **CORS / MCP-Protocol-Version** | Allowed in CORS: `Authorization`, `MCP-Protocol-Version` (`sse-server.ts:35`) | SDK 1.27.0 sends `MCP-Protocol-Version` on negotiation; Python `httpx` client passes custom headers via `headers=` param | YES |
+| **Session lifecycle** | Server creates `SSEServerTransport` per connection; session cleaned up on SSE `close` event (`sse-server.ts:197-207`) | `sse_client` context manager — closes cleanly on `__aexit__`; reconnect is caller's responsibility | YES |
+
+---
+
+## Gaps
+
+### Note 1 — Missing `isError` flag on TS error returns (server-side, YELLOW)
+
+**What ETO does:** All tool handlers in `src/tools/` return errors as plain content blocks:
+
+```typescript
+// src/tools/wallet.ts:82-85
+return { content: [{ type: "text" as const, text: `Error creating wallet: ${err?.message}` }] };
+```
+
+No `isError: true` is set. The MCP specification defines `isError` on `CallToolResult` to signal
+tool-level failures distinct from successful results.
+
+**Python client behaviour:** `CallToolResult.isError` defaults to `False`. A Python client receives
+the error text in `.content[0].text` but cannot distinguish a tool failure from a successful
+text-only response without inspecting the text itself.
+
+**Impact:** Transport-level compatibility is unaffected — the wire frame is valid JSON-RPC. However,
+a Python consumer that branches on `result.isError` will silently treat TS error returns as successes.
+
+**Severity:** YELLOW — server-side fix (add `isError: true` to error return paths in all tool handlers).
+Not a Python SDK gap; Python `mcp` correctly implements the spec field.
+
+### Note 2 — SSE transport deprecation lifecycle (YELLOW, future migration)
+
+The Python SDK README states: _"SSE transport is being superseded by Streamable HTTP transport."_
+ETO's `sse-server.ts` uses `SSEServerTransport` exclusively. Both transports remain supported in
+`mcp` 1.27.0, so adoption is not blocked today. A future migration to `StreamableHTTPServerTransport`
+(TS) and `streamablehttp_client` (Python) should be tracked.
+
+---
+
+## Adoption Recommendation
+
+**Adopt `mcp` 1.27.0 as the Python client transport now.**
+
+Minimal connection pattern:
+
+```python
+from mcp.client.sse import sse_client
+from mcp.client.session import ClientSession
+import httpx
+
+headers = {"Authorization": f"Bearer {token}"}
+async with sse_client("https://mcp.entropytoorder.xyz/sse", headers=headers) as (read, write):
+    async with ClientSession(read, write) as session:
+        await session.initialize()
+        result = await session.call_tool("create_wallet", {"label": "py-test"})
+        print(result.content[0].text)
+```
+
+For the full OAuth 2.1 flow (discovery → authorize → token → refresh), use `OAuthClientProvider`
+with a `TokenStorage` implementation. The ETO server's RFC 9728 metadata at
+`/.well-known/oauth-protected-resource` is already compatible with this flow.
+
+**Before relying on `result.isError` in Python consumers:** open a follow-up ticket to add
+`isError: true` to all error return paths in `src/tools/` TS handlers.
+
+---
+
+## References
+
+- `src/sse-server.ts:23` — RESOURCE_METADATA_URL (RFC 9728 discovery)
+- `src/sse-server.ts:45-50` — `mcpAuthRouter` mount
+- `src/sse-server.ts:52-105` — Bearer extraction + WWW-Authenticate challenge
+- `src/sse-server.ts:189-228` — SSE handshake + POST /message routing
+- `src/server.ts:33-44` — `McpServer` construction
+- `src/tools/wallet.ts:62-85` — tool registration envelope + error return shape
+- [PyPI mcp 1.27.0](https://pypi.org/project/mcp/)
+- [python-sdk README](https://github.com/modelcontextprotocol/python-sdk)
+- [python-sdk mcp/client/sse.py](https://github.com/modelcontextprotocol/python-sdk/blob/main/src/mcp/client/sse.py)

--- a/docs/singularity-record-registry.md
+++ b/docs/singularity-record-registry.md
@@ -1,0 +1,285 @@
+# ETO Singularity Record Schema Registry
+
+> Tracking issue: SDK API spec follow-up (FN-055) — closes the open-question
+> item on Singularity record schemas (referenced as item #6 of the SDK API
+> spec §7 once that doc lands; that document does not yet exist in this
+> repo).
+>
+> **Companion to** [`docs/schema-registry.md`](./schema-registry.md) and
+> [`docs/memo-schema-registry.md`](./memo-schema-registry.md). Together these
+> three documents form the normative schema-naming surface for the project.
+>
+> This registry catalogs **Layer 3 Singularity SDK record schemas** — typed
+> JSON envelopes produced by `agent.log()` and consumed by
+> `agent.queryRecords()` in the Singularity SDK. It is intentionally distinct
+> from the **credential schema registry** (W3C VC payloads gated on-chain by
+> `schema_hash`) and the **memo schema registry** (typed JSON envelopes
+> anchored in SPL Memo Program v2 instruction data). The three namespaces —
+> `eto.beckn.schema.*`, `eto.memo.*`, and `eto.singularity.record.*` — are
+> deliberately disjoint; a single label MUST NOT appear in more than one
+> registry.
+
+## §1 — Why a registry
+
+The Singularity SDK gives every agent a single durable channel for writing
+and querying its own structured activity. `agent.log()` accepts a typed
+record; `agent.queryRecords()` returns matching records back to the same (or
+a peer) agent for reflection, evaluation, or downstream automation. Without a
+single source of truth for record shapes:
+
+- **No type discrimination.** A consumer cannot tell a tool-call trace from
+  an evaluation outcome from a free-form activity entry without ad-hoc
+  string sniffing on the payload.
+- **No version evolution.** Producers cannot evolve a record's shape without
+  silently breaking older readers or query filters.
+- **No validation contract.** Each consumer of `agent.queryRecords()`
+  re-implements its own parser, and malformed entries surface as opaque
+  errors instead of being skipped cleanly.
+- **No filter contract.** `agent.queryRecords({ schema, ... })` cannot offer
+  a typed filter surface unless the set of legal `schema` values is
+  enumerable.
+
+This registry defines the envelope, the naming convention, and the addition
+procedure so that record kinds can be proposed, registered, and evolved
+safely once the Singularity SDK lands.
+
+## §2 — Record envelope shape
+
+Every Singularity record is a single JSON object with the following
+canonical envelope:
+
+```json
+{
+  "type": "activity_log",
+  "schema": "eto.singularity.record.activity_log.v1",
+  "v": 1,
+  "ts": "2026-05-03T12:00:00Z",
+  "agent_id": "<opaque-agent-id>",
+  "payload": { "...": "..." }
+}
+```
+
+Required top-level fields:
+
+| Field      | Type    | Notes                                                                                |
+|------------|---------|--------------------------------------------------------------------------------------|
+| `type`     | string  | Short kind discriminator. Must equal the `<name>` segment of `schema`.               |
+| `schema`   | string  | Full registry label (see §3). Identifies the payload schema.                         |
+| `v`        | integer | Major schema version, ≥ 1. Equals the `vN` suffix of `schema`.                       |
+| `ts`       | string  | RFC 3339 / ISO 8601 UTC timestamp (e.g. `2026-05-03T12:00:00Z`).                     |
+| `agent_id` | string  | Opaque agent identifier as produced by the SDK (see identity model — link below).    |
+| `payload`  | object  | The typed body, validated by the schema named in `schema`.                           |
+
+`additionalProperties` on the envelope is **false**; producers MUST NOT add
+extra top-level fields. Extensibility happens inside `payload` per its own
+schema (additive within a major version — see §6).
+
+The internal shape of `agent_id` is not prescribed here. See
+[`docs/agent-identity-model.md`](./agent-identity-model.md) for the canonical
+agent identity model (`human × model × environment × session_scope`); this
+registry treats the value as an opaque string.
+
+### Size guidance (no hard budget)
+
+Unlike the memo registry, Singularity records are **not** bounded by SPL
+Memo's ~566-byte single-instruction budget — records flow through the SDK's
+own persistence layer (transport and storage are out of scope for this
+document; see §9 and the SDK API spec FN-055 follow-up). Producers SHOULD
+nevertheless keep payloads modest:
+
+- Inline only the structured fields the consumer needs to filter or display.
+- For bulk content (logs, transcripts, model outputs), store the bulk
+  off-line and put a content digest + pointer URI inside the payload —
+  analogous to the `evidence_uri` pattern used by `eto.memo.eval_score.v1`.
+
+## §3 — Naming convention
+
+```
+eto.singularity.record.<name>[.<sub>].v<N>
+```
+
+- `<name>` — required kind discriminator. Matches the envelope `type` field.
+- `<sub>` — optional refinement (e.g. `tool_call.openai.v1`). Most v1 records
+  are expected to omit the sub-segment.
+- `<N>` — major version, integer ≥ 1. Additive changes within a major
+  version are non-breaking; breaking changes mint `v(N+1)`.
+
+The `eto.singularity.record.*` prefix is **deliberately distinct** from
+`eto.beckn.schema.*` (credential registry) and `eto.memo.*` (memo registry)
+to prevent cross-registry label collision. The three namespaces are disjoint
+by construction; a label registered here MUST NOT shadow a label in either
+sibling registry.
+
+Pre-image strings are case-sensitive ASCII.
+
+## §4 — Registered schemas (v1)
+
+> _Reserved — no v1 records are registered by this document._
+
+Initial record kinds (candidates discussed during SDK scoping include agent
+activity log entries, tool-call traces, and evaluation outcomes) will be
+proposed via the addition procedure in §7 once the Singularity SDK lands.
+Minting labels here ahead of an implementation would risk reserving names
+whose semantics shift during SDK design; this registry intentionally defers
+that until producers and consumers exist.
+
+| Label | Producer | Consumer | Schema file |
+|-------|----------|----------|-------------|
+| _(none registered for v1)_ | — | — | — |
+
+### Example (illustrative, not registered)
+
+The following row shows the table format only. It is **not** a registered
+label and MUST NOT be assumed available by any producer or consumer.
+
+| Label | Producer | Consumer | Schema file |
+|-------|----------|----------|-------------|
+| `eto.singularity.record.activity_log.v1` | Singularity SDK `agent.log()` callers | `agent.queryRecords()` consumers, dashboards | `spec/singularity-records/activity_log.v1.json` |
+
+## §5 — Validation approach
+
+Validation uses [Ajv](https://ajv.js.org/) (already a project dependency in
+`package.json`, `^8.20.0`) compiled against JSON Schema **Draft 2020-12**,
+with `ajv-formats` providing `date-time` validation for the `ts` field.
+This matches the toolchain used by the memo registry so the two share
+validator infrastructure.
+
+Two-stage validation:
+
+1. **Envelope** — validate top-level shape (`type`, `schema`, `v`, `ts`,
+   `agent_id`, `payload`) against a single shared envelope schema.
+2. **Payload** — look up the per-schema validator by the envelope's
+   `schema` label and validate `payload` against the schema file under
+   `spec/singularity-records/`.
+
+Producer/consumer contract:
+
+- **`agent.log()` MUST validate before persistence.** A failing validation
+  aborts the call; the record is not written.
+- **`agent.queryRecords()` MUST tolerate unknown or future-version
+  envelopes.** An unrecognised `schema`, a `v` higher than the consumer
+  knows, or a malformed envelope MUST NOT throw out of the entire call —
+  the offending record is returned alongside valid records as
+  `{ ok: false, reason }` so the caller can decide whether to skip or
+  surface it.
+
+Suggested TypeScript helper signatures (the runtime task that implements
+the SDK persistence layer will provide concrete bindings; this document
+only fixes the contract):
+
+```ts
+export interface SingularityRecord<T = unknown> {
+  type: string;
+  schema: string;
+  v: number;
+  ts: string;       // RFC 3339 UTC
+  agent_id: string; // opaque
+  payload: T;
+}
+
+export function encodeRecord<T>(
+  type: string,
+  payload: T,
+  opts: { agent_id: string; schema?: string; v?: number; ts?: string },
+): SingularityRecord<T>;
+
+export type DecodeResult =
+  | { ok: true; record: SingularityRecord }
+  | { ok: false; reason: string; raw: unknown };
+
+export function decodeRecord(raw: unknown): DecodeResult;
+```
+
+`encodeRecord` is the single sanctioned way for SDK callers to produce
+typed records; it MUST run Ajv against both envelope and payload before
+returning. `decodeRecord` MUST never throw — all parse/validate failures
+land in the `{ ok: false }` branch.
+
+## §6 — Versioning rules
+
+- **Additive within a major version.** New optional fields can be added to
+  a payload schema's `properties` without bumping `vN`. Required fields,
+  type changes, and removed fields are breaking and require `v(N+1)`.
+- **One major version per file.** Each `vN` lives in its own
+  `<name>.v<N>.json` file under `spec/singularity-records/`. Older versions
+  remain in the repo so historical records remain decodable.
+- **Consumer compatibility.** A consumer that knows versions up to `vK`
+  SHOULD accept any envelope with `v ≤ K` and SHOULD treat envelopes with
+  `v > K` as opaque (returned via the `{ ok: false }` branch of
+  `decodeRecord`). Consumers MUST NOT crash on unknown future versions.
+- **Label immutability.** Once published, a label like
+  `eto.singularity.record.activity_log.v1` is frozen. Never reuse the label
+  for a different shape.
+
+## §7 — Adding a new schema
+
+1. Pick a `<name>` discriminator and full label per §3 (e.g.
+   `eto.singularity.record.tool_call.v1`).
+2. Add a JSON Schema Draft 2020-12 file at
+   `spec/singularity-records/<name>.v<N>.json` validating the **payload
+   only** (the envelope is validated separately). Set `$schema`, `$id`,
+   `title`, `type: "object"`, `required`, and
+   `additionalProperties: false`. The first registered schema also lands
+   the `spec/singularity-records/` directory; the directory is not assumed
+   to exist before that point.
+3. Add a row to §4 with Producer / Consumer / Schema file columns, and
+   remove the "no v1 records are registered" reservation note in the same
+   PR if this is the first registered label.
+4. Add a one-line description to a `spec/singularity-records/README.md`
+   index (created alongside the first schema file).
+5. Verify the schema compiles under Ajv 2020 in strict mode (the SDK's
+   compile-check task will provide an exact one-liner; until then,
+   `ajv compile -s <file> --spec=draft2020` is the canonical check).
+6. If breaking an existing schema, mint `v(N+1)` rather than mutating the
+   existing file.
+7. Open a PR; CI re-runs the Ajv compile check.
+
+## §8 — Hash derivation (intentionally absent)
+
+Unlike [`docs/schema-registry.md`](./schema-registry.md), Singularity record
+schemas are **not** hashed onto chain. They are identified by label string
+only. There is no `schema_hash`, no on-chain commitment, and no
+canonicalization step in the v1 contract. Producers and consumers compare
+labels byte-for-byte.
+
+If cryptographic schema commitments are needed in the future, see §9 — the
+open-question list is kept symmetric with the memo registry's so the two
+off-chain registries can adopt a shared digest scheme together.
+
+## §9 — Open questions / out of scope for v1
+
+- **Cryptographic schema commitments — out of scope for v1.** v1 identifies
+  schemas by label string only. We do not bind a
+  `sha256(canonical-JSON-of-schema)` digest into the envelope. If strong
+  schema integrity is needed later, add a `schema_digest` field and define
+  canonicalization rules (likely RFC 8785 JCS).
+- **Cross-registry bridging — out of scope for v1.** A Singularity record
+  that doubles as a memo (anchored on-chain via SPL Memo) or as a VC
+  payload (gated by the credential registry) will need a defined mapping
+  from `eto.singularity.record.<name>.vN` into the sibling label space.
+  The three registries deliberately do not share a namespace; a runtime
+  adapter could project one into the other, but no such adapter is
+  specified here.
+- **Compression / binary framing — out of scope for v1.** All v1 envelopes
+  are uncompressed UTF-8 JSON. Candidates for size pressure (CBOR per
+  RFC 8949, field aliasing, schema-aware encoders) would mint `v2` or a
+  sibling envelope kind.
+- **Persistence and transport layer — out of scope for v1.** How records
+  are stored, replicated, queried, and access-controlled is owned by the
+  Singularity SDK API spec (FN-055 follow-up). This registry only fixes
+  the wire shape, not the storage substrate.
+- **Discovery and indexing across agents — out of scope for v1.** v1
+  assumes records are queried via the SDK methods on a single agent's
+  scope. Cross-agent discovery (e.g. searching another agent's records
+  with a capability grant) is left to a future spec.
+
+## See also
+
+- [`docs/schema-registry.md`](./schema-registry.md) — Beckn **credential**
+  schema registry (`eto.beckn.schema.*`). W3C VC payload shapes gated
+  on-chain by `schema_hash = SHA-256(label)`.
+- [`docs/memo-schema-registry.md`](./memo-schema-registry.md) — **memo**
+  schema registry (`eto.memo.*`). Typed JSON envelopes anchored in SPL
+  Memo v2 instruction data, validated off-chain with Ajv.
+- [`docs/agent-identity-model.md`](./agent-identity-model.md) — the agent
+  identity model referenced by the envelope's `agent_id` field.

--- a/keeper/bpps/bank/README.md
+++ b/keeper/bpps/bank/README.md
@@ -78,6 +78,81 @@ To stay within budget the bank BPP uses a **two-tier** approach:
 | `handlers/issue-card.ts`| FN-125     | `issueCard` — v0 stub: issues `card.debit.<jurisdiction>.v1` credential against a CheckingAccount. |
 | `index.ts`              | shared     | Public barrel; re-exports all public surface.                   |
 
+## Caller-authentication contract (FN-015)
+
+Money- and identity-binding bank BPP handlers MUST verify that the
+on-the-wire caller (the BAP whose signature was checked at the gateway)
+is the same principal named by the request body before any side effect
+runs. The shared contract lives in [`auth.ts`](./auth.ts):
+
+```ts
+import {
+  type AuthenticatedRequest,
+  assertCallerEquals,
+  UNAUTHORIZED_CALLER_REASON, // = "unauthorized_caller"
+} from "./auth.js";
+
+export interface AuthenticatedRequest<T> {
+  readonly callerPubkey: string; // hex pubkey verified by the gateway
+  readonly body: T;              // existing per-handler request shape
+}
+```
+
+Handlers receive an `AuthenticatedRequest<T>` and call
+`assertCallerEquals(req.callerPubkey, req.body.subject)` as the FIRST
+line of execution — BEFORE any credential, ledger, chain, or stub call.
+A missing / empty / mismatched `callerPubkey` is rejected with the
+canonical reason `unauthorized_caller`. Comparison is case-insensitive
+over hex and length-checked / constant-time-ish via `timingSafeEqual`.
+
+### Coverage status
+
+| Handler                          | Caller-auth wired?  | Owner |
+| -------------------------------- | ------------------- | ----- |
+| `handlers/issue-card.ts`         | ✅ yes              | FN-015 |
+| `handlers/open-checking.ts`      | ✅ yes              | FN-015 |
+| `handlers/wire.ts`               | ⏳ pending           | FN-034 |
+| `handlers/offramp.ts`            | ⏳ pending           | FN-034 |
+| `handlers/onramp.ts`             | ⏳ pending           | FN-034 |
+| `handlers/open-savings.ts`       | ⏳ pending           | FN-034 |
+
+### Dispatcher plumbing point
+
+`handler.ts` exports `extractCallerPubkey(req)`, the single point at
+which a verified caller pubkey is read off the inbound `TaskRequest`
+before the dispatcher wraps `req.input` as `AuthenticatedRequest<T>`
+for a per-capability handler. Until **FN-073** (gateway BAP-signature
+verification) and **FN-075** (populate the verified pubkey on
+`TaskRequest`) land, `extractCallerPubkey` returns `undefined` for
+every real request and the per-capability handlers continue to
+short-circuit via `STUB_REASONS`. When FN-073 / FN-075 land, the
+dispatcher MUST fail-closed with `UNAUTHORIZED_CALLER_REASON` if
+`extractCallerPubkey` returns `undefined` BEFORE invoking a real
+per-capability handler — the per-handler `assertCallerEquals` gate is
+the second line of defence, not the first.
+
+### Pitfall — do NOT confuse credential validity with caller authentication
+
+The following are **credential / issuance-side checks**. They DO NOT
+substitute for caller authentication and MUST NOT be repurposed as
+such:
+
+- `verifyHolderCredentials` — checks whether a subject possesses
+  required on-chain credentials. Says nothing about who sent the
+  current message.
+- `verifyLinkedAccount` — checks ledger-side ownership of an account
+  PDA. Same caveat.
+- `verifyCheckingCredential` (and similar `verify*Credential` deps) —
+  checks issuance metadata of an existing credential.
+- `cred.issuer === bankIssuer.issuerAuthorityPubkey` (the prod adapter
+  guard in `makeProdIssueCardCredential`) — confirms the bank is
+  signing with the right authority key. It does not bind the
+  caller's BAP signature to `cred.subject`.
+
+Caller authentication is the caller-message-authorship gate enforced
+by `assertCallerEquals` against a gateway-verified `callerPubkey`.
+All other checks layer on top.
+
 ## Running the smoke check
 
 ```bash

--- a/keeper/bpps/bank/auth.test.ts
+++ b/keeper/bpps/bank/auth.test.ts
@@ -1,0 +1,80 @@
+/**
+ * FN-015 — Tests for the bank-BPP caller-authentication helper.
+ */
+import { describe, it, expect } from "vitest";
+import {
+  assertCallerEquals,
+  UNAUTHORIZED_CALLER_REASON,
+  type AuthenticatedRequest,
+} from "./auth.js";
+
+const SUBJECT = "a".repeat(64);
+const OTHER = "b".repeat(64);
+
+describe("assertCallerEquals", () => {
+  it("returns silently when callerPubkey === expected", () => {
+    expect(() => assertCallerEquals(SUBJECT, SUBJECT)).not.toThrow();
+  });
+
+  it("throws unauthorized_caller when callerPubkey !== expected", () => {
+    expect(() => assertCallerEquals(OTHER, SUBJECT)).toThrow(
+      UNAUTHORIZED_CALLER_REASON,
+    );
+  });
+
+  it("throws unauthorized_caller when callerPubkey is undefined", () => {
+    expect(() => assertCallerEquals(undefined, SUBJECT)).toThrow(
+      UNAUTHORIZED_CALLER_REASON,
+    );
+  });
+
+  it("throws unauthorized_caller when callerPubkey is empty string", () => {
+    expect(() => assertCallerEquals("", SUBJECT)).toThrow(
+      UNAUTHORIZED_CALLER_REASON,
+    );
+  });
+
+  it("throws unauthorized_caller when expected is empty string", () => {
+    expect(() => assertCallerEquals(SUBJECT, "")).toThrow(
+      UNAUTHORIZED_CALLER_REASON,
+    );
+  });
+
+  it("matches case-insensitively (uppercase vs lowercase hex)", () => {
+    const upper = SUBJECT.toUpperCase();
+    expect(() => assertCallerEquals(upper, SUBJECT)).not.toThrow();
+    expect(() => assertCallerEquals(SUBJECT, upper)).not.toThrow();
+  });
+
+  it("rejects (does not panic) on differing-length input", () => {
+    expect(() => assertCallerEquals("a".repeat(63), SUBJECT)).toThrow(
+      UNAUTHORIZED_CALLER_REASON,
+    );
+    expect(() => assertCallerEquals("a".repeat(65), SUBJECT)).toThrow(
+      UNAUTHORIZED_CALLER_REASON,
+    );
+  });
+
+  it("error message is exactly the reason constant (no leakage)", () => {
+    try {
+      assertCallerEquals(OTHER, SUBJECT);
+      throw new Error("should have thrown");
+    } catch (err) {
+      expect((err as Error).message).toBe(UNAUTHORIZED_CALLER_REASON);
+    }
+  });
+
+  it("AuthenticatedRequest envelope shape carries body verbatim", () => {
+    interface Body {
+      subject: string;
+      amount: number;
+    }
+    const env: AuthenticatedRequest<Body> = {
+      callerPubkey: SUBJECT,
+      body: { subject: SUBJECT, amount: 42 },
+    };
+    expect(env.callerPubkey).toBe(SUBJECT);
+    expect(env.body.subject).toBe(SUBJECT);
+    expect(env.body.amount).toBe(42);
+  });
+});

--- a/keeper/bpps/bank/auth.ts
+++ b/keeper/bpps/bank/auth.ts
@@ -1,0 +1,139 @@
+/**
+ * FN-015 — Caller-authentication contract for bank BPP handlers.
+ *
+ * This module defines the shared `AuthenticatedRequest<T>` envelope and the
+ * `assertCallerEquals` helper that money / identity-binding bank BPP handlers
+ * use to bind a verified caller pubkey to the per-handler request body.
+ *
+ * ## What this is — and what it is NOT
+ *
+ * `assertCallerEquals` checks **caller-message-authorship authentication**:
+ * the on-the-wire principal whose signature was verified by the gateway must
+ * match the `subject` (or other actor) named inside the body of the Beckn
+ * message before any side effect runs.
+ *
+ * It is NOT a credential-validity check. The following are credential /
+ * issuance-side checks that DO NOT substitute for caller authentication —
+ * they MUST NOT be repurposed as such:
+ *
+ *   - `verifyHolderCredentials` — checks whether a subject possesses
+ *     required on-chain credentials. It says nothing about who sent the
+ *     current message.
+ *   - `verifyLinkedAccount` — checks ledger-side ownership of an account
+ *     PDA. Same caveat.
+ *   - `verifyCheckingCredential` (and similar) — checks issuance metadata
+ *     of an existing credential.
+ *   - `cred.issuer === bankIssuer.issuerAuthorityPubkey` — adapter-side
+ *     guard that the bank is signing with the right authority key. It does
+ *     not bind the caller's BAP signature to `cred.subject`.
+ *
+ * The verified `callerPubkey` is sourced from the gateway-level BAP
+ * signature verification (FN-073 / FN-075). Until that plumbing lands,
+ * the dispatcher (`handler.ts`) returns `undefined` for `callerPubkey`,
+ * and per-capability handlers fail-closed via this module's
+ * `unauthorized_caller` reason.
+ *
+ * @see FN-034 — apply this contract to wire / offramp / onramp / open-savings
+ * @see FN-073 / FN-075 — gateway-level BAP signature plumbing that will
+ *   populate `callerPubkey` for real.
+ */
+
+import { Buffer } from "node:buffer";
+import { timingSafeEqual } from "node:crypto";
+
+// ---------------------------------------------------------------------------
+// Public types & constants
+// ---------------------------------------------------------------------------
+
+/**
+ * Generic envelope wrapping a per-handler request body with the verified
+ * caller pubkey produced by gateway-level BAP signature verification.
+ *
+ * The envelope is intentionally additive: `body` carries the existing
+ * per-handler request shape verbatim. Handlers should read business
+ * fields from `req.body.<field>` and authorisation context from
+ * `req.callerPubkey`.
+ *
+ * `callerPubkey` is the lower-cased hex-encoded ed25519 public key of
+ * the BAP whose signature was verified by the gateway. If the gateway
+ * could not verify a signature it MUST omit `callerPubkey` (or set it
+ * to the empty string) — handlers will reject such requests with
+ * {@link UNAUTHORIZED_CALLER_REASON}.
+ */
+export interface AuthenticatedRequest<T> {
+  readonly callerPubkey: string;
+  readonly body: T;
+}
+
+/**
+ * Canonical rejection reason emitted by handlers when caller-authentication
+ * fails. Per-handler `*Rejected` error classes extend their reason union
+ * with this literal so callers can switch on it.
+ */
+export const UNAUTHORIZED_CALLER_REASON = "unauthorized_caller" as const;
+
+/**
+ * Type alias for the literal value, useful for handler reason unions.
+ */
+export type UnauthorizedCallerReason = typeof UNAUTHORIZED_CALLER_REASON;
+
+// ---------------------------------------------------------------------------
+// Helper
+// ---------------------------------------------------------------------------
+
+/**
+ * Assert that the verified caller pubkey matches `expected`.
+ *
+ * Throws an `Error` whose `message` is exactly `"unauthorized_caller"`
+ * when:
+ *   - `callerPubkey` is `undefined`, `null`, or empty
+ *   - `expected` is empty
+ *   - the two values differ in length (after lowercasing)
+ *   - the two values differ in content (constant-time-ish via
+ *     `timingSafeEqual` over equal-length `Buffer`s)
+ *
+ * Comparison is case-insensitive over hex (both sides are lowercased
+ * before comparison). The function NEVER reveals which input was
+ * malformed in the error message — the message is always the bare
+ * reason constant so callers can rethrow as their typed `*Rejected`
+ * error without leaking timing or validation detail.
+ *
+ * Reminder: this is caller-message-authorship authentication. See the
+ * module-level JSDoc — credential-validity checks are NOT a substitute
+ * for this gate.
+ *
+ * @param callerPubkey - lower- or upper-case hex pubkey reported by the
+ *   gateway's BAP signature verifier; `undefined` / empty means
+ *   "gateway did not verify a caller".
+ * @param expected - the pubkey the request body claims to act on
+ *   (typically `req.body.subject`).
+ */
+export function assertCallerEquals(
+  callerPubkey: string | undefined,
+  expected: string,
+): void {
+  if (
+    callerPubkey === undefined ||
+    callerPubkey === null ||
+    callerPubkey.length === 0 ||
+    expected.length === 0
+  ) {
+    throw new Error(UNAUTHORIZED_CALLER_REASON);
+  }
+
+  const a = callerPubkey.toLowerCase();
+  const b = expected.toLowerCase();
+
+  if (a.length !== b.length) {
+    // Differing lengths can never be equal; reject without invoking
+    // `timingSafeEqual` (which throws on mismatched lengths).
+    throw new Error(UNAUTHORIZED_CALLER_REASON);
+  }
+
+  const aBuf = Buffer.from(a, "utf8");
+  const bBuf = Buffer.from(b, "utf8");
+
+  if (!timingSafeEqual(aBuf, bBuf)) {
+    throw new Error(UNAUTHORIZED_CALLER_REASON);
+  }
+}

--- a/keeper/bpps/bank/handler.test.ts
+++ b/keeper/bpps/bank/handler.test.ts
@@ -1,0 +1,134 @@
+/**
+ * Tests for the Bank-as-BPP dispatcher (FN-096) — caller-authentication
+ * plumbing point added by FN-015.
+ *
+ * These tests document the FN-015 contract:
+ *   - {@link extractCallerPubkey} reads a defensive `callerPubkey` field
+ *     from the inbound `TaskRequest` and returns `undefined` when it is
+ *     missing or empty (the current state until FN-073 / FN-075 land).
+ *   - The dispatcher MUST NOT throw on requests that lack `callerPubkey`
+ *     today; per-capability handlers are still stubs and short-circuit
+ *     via `STUB_REASONS`, so the existing wire contract is preserved.
+ *   - When FN-073 / FN-075 populate `callerPubkey`, {@link extractCallerPubkey}
+ *     surfaces it so the dispatcher can build `AuthenticatedRequest<T>`
+ *     for per-capability handlers.
+ */
+
+import { describe, it, expect } from "vitest";
+import type { TaskRequest } from "../../templates/bpp/index.js";
+import {
+  createBankHandler,
+  extractCallerPubkey,
+  UNAUTHORIZED_CALLER_REASON,
+} from "./handler.js";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeReq(
+  overrides: Partial<TaskRequest<unknown>> & { callerPubkey?: string } = {},
+): TaskRequest<unknown> {
+  const { callerPubkey, ...rest } = overrides;
+  const base: TaskRequest<unknown> = {
+    taskId: "task-123",
+    bapPubkey: "00".repeat(32),
+    bppPubkey: "11".repeat(32),
+    networkPubkey: "22".repeat(32),
+    action: "bank.card",
+    input: {},
+    ...rest,
+  };
+  if (callerPubkey !== undefined) {
+    return { ...base, callerPubkey } as TaskRequest<unknown>;
+  }
+  return base;
+}
+
+// ---------------------------------------------------------------------------
+// extractCallerPubkey
+// ---------------------------------------------------------------------------
+
+describe("extractCallerPubkey (FN-015 plumbing point)", () => {
+  it("returns undefined when callerPubkey is missing (pre-FN-073/FN-075)", () => {
+    expect(extractCallerPubkey(makeReq())).toBeUndefined();
+  });
+
+  it("returns undefined when callerPubkey is the empty string", () => {
+    expect(extractCallerPubkey(makeReq({ callerPubkey: "" }))).toBeUndefined();
+  });
+
+  it("returns the verified caller pubkey when populated", () => {
+    const pk = "ab".repeat(32);
+    expect(extractCallerPubkey(makeReq({ callerPubkey: pk }))).toBe(pk);
+  });
+
+  it("returns undefined for a non-string callerPubkey value", () => {
+    const req = {
+      taskId: "t",
+      bapPubkey: "00".repeat(32),
+      bppPubkey: "11".repeat(32),
+      networkPubkey: "22".repeat(32),
+      action: "bank.card",
+      input: {},
+      callerPubkey: 1234,
+    } as unknown as TaskRequest<unknown>;
+    expect(extractCallerPubkey(req)).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Dispatcher fail-closed / stub-preserving behaviour
+// ---------------------------------------------------------------------------
+
+describe("createBankHandler — FN-015 caller-auth contract", () => {
+  it("does not throw on requests without callerPubkey (pre-gateway-plumbing)", async () => {
+    const handler = createBankHandler();
+    await expect(
+      handler.handleTask(makeReq({ action: "bank.card" })),
+    ).resolves.toEqual({
+      status: "failure",
+      reason: expect.stringContaining("not_implemented: bank.card"),
+    });
+  });
+
+  it("preserves the existing stub failure for each known capability", async () => {
+    const handler = createBankHandler();
+    for (const action of [
+      "bank.checking",
+      "bank.savings",
+      "bank.fiat-ramp",
+      "bank.card",
+      "bank.wire",
+    ]) {
+      const result = await handler.handleTask(makeReq({ action }));
+      expect(result).toEqual({
+        status: "failure",
+        reason: expect.stringContaining(`not_implemented: ${action}`),
+      });
+    }
+  });
+
+  it("returns unknown_action for unrecognised actions", async () => {
+    const handler = createBankHandler();
+    const result = await handler.handleTask(
+      makeReq({ action: "bank.unknown" }),
+    );
+    expect(result).toEqual({
+      status: "failure",
+      reason: "unknown_action: bank.unknown",
+    });
+  });
+
+  it("does not throw when callerPubkey IS populated (forward-compat with FN-073/FN-075)", async () => {
+    const handler = createBankHandler();
+    const result = await handler.handleTask(
+      makeReq({ action: "bank.card", callerPubkey: "ab".repeat(32) }),
+    );
+    expect(result.status).toBe("failure");
+  });
+
+  it("re-exports UNAUTHORIZED_CALLER_REASON for downstream callers", () => {
+    expect(UNAUTHORIZED_CALLER_REASON).toBe("unauthorized_caller");
+  });
+});

--- a/keeper/bpps/bank/handler.ts
+++ b/keeper/bpps/bank/handler.ts
@@ -26,6 +26,7 @@
  */
 
 import type { BppHandler, TaskRequest, TaskResult } from "../../templates/bpp/index.js";
+import { UNAUTHORIZED_CALLER_REASON } from "./auth.js";
 import { BANK_CAPABILITY_KEYS } from "./catalog.js";
 import type { BankCapabilityKey } from "./types.js";
 
@@ -80,6 +81,54 @@ const STUB_REASONS: StubMap = {
 };
 
 /* -------------------------------------------------------------------------- */
+/* Caller-pubkey extraction (FN-015)                                          */
+/* -------------------------------------------------------------------------- */
+
+/**
+ * TODO(gateway-auth, FN-015): bank-BPP caller-authentication contract.
+ *
+ * Per-capability handlers in `./handlers/` (e.g. `issueCard`, `openChecking`)
+ * accept an `AuthenticatedRequest<T>` envelope carrying a verified
+ * `callerPubkey` produced by gateway-level BAP signature verification.
+ *
+ * The dispatcher MUST:
+ *   1. Extract the verified caller pubkey from the inbound `TaskRequest`
+ *      via {@link extractCallerPubkey}.
+ *   2. Wrap the per-handler input in `{ callerPubkey, body: req.input }`
+ *      before invoking the per-capability handler.
+ *   3. Fail-closed with reason `"unauthorized_caller"` if `callerPubkey`
+ *      is missing — this matches the per-handler gate in
+ *      `assertCallerEquals` and surfaces a single canonical reason to the
+ *      BAP regardless of which layer rejected the request.
+ *
+ * Today the per-capability handlers are still stubs (see `STUB_REASONS`),
+ * and the BPP runtime's `TaskRequest` shape does NOT yet carry a
+ * gateway-verified `callerPubkey` field — `req.bapPubkey` is informational
+ * only until FN-073 / FN-075 wire BAP-signature verification at the
+ * gateway. {@link extractCallerPubkey} therefore returns `undefined` for
+ * every real request, and the dispatcher continues to short-circuit via
+ * `STUB_REASONS` so existing flows are not broken pre-gateway-plumbing.
+ *
+ * @see FN-073 / FN-075 — gateway BAP-signature plumbing that will populate
+ *   the verified caller pubkey on `TaskRequest`.
+ * @see FN-034 — apply this contract to wire / offramp / onramp /
+ *   open-savings handlers once the envelope is wired through here.
+ */
+export function extractCallerPubkey(
+  req: TaskRequest<unknown>,
+): string | undefined {
+  // FN-073 / FN-075 will extend `TaskRequest` (or a sibling envelope) with
+  // a verified `callerPubkey` field. Until then we read it defensively so
+  // that test fixtures and future gateway plumbing can populate it without
+  // requiring a synchronised type change here.
+  const candidate = (req as { readonly callerPubkey?: unknown }).callerPubkey;
+  if (typeof candidate === "string" && candidate.length > 0) {
+    return candidate;
+  }
+  return undefined;
+}
+
+/* -------------------------------------------------------------------------- */
 /* createBankHandler                                                           */
 /* -------------------------------------------------------------------------- */
 
@@ -88,6 +137,10 @@ const STUB_REASONS: StubMap = {
  * stub `not_implemented` failures for the five bank capabilities.
  *
  * Unknown actions return an `unknown_action` failure.
+ *
+ * See {@link extractCallerPubkey} and the FN-015 caller-authentication
+ * contract for how this dispatcher will thread `callerPubkey` to
+ * per-capability handlers once FN-073 / FN-075 land.
  */
 export function createBankHandler(
   deps: BankHandlerDeps = {},
@@ -101,10 +154,19 @@ export function createBankHandler(
       req: TaskRequest<unknown>,
     ): Promise<TaskResult<unknown>> {
       const action = req.action;
+      const callerPubkey = extractCallerPubkey(req);
 
       // Check if action is one of the known capability keys
       if ((BANK_CAPABILITY_KEYS as readonly string[]).includes(action)) {
         const key = action as BankCapabilityKey;
+        // TODO(gateway-auth, FN-015): once per-capability handlers replace
+        // their stub returns, wrap `req.input` as
+        //   { callerPubkey, body: req.input }
+        // and invoke the real handler. If `callerPubkey` is `undefined`
+        // here, fail-closed with `UNAUTHORIZED_CALLER_REASON` BEFORE
+        // calling the handler — the per-handler `assertCallerEquals`
+        // gate is the second line of defence, not the first.
+        void callerPubkey;
         return {
           status: "failure",
           reason: STUB_REASONS[key],
@@ -119,3 +181,7 @@ export function createBankHandler(
     },
   };
 }
+
+// Re-export so downstream callers / tests can reference the canonical
+// reason without reaching into `./auth.js` directly.
+export { UNAUTHORIZED_CALLER_REASON };

--- a/keeper/bpps/bank/handlers/fee.correctness.test.ts
+++ b/keeper/bpps/bank/handlers/fee.correctness.test.ts
@@ -240,6 +240,7 @@ const ONRAMP_TOKEN_PDA = 'b'.repeat(64);
  */
 function makeOnrampRequest(gross_eusd_atomic: number): OnrampRequest {
   return {
+    caller_pubkey: ONRAMP_RECIPIENT, // FN-034: caller MUST equal recipient
     recipient: ONRAMP_RECIPIENT,
     recipient_token_account_pda: ONRAMP_TOKEN_PDA,
     usd_amount_cents: gross_eusd_atomic / 10_000,
@@ -274,6 +275,7 @@ const DOMESTIC_DEST: OfframpRequest['destination'] = {
 
 function makeOfframpRequest(eusd_amount_atomic: number): OfframpRequest {
   return {
+    caller_pubkey: OFFRAMP_HOLDER, // FN-034: caller MUST equal holder
     holder: OFFRAMP_HOLDER,
     holder_token_account_pda: OFFRAMP_HOLDER_TOKEN_PDA,
     eusd_amount_atomic,

--- a/keeper/bpps/bank/handlers/index.ts
+++ b/keeper/bpps/bank/handlers/index.ts
@@ -11,6 +11,16 @@
 //             stubRemitToTreasury, type RemitToTreasury }
 //     from "@eto/mcp/keeper/bpps/bank/handlers";
 
+// FN-015: shared caller-authentication contract for bank BPP handlers
+export {
+  assertCallerEquals,
+  UNAUTHORIZED_CALLER_REASON,
+} from "../auth.js";
+export type {
+  AuthenticatedRequest,
+  UnauthorizedCallerReason,
+} from "../auth.js";
+
 // FN-109: 1-pip fee math and treasury remittance
 export {
   ONE_BIP_DIVISOR,

--- a/keeper/bpps/bank/handlers/issue-card.flag-reconciliation.test.ts
+++ b/keeper/bpps/bank/handlers/issue-card.flag-reconciliation.test.ts
@@ -28,10 +28,13 @@ function baseDeps(): IssueCardDeps {
 }
 
 const req = {
-  subject: SUBJECT,
-  bank_issuer: BANK,
-  linked_account_pda: LINKED,
-  issued_slot: 1_000_000,
+  callerPubkey: SUBJECT,
+  body: {
+    subject: SUBJECT,
+    bank_issuer: BANK,
+    linked_account_pda: LINKED,
+    issued_slot: 1_000_000,
+  },
 };
 
 describe("FN-191 — issue-card flagReconciliation", () => {

--- a/keeper/bpps/bank/handlers/issue-card.test.ts
+++ b/keeper/bpps/bank/handlers/issue-card.test.ts
@@ -3,6 +3,7 @@
  */
 
 import { describe, it, expect, vi } from "vitest";
+import type { AuthenticatedRequest } from "../auth.js";
 import {
   issueCard,
   stubs,
@@ -20,7 +21,7 @@ const SUBJECT = "a".repeat(64);
 const BANK_ISSUER = "b".repeat(64);
 const LINKED_ACCOUNT_PDA = "c".repeat(64);
 
-function makeRequest(overrides: Partial<IssueCardRequest> = {}): IssueCardRequest {
+function makeBody(overrides: Partial<IssueCardRequest> = {}): IssueCardRequest {
   return {
     subject: SUBJECT,
     bank_issuer: BANK_ISSUER,
@@ -28,6 +29,13 @@ function makeRequest(overrides: Partial<IssueCardRequest> = {}): IssueCardReques
     issued_slot: 1_000_000,
     ...overrides,
   };
+}
+
+function makeRequest(
+  overrides: Partial<IssueCardRequest> = {},
+  callerPubkey: string = SUBJECT,
+): AuthenticatedRequest<IssueCardRequest> {
+  return { callerPubkey, body: makeBody(overrides) };
 }
 
 function makeDeps(overrides: Partial<IssueCardDeps> = {}): IssueCardDeps {
@@ -39,6 +47,7 @@ function makeDeps(overrides: Partial<IssueCardDeps> = {}): IssueCardDeps {
       credential_pda: "e".repeat(64),
     }),
     recordCard: vi.fn().mockResolvedValue(undefined),
+    flagReconciliation: vi.fn().mockResolvedValue(undefined),
     ...overrides,
   };
 }
@@ -67,6 +76,50 @@ describe("issueCard — happy path", () => {
     const result = await issueCard(makeRequest(), makeDeps());
     expect(result.credential.subject).toBe(SUBJECT);
     expect(result.credential.issuer).toBe(BANK_ISSUER);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Caller authentication (FN-015)
+// ---------------------------------------------------------------------------
+
+describe("issueCard — caller authentication", () => {
+  it("happy path: callerPubkey === body.subject succeeds", async () => {
+    const result = await issueCard(makeRequest({}, SUBJECT), makeDeps());
+    expect(result.card_pda).toMatch(/^[0-9a-f]{64}$/);
+  });
+
+  it("rejects with unauthorized_caller when callerPubkey !== body.subject", async () => {
+    const deps = makeDeps();
+    await expect(
+      issueCard(makeRequest({}, "d".repeat(64)), deps),
+    ).rejects.toMatchObject({ reason: "unauthorized_caller" });
+  });
+
+  it("does NOT invoke any dep when callerPubkey mismatches", async () => {
+    const deps = makeDeps();
+    await expect(
+      issueCard(makeRequest({}, "d".repeat(64)), deps),
+    ).rejects.toBeDefined();
+    expect(deps.verifyHolderCredentials).not.toHaveBeenCalled();
+    expect(deps.verifyLinkedAccount).not.toHaveBeenCalled();
+    expect(deps.recordCard).not.toHaveBeenCalled();
+    expect(deps.issueCardCredential).not.toHaveBeenCalled();
+    expect(deps.flagReconciliation).not.toHaveBeenCalled();
+  });
+
+  it("rejects with unauthorized_caller when callerPubkey is empty string", async () => {
+    const deps = makeDeps();
+    await expect(
+      issueCard(makeRequest({}, ""), deps),
+    ).rejects.toMatchObject({ reason: "unauthorized_caller" });
+    expect(deps.verifyHolderCredentials).not.toHaveBeenCalled();
+  });
+
+  it("matches case-insensitively over hex (uppercase caller, lowercase subject)", async () => {
+    const upper = SUBJECT.toUpperCase();
+    const result = await issueCard(makeRequest({}, upper), makeDeps());
+    expect(result.credential.subject).toBe(SUBJECT);
   });
 });
 
@@ -142,8 +195,10 @@ describe("issueCard — defaults", () => {
 
 describe("issueCard — validation: invalid_pubkey", () => {
   it("throws invalid_pubkey for bad subject (too short)", async () => {
+    // FN-015: callerPubkey must match body.subject for the validation
+    // gate to be exercised at all; here both sides are the (bad) value.
     await expect(
-      issueCard(makeRequest({ subject: "abc" }), makeDeps()),
+      issueCard(makeRequest({ subject: "abc" }, "abc"), makeDeps()),
     ).rejects.toMatchObject({ reason: "invalid_pubkey" });
   });
 
@@ -160,8 +215,9 @@ describe("issueCard — validation: invalid_pubkey", () => {
   });
 
   it("throws invalid_pubkey for 65-char hex subject", async () => {
+    const long = "a".repeat(65);
     await expect(
-      issueCard(makeRequest({ subject: "a".repeat(65) }), makeDeps()),
+      issueCard(makeRequest({ subject: long }, long), makeDeps()),
     ).rejects.toMatchObject({ reason: "invalid_pubkey" });
   });
 });
@@ -361,8 +417,10 @@ describe("issueCard — PDA determinism", () => {
   });
 
   it("differing subject → different card_pda", async () => {
-    const r1 = await issueCard(makeRequest({ subject: "a".repeat(64) }), makeDeps());
-    const r2 = await issueCard(makeRequest({ subject: "b".repeat(64) }), makeDeps());
+    const A = "a".repeat(64);
+    const B = "b".repeat(64);
+    const r1 = await issueCard(makeRequest({ subject: A }, A), makeDeps());
+    const r2 = await issueCard(makeRequest({ subject: B }, B), makeDeps());
     expect(r1.card_pda).not.toBe(r2.card_pda);
   });
 

--- a/keeper/bpps/bank/handlers/issue-card.ts
+++ b/keeper/bpps/bank/handlers/issue-card.ts
@@ -36,6 +36,11 @@ import {
   type IssueCardInput,
   BankIssuerError,
 } from "../../../../src/issuers/bank.js";
+import {
+  assertCallerEquals,
+  UNAUTHORIZED_CALLER_REASON,
+  type AuthenticatedRequest,
+} from "../auth.js";
 import { defaultBankLedger } from "../credential-ledger.js";
 
 // ---------------------------------------------------------------------------
@@ -175,6 +180,7 @@ export interface IssueCardDeps {
 // ---------------------------------------------------------------------------
 
 export type IssueCardRejectedReason =
+  | "unauthorized_caller"
   | "invalid_pubkey"
   | "invalid_jurisdiction"
   | "invalid_limit"
@@ -214,21 +220,41 @@ function sha256(...parts: Buffer[]): string {
 /**
  * Issue a `card.debit.<jurisdiction>.v1` credential against an existing
  * CheckingAccount. Returns `{ card_pda, credential, fulfillment_uri }`.
+ *
+ * FN-015: caller-message-authorship authentication is enforced FIRST,
+ * before any validation, credential gate, ledger write, or chain call.
+ * `req.callerPubkey` (sourced by the gateway from BAP signature
+ * verification) MUST equal `req.body.subject` — otherwise the handler
+ * rejects with `unauthorized_caller` and NO downstream side effect runs.
+ *
+ * NOTE: `verifyHolderCredentials`, `verifyLinkedAccount`, and the
+ * adapter-side `cred.issuer === bankIssuer.issuerAuthorityPubkey` check
+ * are credential-validity guards, NOT caller authentication. See
+ * `keeper/bpps/bank/auth.ts`.
  */
 export async function issueCard(
-  req: IssueCardRequest,
+  req: AuthenticatedRequest<IssueCardRequest>,
   deps: IssueCardDeps,
 ): Promise<IssueCardResult> {
+  // --- Caller-authentication (FN-015) — FIRST, before any side effect ---
+  try {
+    assertCallerEquals(req.callerPubkey, req.body.subject);
+  } catch {
+    throw new IssueCardRejected(UNAUTHORIZED_CALLER_REASON);
+  }
+
+  const body_in = req.body;
+
   // --- Defaults ---
-  const jurisdiction = req.jurisdiction ?? "us";
-  const spending_limit_per_day = req.spending_limit_per_day_atomic ?? 5_000_000_000;
-  const spending_limit_per_tx = req.spending_limit_per_tx_atomic ?? 500_000_000;
-  const expires_slot = req.expires_slot ?? 0;
+  const jurisdiction = body_in.jurisdiction ?? "us";
+  const spending_limit_per_day = body_in.spending_limit_per_day_atomic ?? 5_000_000_000;
+  const spending_limit_per_tx = body_in.spending_limit_per_tx_atomic ?? 500_000_000;
+  const expires_slot = body_in.expires_slot ?? 0;
 
   // --- Validation ---
-  if (!HEX64.test(req.subject)) throw new IssueCardRejected("invalid_pubkey");
-  if (!HEX64.test(req.bank_issuer)) throw new IssueCardRejected("invalid_pubkey");
-  if (!HEX64.test(req.linked_account_pda)) throw new IssueCardRejected("invalid_pubkey");
+  if (!HEX64.test(body_in.subject)) throw new IssueCardRejected("invalid_pubkey");
+  if (!HEX64.test(body_in.bank_issuer)) throw new IssueCardRejected("invalid_pubkey");
+  if (!HEX64.test(body_in.linked_account_pda)) throw new IssueCardRejected("invalid_pubkey");
 
   if (!JURISDICTION_RE.test(jurisdiction)) throw new IssueCardRejected("invalid_jurisdiction");
 
@@ -243,19 +269,19 @@ export async function issueCard(
   if (spending_limit_per_tx > spending_limit_per_day) throw new IssueCardRejected("invalid_limit");
 
   // --- On-chain credential gate ---
-  const credentialsOk = await deps.verifyHolderCredentials(req.subject, REQUIRED_SCHEMAS);
+  const credentialsOk = await deps.verifyHolderCredentials(body_in.subject, REQUIRED_SCHEMAS);
   if (!credentialsOk) throw new IssueCardRejected("credentials_missing");
 
   // --- Linked account gate ---
-  const accountOk = await deps.verifyLinkedAccount(req.linked_account_pda, req.subject);
+  const accountOk = await deps.verifyLinkedAccount(body_in.linked_account_pda, body_in.subject);
   if (!accountOk) throw new IssueCardRejected("account_not_found");
 
   // --- PDA derivation ---
   const card_pda = sha256(
     Buffer.from("card_debit", "utf8"),
-    Buffer.from(req.subject, "hex"),
-    Buffer.from(req.linked_account_pda, "hex"),
-    u64BE(req.issued_slot),
+    Buffer.from(body_in.subject, "hex"),
+    Buffer.from(body_in.linked_account_pda, "hex"),
+    u64BE(body_in.issued_slot),
   );
 
   // --- card_id_hash — explicit stub salt; NO real PAN material ---
@@ -265,26 +291,26 @@ export async function issueCard(
   );
 
   const body: CardDebitCredentialBody = {
-    holder: req.subject,
-    linked_account_pda: req.linked_account_pda,
+    holder: body_in.subject,
+    linked_account_pda: body_in.linked_account_pda,
     jurisdiction,
     card_id_hash,
-    issued_slot: req.issued_slot,
+    issued_slot: body_in.issued_slot,
     expires_slot,
     spending_limit_per_day,
     spending_limit_per_tx,
     network_brand: "internal",
     tier: "standard",
-    ...(req.merchant_category_blocklist !== undefined &&
-    req.merchant_category_blocklist.length > 0
-      ? { merchant_category_blocklist: req.merchant_category_blocklist }
+    ...(body_in.merchant_category_blocklist !== undefined &&
+    body_in.merchant_category_blocklist.length > 0
+      ? { merchant_category_blocklist: body_in.merchant_category_blocklist }
       : {}),
   };
 
   const credential: IssueCardCredential = {
     schema: `card.debit.${jurisdiction}.v1`,
-    subject: req.subject,
-    issuer: req.bank_issuer,
+    subject: body_in.subject,
+    issuer: body_in.bank_issuer,
     body,
   };
 

--- a/keeper/bpps/bank/handlers/offramp.test.ts
+++ b/keeper/bpps/bank/handlers/offramp.test.ts
@@ -33,6 +33,7 @@ const INTL_DEST: OfframpRequest['destination'] = {
 
 function makeRequest(overrides: Partial<OfframpRequest> = {}): OfframpRequest {
   return {
+    caller_pubkey: HOLDER, // FN-034: caller MUST equal holder
     holder: HOLDER,
     holder_token_account_pda: HOLDER_TOKEN_PDA,
     eusd_amount_atomic: 100_000_000,
@@ -151,6 +152,34 @@ describe('executeOfframp — invalid_pubkey', () => {
     const deps = makeDeps();
     await expect(executeOfframp(makeRequest({ holder_token_account_pda: '00' }), deps))
       .rejects.toMatchObject({ reason: 'invalid_pubkey' });
+  });
+});
+
+describe('executeOfframp — caller-binding (FN-034)', () => {
+  it('rejects when caller_pubkey != holder with caller_mismatch', async () => {
+    const deps = makeDeps();
+    const attacker = 'f'.repeat(64);
+    await expect(
+      executeOfframp(makeRequest({ caller_pubkey: attacker }), deps),
+    ).rejects.toMatchObject({ reason: 'caller_mismatch' });
+  });
+
+  it('rejects without invoking burnOnChain / pushUsd / remitToTreasury', async () => {
+    const deps = makeDeps();
+    const attacker = 'f'.repeat(64);
+    await expect(
+      executeOfframp(makeRequest({ caller_pubkey: attacker }), deps),
+    ).rejects.toBeInstanceOf(OfframpRejected);
+    expect(deps.burnOnChain).not.toHaveBeenCalled();
+    expect(deps.pushUsd).not.toHaveBeenCalled();
+    expect(deps.remitToTreasury).not.toHaveBeenCalled();
+  });
+
+  it('rejects when caller_pubkey is not a valid hex64 with invalid_pubkey', async () => {
+    const deps = makeDeps();
+    await expect(
+      executeOfframp(makeRequest({ caller_pubkey: 'tooshort' }), deps),
+    ).rejects.toMatchObject({ reason: 'invalid_pubkey' });
   });
 });
 

--- a/keeper/bpps/bank/handlers/offramp.ts
+++ b/keeper/bpps/bank/handlers/offramp.ts
@@ -37,6 +37,13 @@ import {
 } from './fee.js';
 
 export interface OfframpRequest {
+  /**
+   * FN-034: authenticated caller pubkey (hex). MUST equal `holder` —
+   * any mismatch is rejected with `caller_mismatch` before any side-effect
+   * runs. Without this binding, an unauthenticated caller could burn eUSD
+   * and push USD on behalf of any subject.
+   */
+  caller_pubkey: string;
   holder: string;                     // hex pubkey burning eUSD
   holder_token_account_pda: string;   // hex — TokenAccount being burned from
   eusd_amount_atomic: number;         // atomic eUSD units (1 eUSD = 1_000_000)
@@ -84,7 +91,7 @@ export interface OfframpDeps {
 }
 
 export class OfframpRejected extends Error {
-  constructor(public reason: 'invalid_pubkey' | 'invalid_amount' | 'destination_invalid' | 'burn_failed' | 'push_failed_post_burn') {
+  constructor(public reason: 'invalid_pubkey' | 'caller_mismatch' | 'invalid_amount' | 'destination_invalid' | 'burn_failed' | 'push_failed_post_burn') {
     super('offramp rejected: ' + reason);
   }
 }
@@ -97,8 +104,13 @@ function atomicEusdToUsdCents(atomic: number): number {
 }
 
 export async function executeOfframp(req: OfframpRequest, deps: OfframpDeps): Promise<OfframpOutcome> {
+  if (!HEX64.test(req.caller_pubkey)) throw new OfframpRejected('invalid_pubkey');
   if (!HEX64.test(req.holder)) throw new OfframpRejected('invalid_pubkey');
   if (!HEX64.test(req.holder_token_account_pda)) throw new OfframpRejected('invalid_pubkey');
+  // FN-034: caller-binding. Reject before any side-effect when the caller
+  // is not the holder; otherwise an unauth'd caller could burn another
+  // subject's eUSD and direct the USD push.
+  if (req.caller_pubkey !== req.holder) throw new OfframpRejected('caller_mismatch');
   if (!Number.isInteger(req.eusd_amount_atomic) || req.eusd_amount_atomic <= 0) throw new OfframpRejected('invalid_amount');
   if (!req.destination.account_holder_name) throw new OfframpRejected('destination_invalid');
   // At least one routing pair must be present

--- a/keeper/bpps/bank/handlers/onramp.test.ts
+++ b/keeper/bpps/bank/handlers/onramp.test.ts
@@ -21,6 +21,7 @@ const TOKEN_PDA = 'b'.repeat(64);
 
 function makeRequest(overrides: Partial<OnrampRequest> = {}): OnrampRequest {
   return {
+    caller_pubkey: RECIPIENT, // FN-034: caller MUST equal recipient
     recipient: RECIPIENT,
     recipient_token_account_pda: TOKEN_PDA,
     usd_amount_cents: 10_000,        // $100.00
@@ -137,6 +138,34 @@ describe('executeOnramp — invalid_pubkey', () => {
     const deps = makeDeps();
     await expect(executeOnramp(makeRequest({ recipient_token_account_pda: 'bad' }), deps))
       .rejects.toMatchObject({ reason: 'invalid_pubkey' });
+  });
+});
+
+describe('executeOnramp — caller-binding (FN-034)', () => {
+  it('rejects when caller_pubkey != recipient with caller_mismatch', async () => {
+    const deps = makeDeps();
+    const attacker = 'f'.repeat(64);
+    await expect(
+      executeOnramp(makeRequest({ caller_pubkey: attacker }), deps),
+    ).rejects.toMatchObject({ reason: 'caller_mismatch' });
+  });
+
+  it('rejects without invoking verifyUsdPull / mintOnChain / remitToTreasury', async () => {
+    const deps = makeDeps();
+    const attacker = 'f'.repeat(64);
+    await expect(
+      executeOnramp(makeRequest({ caller_pubkey: attacker }), deps),
+    ).rejects.toBeInstanceOf(OnrampRejected);
+    expect(deps.verifyUsdPull).not.toHaveBeenCalled();
+    expect(deps.mintOnChain).not.toHaveBeenCalled();
+    expect(deps.remitToTreasury).not.toHaveBeenCalled();
+  });
+
+  it('rejects when caller_pubkey is not a valid hex64 with invalid_pubkey', async () => {
+    const deps = makeDeps();
+    await expect(
+      executeOnramp(makeRequest({ caller_pubkey: 'tooshort' }), deps),
+    ).rejects.toMatchObject({ reason: 'invalid_pubkey' });
   });
 });
 

--- a/keeper/bpps/bank/handlers/onramp.ts
+++ b/keeper/bpps/bank/handlers/onramp.ts
@@ -5,7 +5,7 @@
  *   [{ id: 'onramp-eusd', ... }].
  * Outbound: signs CompleteTask with the minted eUSD amount in the
  *   fulfillment_uri, having verified the USD pull and submitted an
- *   on-chain Mint instruction (FN-103).
+ *   on-chain Mint instruction.
  *
  * 2-phase flow:
  *   Phase 1 — verify USD pull cleared (mocked in v0: always succeeds).
@@ -55,7 +55,7 @@ export interface OnrampOutcome {
 export interface OnrampDeps {
   /** Verify the USD pull cleared. STUB always returns true in v0. */
   verifyUsdPull: (method: OnrampRequest['funding_method'], ref: string, cents: number) => Promise<boolean>;
-  /** Submit on-chain Mint instruction (FN-103). STUBBED. */
+  /** Submit on-chain Mint instruction. STUBBED. */
   mintOnChain: (args: { recipient_token_pda: string; amount: number }) => Promise<{ tx_signature: string }>;
   /**
    * 1-pip fee per FN-109 (0.01% = 1 bp). Defaults to `oneBipFee` from fee.ts.

--- a/keeper/bpps/bank/handlers/onramp.ts
+++ b/keeper/bpps/bank/handlers/onramp.ts
@@ -26,6 +26,13 @@ import {
 } from './fee.js';
 
 export interface OnrampRequest {
+  /**
+   * FN-034: authenticated caller pubkey (hex). MUST equal `recipient` —
+   * any mismatch is rejected with `caller_mismatch` before any side-effect
+   * runs. Without this binding, an unauthenticated caller could direct a
+   * mint of eUSD into any subject's TokenAccount.
+   */
+  caller_pubkey: string;
   recipient: string;                     // hex pubkey — receives the eUSD
   recipient_token_account_pda: string;   // hex — TokenAccount PDA
   usd_amount_cents: number;              // amount in USD cents (1000 = $10.00)
@@ -64,7 +71,7 @@ export interface OnrampDeps {
 }
 
 export class OnrampRejected extends Error {
-  constructor(public reason: 'invalid_pubkey' | 'invalid_amount' | 'usd_pull_failed' | 'mint_failed') {
+  constructor(public reason: 'invalid_pubkey' | 'caller_mismatch' | 'invalid_amount' | 'usd_pull_failed' | 'mint_failed') {
     super('onramp rejected: ' + reason);
   }
 }
@@ -78,8 +85,13 @@ function usdCentsToAtomicEusd(cents: number): number {
 }
 
 export async function executeOnramp(req: OnrampRequest, deps: OnrampDeps): Promise<OnrampOutcome> {
+  if (!HEX64.test(req.caller_pubkey)) throw new OnrampRejected('invalid_pubkey');
   if (!HEX64.test(req.recipient)) throw new OnrampRejected('invalid_pubkey');
   if (!HEX64.test(req.recipient_token_account_pda)) throw new OnrampRejected('invalid_pubkey');
+  // FN-034: caller-binding. Reject before any side-effect when the caller
+  // is not the recipient; otherwise an unauth'd caller could direct a
+  // mint into any subject's account.
+  if (req.caller_pubkey !== req.recipient) throw new OnrampRejected('caller_mismatch');
   if (!Number.isInteger(req.usd_amount_cents) || req.usd_amount_cents <= 0) throw new OnrampRejected('invalid_amount');
 
   const eusd_gross = usdCentsToAtomicEusd(req.usd_amount_cents);

--- a/keeper/bpps/bank/handlers/open-checking.flag-reconciliation.test.ts
+++ b/keeper/bpps/bank/handlers/open-checking.flag-reconciliation.test.ts
@@ -26,10 +26,13 @@ function baseDeps(): OpenCheckingDeps {
 }
 
 const req = {
-  subject: SUBJECT,
-  bank_issuer: BANK,
-  opened_slot: 1_000_000,
-  opening_deposit_atomic: 5_000_000,
+  callerPubkey: SUBJECT,
+  body: {
+    subject: SUBJECT,
+    bank_issuer: BANK,
+    opened_slot: 1_000_000,
+    opening_deposit_atomic: 5_000_000,
+  },
 };
 
 describe("FN-191 — open-checking flagReconciliation", () => {

--- a/keeper/bpps/bank/handlers/open-checking.test.ts
+++ b/keeper/bpps/bank/handlers/open-checking.test.ts
@@ -3,6 +3,7 @@
  */
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { AuthenticatedRequest } from '../auth.js';
 import {
   openChecking,
   stubs,
@@ -19,7 +20,7 @@ import {
 const SUBJECT = 'a'.repeat(64);
 const ISSUER = 'c'.repeat(64);
 
-function makeRequest(overrides: Partial<OpenCheckingRequest> = {}): OpenCheckingRequest {
+function makeBody(overrides: Partial<OpenCheckingRequest> = {}): OpenCheckingRequest {
   return {
     subject: SUBJECT,
     bank_issuer: ISSUER,
@@ -28,11 +29,19 @@ function makeRequest(overrides: Partial<OpenCheckingRequest> = {}): OpenChecking
   };
 }
 
+function makeRequest(
+  overrides: Partial<OpenCheckingRequest> = {},
+  callerPubkey: string = SUBJECT,
+): AuthenticatedRequest<OpenCheckingRequest> {
+  return { callerPubkey, body: makeBody(overrides) };
+}
+
 function makeDeps(overrides: Partial<OpenCheckingDeps> = {}): OpenCheckingDeps {
   return {
     verifyHolderCredentials: vi.fn().mockResolvedValue(true),
     issueCheckingCredential: vi.fn().mockResolvedValue({ tx_signature: 'sig'.repeat(21).slice(0, 64), credential_pda: 'd'.repeat(64) }),
     recordCheckingAccount: vi.fn().mockResolvedValue(undefined),
+    flagReconciliation: vi.fn().mockResolvedValue(undefined),
     ...overrides,
   };
 }
@@ -63,6 +72,49 @@ describe('openChecking — happy path', () => {
 });
 
 // ---------------------------------------------------------------------------
+// Caller authentication (FN-015)
+// ---------------------------------------------------------------------------
+
+describe('openChecking — caller authentication', () => {
+  it('happy path: callerPubkey === body.subject succeeds', async () => {
+    const result = await openChecking(makeRequest({}, SUBJECT), makeDeps());
+    expect(result.checking_account_pda).toMatch(/^[0-9a-f]{64}$/);
+  });
+
+  it('rejects with unauthorized_caller when callerPubkey !== body.subject', async () => {
+    const deps = makeDeps();
+    await expect(
+      openChecking(makeRequest({}, 'd'.repeat(64)), deps),
+    ).rejects.toMatchObject({ reason: 'unauthorized_caller' });
+  });
+
+  it('does NOT invoke any dep when caller mismatches', async () => {
+    const deps = makeDeps();
+    await expect(
+      openChecking(makeRequest({}, 'd'.repeat(64)), deps),
+    ).rejects.toBeDefined();
+    expect(deps.verifyHolderCredentials).not.toHaveBeenCalled();
+    expect(deps.recordCheckingAccount).not.toHaveBeenCalled();
+    expect(deps.issueCheckingCredential).not.toHaveBeenCalled();
+    expect(deps.flagReconciliation).not.toHaveBeenCalled();
+  });
+
+  it('rejects with unauthorized_caller when callerPubkey is empty', async () => {
+    const deps = makeDeps();
+    await expect(
+      openChecking(makeRequest({}, ''), deps),
+    ).rejects.toMatchObject({ reason: 'unauthorized_caller' });
+    expect(deps.verifyHolderCredentials).not.toHaveBeenCalled();
+  });
+
+  it('matches case-insensitively over hex', async () => {
+    const upper = SUBJECT.toUpperCase();
+    const result = await openChecking(makeRequest({}, upper), makeDeps());
+    expect(result.credential.subject).toBe(SUBJECT);
+  });
+});
+
+// ---------------------------------------------------------------------------
 // Default values
 // ---------------------------------------------------------------------------
 
@@ -87,13 +139,15 @@ describe('openChecking — defaults', () => {
 describe('openChecking — invalid_pubkey', () => {
   it('throws invalid_pubkey for short subject', async () => {
     const deps = makeDeps();
-    await expect(openChecking(makeRequest({ subject: 'tooshort' }), deps))
+    // FN-015: caller must match body.subject for validation gate to run.
+    await expect(openChecking(makeRequest({ subject: 'tooshort' }, 'tooshort'), deps))
       .rejects.toMatchObject({ reason: 'invalid_pubkey' });
   });
 
   it('throws invalid_pubkey for non-hex subject', async () => {
     const deps = makeDeps();
-    await expect(openChecking(makeRequest({ subject: 'z'.repeat(64) }), deps))
+    const z = 'z'.repeat(64);
+    await expect(openChecking(makeRequest({ subject: z }, z), deps))
       .rejects.toMatchObject({ reason: 'invalid_pubkey' });
   });
 

--- a/keeper/bpps/bank/handlers/open-checking.ts
+++ b/keeper/bpps/bank/handlers/open-checking.ts
@@ -28,6 +28,11 @@
 
 import { createHash } from 'node:crypto';
 
+import {
+  assertCallerEquals,
+  UNAUTHORIZED_CALLER_REASON,
+  type AuthenticatedRequest,
+} from '../auth.js';
 import { defaultBankLedger } from '../credential-ledger.js';
 
 export interface OpenCheckingRequest {
@@ -79,7 +84,7 @@ export interface OpenCheckingDeps {
 }
 
 export class OpenCheckingRejected extends Error {
-  constructor(public reason: 'invalid_pubkey' | 'invalid_deposit' | 'credentials_missing' | 'issue_failed' | 'ledger_failed') {
+  constructor(public reason: 'unauthorized_caller' | 'invalid_pubkey' | 'invalid_deposit' | 'credentials_missing' | 'issue_failed' | 'ledger_failed') {
     super('open-checking rejected: ' + reason);
   }
 }
@@ -89,31 +94,53 @@ const HEX64 = /^[0-9a-fA-F]{64}$/;
 /** Credential schemas required by the on-chain Network policy for this BPP. */
 export const REQUIRED_SCHEMAS = ['eto.beckn.schema.verified-human.v1', 'eto.beckn.schema.kyc.us-test.v1'];
 
-export async function openChecking(req: OpenCheckingRequest, deps: OpenCheckingDeps): Promise<OpenCheckingResult> {
-  if (!HEX64.test(req.subject)) throw new OpenCheckingRejected('invalid_pubkey');
-  if (!HEX64.test(req.bank_issuer)) throw new OpenCheckingRejected('invalid_pubkey');
-  const opening = req.opening_deposit_atomic ?? 0;
+/**
+ * FN-015: caller-message-authorship authentication is enforced FIRST,
+ * before any validation, credential gate, ledger write, or chain call.
+ * `req.callerPubkey` (sourced by the gateway from BAP signature
+ * verification) MUST equal `req.body.subject` — otherwise the handler
+ * rejects with `unauthorized_caller` and NO downstream side effect runs.
+ *
+ * NOTE: `verifyHolderCredentials` is a credential-validity guard, NOT
+ * caller authentication. See `keeper/bpps/bank/auth.ts`.
+ */
+export async function openChecking(
+  req: AuthenticatedRequest<OpenCheckingRequest>,
+  deps: OpenCheckingDeps,
+): Promise<OpenCheckingResult> {
+  // --- Caller-authentication (FN-015) — FIRST, before any side effect ---
+  try {
+    assertCallerEquals(req.callerPubkey, req.body.subject);
+  } catch {
+    throw new OpenCheckingRejected(UNAUTHORIZED_CALLER_REASON);
+  }
+
+  const body = req.body;
+
+  if (!HEX64.test(body.subject)) throw new OpenCheckingRejected('invalid_pubkey');
+  if (!HEX64.test(body.bank_issuer)) throw new OpenCheckingRejected('invalid_pubkey');
+  const opening = body.opening_deposit_atomic ?? 0;
   if (!Number.isInteger(opening) || opening < 0) throw new OpenCheckingRejected('invalid_deposit');
 
   // Defensive re-check (chain gate is authoritative; this guards against
   // mis-routed requests that bypass the on-chain Init gate).
-  const ok = await deps.verifyHolderCredentials(req.subject, REQUIRED_SCHEMAS);
+  const ok = await deps.verifyHolderCredentials(body.subject, REQUIRED_SCHEMAS);
   if (!ok) throw new OpenCheckingRejected('credentials_missing');
 
   const checking_account_pda = createHash('sha256')
     .update('checking_account')
-    .update(Buffer.from(req.subject, 'hex'))
-    .update(Buffer.from(BigInt(req.opened_slot).toString(16).padStart(16, '0'), 'hex'))
+    .update(Buffer.from(body.subject, 'hex'))
+    .update(Buffer.from(BigInt(body.opened_slot).toString(16).padStart(16, '0'), 'hex'))
     .digest('hex');
 
   const credential: OpenCheckingResult['credential'] = {
     schema: 'account.checking.v1',
-    subject: req.subject,
-    issuer: req.bank_issuer,
+    subject: body.subject,
+    issuer: body.bank_issuer,
     body: {
       account_pda: checking_account_pda,
-      holder: req.subject,
-      opened_slot: req.opened_slot,
+      holder: body.subject,
+      opened_slot: body.opened_slot,
       currency: 'eUSD',
       opening_balance: opening,
     },
@@ -122,8 +149,8 @@ export async function openChecking(req: OpenCheckingRequest, deps: OpenCheckingD
   // Side-effects (atomicity is best-effort in v0; real impl uses 2-phase commit)
   try {
     await deps.recordCheckingAccount(checking_account_pda, {
-      holder: req.subject,
-      opened_slot: req.opened_slot,
+      holder: body.subject,
+      opened_slot: body.opened_slot,
       opening_balance: opening,
     });
   } catch {
@@ -139,8 +166,8 @@ export async function openChecking(req: OpenCheckingRequest, deps: OpenCheckingD
     // throw — if it does, swallow: the primary issue_failed error is
     // what callers act on.
     try {
-      await deps.flagReconciliation(checking_account_pda, req.subject, {
-        opened_slot: req.opened_slot,
+      await deps.flagReconciliation(checking_account_pda, body.subject, {
+        opened_slot: body.opened_slot,
         opening_balance: opening,
       });
     } catch {

--- a/keeper/bpps/bank/handlers/open-savings.test.ts
+++ b/keeper/bpps/bank/handlers/open-savings.test.ts
@@ -21,6 +21,7 @@ const ISSUER = 'c'.repeat(64);
 
 function makeRequest(overrides: Partial<OpenSavingsRequest> = {}): OpenSavingsRequest {
   return {
+    caller_pubkey: SUBJECT, // FN-034: caller MUST equal subject
     subject: SUBJECT,
     linked_checking_account_pda: CHECKING_PDA,
     bank_issuer: ISSUER,
@@ -123,6 +124,34 @@ describe('openSavings — atomicity on failure', () => {
 // Validation errors
 // ---------------------------------------------------------------------------
 
+describe('openSavings — caller-binding (FN-034)', () => {
+  it('rejects when caller_pubkey != subject with caller_mismatch', async () => {
+    const deps = makeDeps();
+    const attacker = 'f'.repeat(64);
+    await expect(
+      openSavings(makeRequest({ caller_pubkey: attacker }), deps),
+    ).rejects.toMatchObject({ reason: 'caller_mismatch' });
+  });
+
+  it('rejects without invoking verifyCheckingCredential / recordSavingsAccount / issueSavingsCredential', async () => {
+    const deps = makeDeps();
+    const attacker = 'f'.repeat(64);
+    await expect(
+      openSavings(makeRequest({ caller_pubkey: attacker }), deps),
+    ).rejects.toBeInstanceOf(OpenSavingsRejected);
+    expect(deps.verifyCheckingCredential).not.toHaveBeenCalled();
+    expect(deps.recordSavingsAccount).not.toHaveBeenCalled();
+    expect(deps.issueSavingsCredential).not.toHaveBeenCalled();
+  });
+
+  it('rejects when caller_pubkey is not a valid hex64 with invalid_pda', async () => {
+    const deps = makeDeps();
+    await expect(
+      openSavings(makeRequest({ caller_pubkey: 'tooshort' }), deps),
+    ).rejects.toMatchObject({ reason: 'invalid_pda' });
+  });
+});
+
 describe('openSavings — invalid_pda', () => {
   it('throws invalid_pda for short subject', async () => {
     const deps = makeDeps();
@@ -203,8 +232,9 @@ describe('openSavings — PDA derivation', () => {
   });
 
   it('produces different PDAs when subject differs', async () => {
-    const result1 = await openSavings(makeRequest({ subject: 'a'.repeat(64) }), makeDeps());
-    const result2 = await openSavings(makeRequest({ subject: '1'.repeat(64) }), makeDeps());
+    // FN-034: caller_pubkey must equal subject, so override both together.
+    const result1 = await openSavings(makeRequest({ caller_pubkey: 'a'.repeat(64), subject: 'a'.repeat(64) }), makeDeps());
+    const result2 = await openSavings(makeRequest({ caller_pubkey: '1'.repeat(64), subject: '1'.repeat(64) }), makeDeps());
     expect(result1.savings_account_pda).not.toBe(result2.savings_account_pda);
   });
 });

--- a/keeper/bpps/bank/handlers/open-savings.ts
+++ b/keeper/bpps/bank/handlers/open-savings.ts
@@ -17,6 +17,13 @@
 import { createHash } from 'node:crypto';
 
 export interface OpenSavingsRequest {
+  /**
+   * FN-034: authenticated caller pubkey (hex). MUST equal `subject` —
+   * any mismatch is rejected with `caller_mismatch` before any side-effect
+   * runs. Without this binding, an unauthenticated caller could mint an
+   * `account.savings.v1` credential to any subject.
+   */
+  caller_pubkey: string;
   /** Subject pubkey (hex) — receives the credential and owns the account. */
   subject: string;
   /** Pubkey of the holder's existing CheckingAccount, required reference. */
@@ -66,16 +73,21 @@ export interface OpenSavingsDeps {
 }
 
 export class OpenSavingsRejected extends Error {
-  constructor(public reason: 'no_checking_credential' | 'invalid_pda' | 'invalid_tier' | 'invalid_apy') {
+  constructor(public reason: 'no_checking_credential' | 'invalid_pda' | 'caller_mismatch' | 'invalid_tier' | 'invalid_apy') {
     super('open-savings rejected: ' + reason);
   }
 }
 
 export async function openSavings(req: OpenSavingsRequest, deps: OpenSavingsDeps): Promise<OpenSavingsResult> {
   // Validate inputs
+  if (!/^[0-9a-fA-F]{64}$/.test(req.caller_pubkey)) throw new OpenSavingsRejected('invalid_pda');
   if (!/^[0-9a-fA-F]{64}$/.test(req.subject)) throw new OpenSavingsRejected('invalid_pda');
   if (!/^[0-9a-fA-F]{64}$/.test(req.linked_checking_account_pda)) throw new OpenSavingsRejected('invalid_pda');
   if (!/^[0-9a-fA-F]{64}$/.test(req.bank_issuer)) throw new OpenSavingsRejected('invalid_pda');
+  // FN-034: caller-binding. Reject before any side-effect when the caller
+  // is not the subject; otherwise an unauth'd caller could mint an
+  // account.savings credential bound to any subject.
+  if (req.caller_pubkey !== req.subject) throw new OpenSavingsRejected('caller_mismatch');
   const tier = req.tier ?? 'standard';
   if (!(['standard', 'premium', 'private'] as const).includes(tier)) throw new OpenSavingsRejected('invalid_tier');
   const apy_bps = req.apy_bps ?? 400;

--- a/keeper/bpps/bank/handlers/tax-1099-sketch.test.ts
+++ b/keeper/bpps/bank/handlers/tax-1099-sketch.test.ts
@@ -1,0 +1,504 @@
+/**
+ * Tests for the Tax 1099 BPP sketch handler (FN-087 / FN-132).
+ *
+ * The handler is a v0 sketch — no idempotency store, no real signing,
+ * no monetary totals. Tests below assert the behaviour the sketch
+ * actually has and leave `test.todo(...)` markers for the gaps that
+ * follow-up tasks (FN-023 / FN-034 / FN-117 / FN-118 / idempotency)
+ * are tracking.
+ *
+ * Test runner: vitest (matching `offramp.test.ts` / `wire.test.ts`).
+ */
+
+import { createHash } from 'node:crypto';
+
+import { describe, it, test, expect, vi } from 'vitest';
+
+import {
+  runTax1099Sketch,
+  buildTax1099Vc,
+  tax1099SchemaIdHex,
+  Tax1099SketchError,
+  defaultFirstSlotOfYear,
+  DEFAULT_SLOTS_PER_YEAR,
+} from './tax-1099-sketch.js';
+import type {
+  Tax1099SketchDeps,
+  Tax1099SketchRequest,
+  Tax1099VcEnvelope,
+} from './tax-1099-sketch.js';
+
+import { jcsCanonicalize } from '../../../../src/issuers/bank-mock.js';
+import type { AuditFeedJsonLd } from '../../../../src/services/indexer/audit-trail.js';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const AUTHORITY = 'AgntCard1111111111111111111111111111111111';
+const ISSUER_AUTH = 'IssuerAuth111111111111111111111111111111111';
+const NETWORK = 'NetworkAuth11111111111111111111111111111111';
+
+function sha256Hex(s: string): string {
+  return createHash('sha256').update(s, 'utf8').digest('hex');
+}
+
+function makeFeed(
+  authority: string,
+  opts: { kytCount?: number; revocationCount?: number } = {},
+): AuditFeedJsonLd {
+  const kytCount = opts.kytCount ?? 3;
+  const revocationCount = opts.revocationCount ?? 0;
+  return {
+    '@context': [
+      'https://www.w3.org/2018/credentials/v1',
+      'https://schema.eto.network/audit/v1',
+    ],
+    id: `urn:eto:audit:${authority}`,
+    type: ['VerifiableCredential', 'AuditTrailFeed'],
+    issuer: 'did:eto:indexer:audit-trail:v0',
+    issuanceDate: '2025-01-01T00:00:00.000Z',
+    credentialSubject: {
+      id: `did:eto:agentcard:${authority}`,
+      authority,
+      bounds: { sinceSlot: 0, untilSlot: 1_000_000 },
+      events: [
+        {
+          kind: 'kyt',
+          stage: 'init',
+          txSignature: 'sig1',
+          slot: 100,
+          timestamp: '2025-02-01T00:00:00Z',
+          counterparty: { party: 'bpp', authority: 'cp1', credPointers: [] },
+          selfCredPointers: [],
+        },
+      ],
+      summary: {
+        kytCount,
+        initCount: kytCount,
+        confirmCount: 0,
+        rateCount: 0,
+        revocationCount,
+      },
+    },
+  };
+}
+
+function makeRequest(
+  overrides: Partial<Tax1099SketchRequest> = {},
+): Tax1099SketchRequest {
+  return {
+    agentCardAuthority: AUTHORITY,
+    taxYear: 2025,
+    jurisdiction: 'US',
+    issuerAuthorityPubkey: ISSUER_AUTH,
+    networkPubkey: NETWORK,
+    ...overrides,
+  };
+}
+
+interface CallLog {
+  events: Array<'pin' | 'issue'>;
+  pinArgs: string[];
+  issueArgs: Array<Record<string, unknown>>;
+}
+
+function makeDeps(
+  overrides: Partial<Tax1099SketchDeps> = {},
+  log?: CallLog,
+): Tax1099SketchDeps {
+  const buildAuditFeed = vi.fn(async (authority: string) =>
+    makeFeed(authority),
+  );
+  const indexer = { buildAuditFeed } as unknown as Tax1099SketchDeps['indexer'];
+
+  const pinner: Tax1099SketchDeps['pinner'] = {
+    pin: vi.fn(async (jcs: string) => {
+      log?.events.push('pin');
+      log?.pinArgs.push(jcs);
+      return { uri: `ipfs://${sha256Hex(jcs).slice(0, 16)}` };
+    }),
+  };
+
+  const chain: Tax1099SketchDeps['chain'] = {
+    issueCredential: vi.fn(async (input) => {
+      log?.events.push('issue');
+      log?.issueArgs.push({ ...input });
+      return {
+        credentialPda: 'CredPda1111111111111111111111111111111111',
+        txSignature: 's'.repeat(64),
+      };
+    }),
+  };
+
+  const clock: Tax1099SketchDeps['clock'] = {
+    currentSlot: vi.fn(async () => 1n),
+  };
+
+  return {
+    indexer,
+    chain,
+    pinner,
+    clock,
+    nowUnix: () => 1_700_000_000,
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Happy path
+// ---------------------------------------------------------------------------
+
+describe('runTax1099Sketch — happy path', () => {
+  it('returns a Tax1099SketchResponse with the expected shape', async () => {
+    const log: CallLog = { events: [], pinArgs: [], issueArgs: [] };
+    const deps = makeDeps({}, log);
+    const req = makeRequest();
+
+    const res = await runTax1099Sketch(deps, req);
+
+    expect(res.status).toBe('issued');
+    expect(res.credentialPda).toMatch(/^CredPda/);
+    expect(res.txSignature).toHaveLength(64);
+    expect(res.claimUri).toMatch(/^ipfs:\/\//);
+    expect(res.claimHashHex).toMatch(/^[0-9a-f]{64}$/);
+    expect(res.schemaIdHex).toBe(tax1099SchemaIdHex('US', 2025));
+
+    // VC matches buildTax1099Vc shape
+    expect(res.vc.type).toEqual(['VerifiableCredential', 'Tax1099Credential']);
+    expect(res.vc.issuer).toBe('did:eto:bank:eto-reference');
+    expect(res.vc.credentialSubject.taxYear).toBe(2025);
+    expect(res.vc.credentialSubject.jurisdiction).toBe('US');
+    expect(res.vc.credentialSubject.id).toBe(
+      `did:eto:agentcard:${AUTHORITY}`,
+    );
+    expect(res.vc.evidence[0].type).toBe('EtoChainEventDigest');
+    expect(res.vc.proof?.proofValue).toBe('<unsigned-v0>');
+  });
+
+  it('claim_hash equals sha256(JCS(envelope without proof))', async () => {
+    const log: CallLog = { events: [], pinArgs: [], issueArgs: [] };
+    const deps = makeDeps({}, log);
+    const res = await runTax1099Sketch(deps, makeRequest());
+
+    const { proof, ...withoutProof } = res.vc as Tax1099VcEnvelope & {
+      proof?: unknown;
+    };
+    void proof;
+    const expected = sha256Hex(jcsCanonicalize(withoutProof));
+    expect(res.claimHashHex).toBe(expected);
+
+    // The bytes pinned are the JCS bytes (without proof) — same string the
+    // hash was taken over.
+    expect(log.pinArgs[0]).toBe(jcsCanonicalize(withoutProof));
+  });
+
+  it('forwards schemaIdHex and claim_hash into IssueCredential call', async () => {
+    const log: CallLog = { events: [], pinArgs: [], issueArgs: [] };
+    const deps = makeDeps({}, log);
+    const res = await runTax1099Sketch(deps, makeRequest());
+
+    expect(log.issueArgs).toHaveLength(1);
+    const issueArg = log.issueArgs[0]!;
+    expect(issueArg.schemaIdHex).toBe(res.schemaIdHex);
+    expect(issueArg.claimHashHex).toBe(res.claimHashHex);
+    expect(issueArg.subjectAgentCardPubkey).toBe(AUTHORITY);
+    expect(issueArg.validUntilSlot).toBe(0n);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Schema-id rule
+// ---------------------------------------------------------------------------
+
+describe('tax1099SchemaIdHex — schema-id rule', () => {
+  it('hashes "eto.beckn.schema.tax.1099.us.2025.v1" for US/2025', () => {
+    const expected = sha256Hex('eto.beckn.schema.tax.1099.us.2025.v1');
+    expect(tax1099SchemaIdHex('US', 2025)).toBe(expected);
+    expect(tax1099SchemaIdHex('US', 2025)).toMatch(/^[0-9a-f]{64}$/);
+  });
+
+  it('hashes "eto.beckn.schema.tax.1099.gb.2024.v1" for GB/2024', () => {
+    const expected = sha256Hex('eto.beckn.schema.tax.1099.gb.2024.v1');
+    expect(tax1099SchemaIdHex('GB', 2024)).toBe(expected);
+  });
+
+  it('normalises uppercase jurisdiction to lowercase before hashing', () => {
+    expect(tax1099SchemaIdHex('US', 2025)).toBe(
+      tax1099SchemaIdHex('us', 2025),
+    );
+    expect(tax1099SchemaIdHex('Gb', 2024)).toBe(
+      tax1099SchemaIdHex('gb', 2024),
+    );
+  });
+
+  it('different (jurisdiction, year) pairs hash to different ids', () => {
+    expect(tax1099SchemaIdHex('US', 2025)).not.toBe(
+      tax1099SchemaIdHex('US', 2024),
+    );
+    expect(tax1099SchemaIdHex('US', 2025)).not.toBe(
+      tax1099SchemaIdHex('GB', 2025),
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// JCS hash stability
+// ---------------------------------------------------------------------------
+
+describe('runTax1099Sketch — JCS hash stability', () => {
+  it('identical inputs (and pinned now) produce identical claim_hash', async () => {
+    const deps1 = makeDeps();
+    const deps2 = makeDeps();
+    const req = makeRequest();
+
+    const r1 = await runTax1099Sketch(deps1, req);
+    const r2 = await runTax1099Sketch(deps2, req);
+
+    expect(r1.claimHashHex).toBe(r2.claimHashHex);
+  });
+
+  it('mutating proof.proofValue does NOT change the hashed bytes', async () => {
+    // Build a VC and hash it without the proof — the placeholder
+    // `<unsigned-v0>` MUST be excluded.
+    const vc = buildTax1099Vc({
+      agentCardAuthority: AUTHORITY,
+      taxYear: 2025,
+      jurisdiction: 'US',
+      currency: 'USD',
+      formVariant: '1099-MISC',
+      totals: {
+        totalIncome: '0.00',
+        totalFees: '0.00',
+        totalInterestPaid: '0.00',
+        totalWithholding: '0.00',
+        transactionCount: 0,
+        digestRootBase58: '1111',
+      },
+      issuerAuthorityPubkey: ISSUER_AUTH,
+      networkPubkey: NETWORK,
+      nowUnix: 1_700_000_000,
+    });
+
+    const stripProof = (v: Tax1099VcEnvelope) => {
+      const { proof, ...rest } = v as Tax1099VcEnvelope & { proof?: unknown };
+      void proof;
+      return rest;
+    };
+
+    const baseHash = sha256Hex(jcsCanonicalize(stripProof(vc)));
+
+    const mutated = {
+      ...vc,
+      proof: { ...vc.proof!, proofValue: 'OTHER-PLACEHOLDER-VALUE' },
+    } as Tax1099VcEnvelope;
+    const mutatedHash = sha256Hex(jcsCanonicalize(stripProof(mutated)));
+
+    expect(mutatedHash).toBe(baseHash);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Error paths — every Tax1099SketchErrorKind discriminant is exercised.
+// ---------------------------------------------------------------------------
+
+describe('runTax1099Sketch — invalid_request', () => {
+  it('rejects empty agentCardAuthority', async () => {
+    await expect(
+      runTax1099Sketch(makeDeps(), makeRequest({ agentCardAuthority: '' })),
+    ).rejects.toThrow(Tax1099SketchError);
+    await expect(
+      runTax1099Sketch(makeDeps(), makeRequest({ agentCardAuthority: '' })),
+    ).rejects.toMatchObject({ kind: 'invalid_request', reason: 'empty_authority' });
+  });
+
+  it('rejects taxYear < 2024', async () => {
+    await expect(
+      runTax1099Sketch(makeDeps(), makeRequest({ taxYear: 2023 })),
+    ).rejects.toMatchObject({ kind: 'invalid_request', reason: 'invalid_tax_year' });
+  });
+
+  it('rejects non-integer taxYear', async () => {
+    await expect(
+      runTax1099Sketch(makeDeps(), makeRequest({ taxYear: 2025.5 })),
+    ).rejects.toMatchObject({ kind: 'invalid_request', reason: 'invalid_tax_year' });
+  });
+
+  it('rejects malformed jurisdiction (length / case)', async () => {
+    await expect(
+      runTax1099Sketch(makeDeps(), makeRequest({ jurisdiction: 'USA' })),
+    ).rejects.toMatchObject({ kind: 'invalid_request', reason: 'invalid_jurisdiction' });
+    await expect(
+      runTax1099Sketch(makeDeps(), makeRequest({ jurisdiction: 'us' })),
+    ).rejects.toMatchObject({ kind: 'invalid_request', reason: 'invalid_jurisdiction' });
+  });
+
+  it('rejects malformed currency', async () => {
+    await expect(
+      runTax1099Sketch(makeDeps(), makeRequest({ currency: 'usd' })),
+    ).rejects.toMatchObject({ kind: 'invalid_request', reason: 'invalid_currency' });
+  });
+
+  it('rejects unknown formVariant', async () => {
+    await expect(
+      runTax1099Sketch(
+        makeDeps(),
+        // @ts-expect-error - intentionally bad value
+        makeRequest({ formVariant: '1099-XX' }),
+      ),
+    ).rejects.toMatchObject({ kind: 'invalid_request', reason: 'invalid_form_variant' });
+  });
+});
+
+describe('runTax1099Sketch — no_activity', () => {
+  it('throws when both kytCount and revocationCount are 0', async () => {
+    const deps = makeDeps({
+      indexer: {
+        buildAuditFeed: vi.fn(async (authority: string) =>
+          makeFeed(authority, { kytCount: 0, revocationCount: 0 }),
+        ),
+      } as unknown as Tax1099SketchDeps['indexer'],
+    });
+
+    await expect(runTax1099Sketch(deps, makeRequest())).rejects.toMatchObject({
+      kind: 'no_activity',
+    });
+  });
+});
+
+describe('runTax1099Sketch — indexer_failed', () => {
+  it('wraps an indexer throw with kind=indexer_failed', async () => {
+    const deps = makeDeps({
+      indexer: {
+        buildAuditFeed: vi.fn(async () => {
+          throw new Error('indexer unreachable');
+        }),
+      } as unknown as Tax1099SketchDeps['indexer'],
+    });
+
+    await expect(runTax1099Sketch(deps, makeRequest())).rejects.toMatchObject({
+      kind: 'indexer_failed',
+    });
+  });
+});
+
+describe('runTax1099Sketch — pin_failed', () => {
+  it('wraps a pinner throw with kind=pin_failed', async () => {
+    const deps = makeDeps({
+      pinner: {
+        pin: vi.fn(async () => {
+          throw new Error('ipfs offline');
+        }),
+      },
+    });
+
+    await expect(runTax1099Sketch(deps, makeRequest())).rejects.toMatchObject({
+      kind: 'pin_failed',
+    });
+  });
+
+  it('does NOT call IssueCredential when pinning fails', async () => {
+    const issue = vi.fn();
+    const deps = makeDeps({
+      pinner: {
+        pin: vi.fn(async () => {
+          throw new Error('pin down');
+        }),
+      },
+      chain: { issueCredential: issue } as unknown as Tax1099SketchDeps['chain'],
+    });
+
+    await expect(runTax1099Sketch(deps, makeRequest())).rejects.toThrow(
+      Tax1099SketchError,
+    );
+    expect(issue).not.toHaveBeenCalled();
+  });
+});
+
+describe('runTax1099Sketch — chain_failed', () => {
+  it('wraps an IssueCredential throw with kind=chain_failed', async () => {
+    const deps = makeDeps({
+      chain: {
+        issueCredential: vi.fn(async () => {
+          throw new Error('rpc timeout');
+        }),
+      } as unknown as Tax1099SketchDeps['chain'],
+    });
+
+    await expect(runTax1099Sketch(deps, makeRequest())).rejects.toMatchObject({
+      kind: 'chain_failed',
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Pinner / issuer call ordering — issuance MUST happen AFTER the JCS bytes
+// have been pinned (charter: "issuance after settlement-equivalent step").
+// ---------------------------------------------------------------------------
+
+describe('runTax1099Sketch — pinner / issuer ordering', () => {
+  it('VcPinner.pin is called before IssueCredentialClient.issueCredential', async () => {
+    const log: CallLog = { events: [], pinArgs: [], issueArgs: [] };
+    const deps = makeDeps({}, log);
+    await runTax1099Sketch(deps, makeRequest());
+
+    expect(log.events).toEqual(['pin', 'issue']);
+  });
+
+  it('the JCS bytes pinned match the bytes used for claim_hash', async () => {
+    const log: CallLog = { events: [], pinArgs: [], issueArgs: [] };
+    const deps = makeDeps({}, log);
+    const res = await runTax1099Sketch(deps, makeRequest());
+
+    expect(log.pinArgs).toHaveLength(1);
+    expect(sha256Hex(log.pinArgs[0]!)).toBe(res.claimHashHex);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Slot-window stub smoke test
+// ---------------------------------------------------------------------------
+
+describe('defaultFirstSlotOfYear', () => {
+  it('maps year 2024 to slot 0', () => {
+    expect(defaultFirstSlotOfYear(2024)).toBe(0n);
+  });
+
+  it('maps year 2025 to one full year of slots', () => {
+    expect(defaultFirstSlotOfYear(2025)).toBe(DEFAULT_SLOTS_PER_YEAR);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// v0 gaps — explicit todos so the charter requirement is visible in the
+// test report rather than silently passing on missing behaviour.
+// ---------------------------------------------------------------------------
+
+describe('runTax1099Sketch — v0 gaps (tracked elsewhere)', () => {
+  // No idempotency store in v0. Every call issues a fresh credential.
+  // Once the dedupe store lands, this test should assert that a second
+  // call with the same (authority, jurisdiction, taxYear) returns
+  // `status: "idempotent"` and does NOT re-invoke `issueCredential`.
+  test.todo(
+    'dedupe on (authority, jurisdiction, taxYear) — once idempotency store lands (FN-132 follow-up)',
+  );
+
+  // proof.proofValue is the placeholder `"<unsigned-v0>"`. Real
+  // Ed25519Signature2020 signing is a follow-up task.
+  test.todo('real Ed25519 signing of proof.proofValue (FN-132 follow-up)');
+
+  // Monetary totals are always "0.00" until FN-117 / FN-118 wire ledger
+  // amounts into the KYT event stream.
+  test.todo(
+    'non-zero monetary totals (totalIncome / totalFees / etc.) — blocked on FN-117 / FN-118',
+  );
+
+  // Caller-auth binding: the request type currently does not carry a
+  // verified principal, so the handler trusts `agentCardAuthority` from
+  // the request body. A `caller_auth_mismatch` discriminant should be
+  // added once the gateway propagates the verified caller identity.
+  // Tracked under FN-023 / FN-034.
+  test.todo(
+    'caller_auth_mismatch when verified caller != request.agentCardAuthority (FN-023 / FN-034)',
+  );
+});

--- a/keeper/bpps/bank/handlers/wire.test.ts
+++ b/keeper/bpps/bank/handlers/wire.test.ts
@@ -32,6 +32,7 @@ const INTL_RECIPIENT = {
 
 function makeRequest(overrides: Partial<WireRequest> = {}): WireRequest {
   return {
+    caller_pubkey: HOLDER, // FN-034: caller MUST equal holder
     holder: HOLDER,
     checking_account_pda: CHECKING_PDA,
     amount: 10_000_000,  // 10 eUSD
@@ -140,6 +141,38 @@ describe('executeWire — invalid_pubkey', () => {
     const deps = makeDeps();
     await expect(executeWire(makeRequest({ holder: 'bad' }), deps))
       .rejects.toBeInstanceOf(WireRejected);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// FN-034 — caller-binding (SECURITY HIGH)
+// ---------------------------------------------------------------------------
+
+describe('executeWire — caller-binding (FN-034)', () => {
+  it('rejects when caller_pubkey != holder with caller_mismatch', async () => {
+    const deps = makeDeps();
+    const attacker = 'f'.repeat(64);
+    await expect(
+      executeWire(makeRequest({ caller_pubkey: attacker }), deps),
+    ).rejects.toMatchObject({ reason: 'caller_mismatch' });
+  });
+
+  it('rejects without invoking lockEscrow / releaseEscrow / refundEscrow', async () => {
+    const deps = makeDeps();
+    const attacker = 'f'.repeat(64);
+    await expect(
+      executeWire(makeRequest({ caller_pubkey: attacker }), deps),
+    ).rejects.toBeInstanceOf(WireRejected);
+    expect(deps.lockEscrow).not.toHaveBeenCalled();
+    expect(deps.releaseEscrow).not.toHaveBeenCalled();
+    expect(deps.refundEscrow).not.toHaveBeenCalled();
+  });
+
+  it('rejects when caller_pubkey is not a valid hex64 with invalid_pubkey', async () => {
+    const deps = makeDeps();
+    await expect(
+      executeWire(makeRequest({ caller_pubkey: 'tooshort' }), deps),
+    ).rejects.toMatchObject({ reason: 'invalid_pubkey' });
   });
 });
 
@@ -293,8 +326,9 @@ describe('executeWire — wire_id determinism', () => {
   });
 
   it('produces different wire_id when holder differs', async () => {
-    const r1 = await executeWire(makeRequest({ holder: 'a'.repeat(64) }), makeDeps());
-    const r2 = await executeWire(makeRequest({ holder: '1'.repeat(64) }), makeDeps());
+    // FN-034: caller_pubkey must equal holder, so override both together.
+    const r1 = await executeWire(makeRequest({ caller_pubkey: 'a'.repeat(64), holder: 'a'.repeat(64) }), makeDeps());
+    const r2 = await executeWire(makeRequest({ caller_pubkey: '1'.repeat(64), holder: '1'.repeat(64) }), makeDeps());
     expect(r1.wire_id).not.toBe(r2.wire_id);
   });
 });

--- a/keeper/bpps/bank/handlers/wire.ts
+++ b/keeper/bpps/bank/handlers/wire.ts
@@ -14,6 +14,13 @@ import { createHash } from 'node:crypto';
 export type WireKind = 'domestic' | 'international';
 
 export interface WireRequest {
+  /**
+   * FN-034: authenticated caller pubkey (hex). MUST equal `holder` —
+   * any mismatch is rejected with `caller_mismatch` before any side-effect
+   * runs. Without this binding, an unauthenticated caller could move money
+   * for any subject.
+   */
+  caller_pubkey: string;
   /** Holder pubkey (hex). */
   holder: string;
   /** Holder's CheckingAccount PDA (hex). */
@@ -56,7 +63,7 @@ export interface WireDeps {
 }
 
 export class WireRejected extends Error {
-  constructor(public reason: 'invalid_pubkey' | 'invalid_amount' | 'recipient_invalid' | 'lock_failed' | 'release_failed') {
+  constructor(public reason: 'invalid_pubkey' | 'caller_mismatch' | 'invalid_amount' | 'recipient_invalid' | 'lock_failed' | 'release_failed') {
     super('wire rejected: ' + reason);
   }
 }
@@ -65,8 +72,13 @@ const HEX64 = /^[0-9a-fA-F]{64}$/;
 
 export async function executeWire(req: WireRequest, deps: WireDeps): Promise<WireOutcome> {
   // Validation
+  if (!HEX64.test(req.caller_pubkey)) throw new WireRejected('invalid_pubkey');
   if (!HEX64.test(req.holder)) throw new WireRejected('invalid_pubkey');
   if (!HEX64.test(req.checking_account_pda)) throw new WireRejected('invalid_pubkey');
+  // FN-034: caller-binding. Reject before any side-effect when the caller
+  // is not the holder; otherwise an unauth'd caller could move money for
+  // any subject.
+  if (req.caller_pubkey !== req.holder) throw new WireRejected('caller_mismatch');
   if (!Number.isInteger(req.amount) || req.amount <= 0) throw new WireRejected('invalid_amount');
   if (req.kind === 'domestic' && !req.recipient.routing_number) throw new WireRejected('recipient_invalid');
   if (req.kind === 'international' && !req.recipient.swift_bic) throw new WireRejected('recipient_invalid');

--- a/keeper/bpps/data-analyze/main.ts
+++ b/keeper/bpps/data-analyze/main.ts
@@ -14,6 +14,7 @@
  * Run: `bun run keeper/bpps/data-analyze/main.ts`
  */
 
+import { schemaIdForSkill } from "../../../src/issuers/skill-cert.js";
 import {
   defaultCredentialGate,
   InMemoryChain,
@@ -21,7 +22,9 @@ import {
   InMemoryPinner,
   registerBppAgentCard,
   runBpp,
+  type AgentCardSnapshot,
   type BeckonInitEvent,
+  type Hex32,
   type Logger,
 } from "../../templates/bpp/index.js";
 import { config, tags } from "./config.js";
@@ -32,6 +35,16 @@ import {
 import { buildHandlerFromPrimitives } from "./handler.js";
 import type { LlmClient } from "./analyzer.js";
 import type { AnalyzeInput, AnalyzeOutput, AnalysisReport } from "./types.js";
+import {
+  assertSelfSkillCredential,
+  inMemoryAgentCardLoader,
+} from "./self-cred.js";
+
+/* -------------------------------------------------------------------------- */
+/* Skill schema (memoised)                                                    */
+/* -------------------------------------------------------------------------- */
+
+export const DATA_ANALYZE_SCHEMA_ID: Hex32 = schemaIdForSkill("data-analyze");
 
 /* -------------------------------------------------------------------------- */
 /* Fake LLM and fake fetch                                                    */
@@ -110,7 +123,39 @@ export async function main(): Promise<void> {
     idempotent: reg.idempotent,
   });
 
-  // 2. Wire the runtime stack.
+  // 2. Self-credential preflight.
+  const devIssuer = "SkillCertIssuerDevPubkey1111111111111111111";
+  const issuerSet = (process.env.DATA_ANALYZE_SELF_ISSUERS ?? "")
+    .split(",")
+    .map((s) => s.trim())
+    .filter((s) => s.length > 0);
+  const resolvedIssuers = issuerSet.length > 0 ? issuerSet : [devIssuer];
+  const seededCard: AgentCardSnapshot = {
+    authority: config.authority,
+    credentials: [
+      {
+        schema: DATA_ANALYZE_SCHEMA_ID,
+        predicateHash: "0".repeat(64),
+        issuer: resolvedIssuers[0]!,
+        validFrom: 0,
+        validUntil: 0,
+        revoked: false,
+      },
+    ],
+  };
+  const ownCardLoader = inMemoryAgentCardLoader(
+    new Map([[config.authority, seededCard]]),
+  );
+  await assertSelfSkillCredential({
+    loadAgentCard: ownCardLoader,
+    ownAuthority: config.authority,
+    issuerSet: resolvedIssuers,
+    schemaId: DATA_ANALYZE_SCHEMA_ID,
+    nowSec: () => Math.floor(Date.now() / 1000),
+  });
+  consoleLogger.info("self-skill credential preflight passed");
+
+  // 3. Wire the runtime stack.
   const events = new InMemoryEventSource<unknown>();
   const inner = new InMemoryChain();
   const chain = new SigningRuntimeChain({
@@ -136,7 +181,7 @@ export async function main(): Promise<void> {
     logger: consoleLogger,
   });
 
-  // 3. Push synthetic events.
+  // 4. Push synthetic events.
   events.push(
     makeEvent("t-csv", {
       source: {
@@ -160,7 +205,7 @@ export async function main(): Promise<void> {
   events.close();
   await done;
 
-  // 4. Report.
+  // 5. Report.
   for (const c of inner.completed) {
     consoleLogger.info("completed", { taskId: c.taskId });
   }

--- a/keeper/bpps/data-analyze/self-cred.ts
+++ b/keeper/bpps/data-analyze/self-cred.ts
@@ -1,0 +1,119 @@
+/**
+ * Self-asserted skill credential preflight for the
+ * `data:analyze` BPP (FN-079).
+ *
+ * The BPP advertises that it holds a `skill.data-analyze/v1`
+ * credential issued by the FN-041 issuer. At startup we verify this
+ * by loading our own AgentCard via an injected `AgentCardLoader` and
+ * scanning its `credentials` for a match. If absent we throw a typed
+ * `MissingSelfCredentialError` whose message points the operator at
+ * the FN-041 admin endpoint to self-issue.
+ *
+ * Pure function — every seam is injected so tests cover all branches
+ * without touching the wire.
+ */
+
+import type {
+  AgentCardSnapshot,
+  Hex32,
+  Pubkey,
+} from "../../templates/bpp/index.js";
+
+/* -------------------------------------------------------------------------- */
+/* AgentCardLoader                                                            */
+/* -------------------------------------------------------------------------- */
+
+/** Loader returning the AgentCard snapshot for a given authority. */
+export type AgentCardLoader = (
+  authority: Pubkey,
+) => Promise<AgentCardSnapshot>;
+
+/**
+ * In-memory loader for tests / the worked example. Real deployments
+ * plug in an RPC-backed loader (TODO: post-FN-082).
+ */
+export function inMemoryAgentCardLoader(
+  map: ReadonlyMap<Pubkey, AgentCardSnapshot>,
+): AgentCardLoader {
+  return async (authority: Pubkey) => {
+    const card = map.get(authority);
+    if (!card) {
+      throw new Error(`agent_card_unavailable: ${authority}`);
+    }
+    return card;
+  };
+}
+
+/* -------------------------------------------------------------------------- */
+/* MissingSelfCredentialError                                                 */
+/* -------------------------------------------------------------------------- */
+
+export interface MissingSelfCredentialDetail {
+  readonly authority: Pubkey;
+  readonly schemaId: Hex32;
+  readonly issuerSet: readonly Pubkey[];
+  readonly remediation: string;
+}
+
+export class MissingSelfCredentialError extends Error {
+  public readonly detail: MissingSelfCredentialDetail;
+
+  public constructor(detail: MissingSelfCredentialDetail) {
+    super(
+      `missing self-asserted skill credential ` +
+        `(authority=${detail.authority}, schema=${detail.schemaId.slice(0, 8)}…). ` +
+        `Remediation: ${detail.remediation}`,
+    );
+    this.name = "MissingSelfCredentialError";
+    this.detail = detail;
+  }
+}
+
+/* -------------------------------------------------------------------------- */
+/* assertSelfSkillCredential                                                  */
+/* -------------------------------------------------------------------------- */
+
+export interface AssertSelfSkillCredentialDeps {
+  readonly loadAgentCard: AgentCardLoader;
+  readonly ownAuthority: Pubkey;
+  readonly issuerSet: readonly Pubkey[];
+  readonly schemaId: Hex32;
+  /** Wall-clock seconds. */
+  readonly nowSec: () => number;
+}
+
+/**
+ * Loads our own AgentCard, finds a `HeldCredentialSnapshot` whose:
+ *  - `schema === schemaId` (plain hex-string equality),
+ *  - `issuer` ∈ `issuerSet`,
+ *  - `revoked === false`,
+ *  - `validFrom === 0` or `validFrom <= now`,
+ *  - `validUntil === 0` or `validUntil >= now`.
+ *
+ * Throws `MissingSelfCredentialError` if no credential matches.
+ */
+export async function assertSelfSkillCredential(
+  deps: AssertSelfSkillCredentialDeps,
+): Promise<void> {
+  const card = await deps.loadAgentCard(deps.ownAuthority);
+  const now = deps.nowSec();
+  const issuerSet = new Set(deps.issuerSet);
+
+  for (const cred of card.credentials) {
+    if (cred.schema !== deps.schemaId) continue;
+    if (!issuerSet.has(cred.issuer)) continue;
+    if (cred.revoked) continue;
+    if (cred.validFrom !== 0 && cred.validFrom > now) continue;
+    if (cred.validUntil !== 0 && cred.validUntil < now) continue;
+    return; // match.
+  }
+
+  throw new MissingSelfCredentialError({
+    authority: deps.ownAuthority,
+    schemaId: deps.schemaId,
+    issuerSet: deps.issuerSet,
+    remediation:
+      "POST /issuers/skill-cert/issue (FN-041) with admin token for " +
+      `subject=${deps.ownAuthority}, skill=data-analyze`,
+  });
+}

--- a/keeper/templates/bpp/runtime.ts
+++ b/keeper/templates/bpp/runtime.ts
@@ -145,7 +145,22 @@ export async function runBpp<TInput = unknown, TOutput = unknown>(
     now,
   };
 
+  // FN-022: idempotent retry — skip duplicate events targeting the same
+  // taskId. The on-chain Beckn flow can replay an Init event (network
+  // partitions, BAP retries, double-delivery from the SVM log
+  // subscription); without dedupe this would result in duplicate
+  // completeTask/failTask submissions, double-charged side-effects, and
+  // duplicate signed envelopes. Memory cost is one string per task for
+  // the lifetime of the BPP process, bounded by Beckon lifetime.
+  const seenTaskIds = new Set<string>();
   for await (const event of deps.eventSource) {
+    if (seenTaskIds.has(event.taskId)) {
+      deps.logger.info("duplicate task event suppressed (idempotent retry)", {
+        taskId: event.taskId,
+      });
+      continue;
+    }
+    seenTaskIds.add(event.taskId);
     await dispatchOne(event, handler, deps, ctx, timeoutMs);
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,13 +9,20 @@
       "version": "0.1.0",
       "license": "Apache-2.0",
       "dependencies": {
+        "@noble/curves": "^1.4.0",
+        "@noble/ed25519": "^2.0.0",
+        "@noble/hashes": "^1.4.0",
+        "ajv": "^8.20.0",
+        "ajv-formats": "^3.0.1",
         "express": "^5.2.1",
+        "pg": "^8.13.0",
         "zod": "^3.25.76"
       },
       "devDependencies": {
-        "@noble/hashes": "^2.2.0",
         "@types/express": "^5.0.0",
         "@types/node": "^20.12.0",
+        "@types/pg": "^8.11.0",
+        "bs58": "^6.0.0",
         "typescript": "^5.4.0",
         "vitest": "^1.6.0"
       },
@@ -435,14 +442,37 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@noble/curves": {
+      "version": "1.9.7",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.9.7.tgz",
+      "integrity": "sha512-gbKGcRUYIjA3/zCCNaWDciTMFI0dCkvou3TL8Zmy5Nc7sJ47a0jtOeZoTaMxkuqRo9cRhjOdZJXegxYE5FN/xw==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "1.8.0"
+      },
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@noble/ed25519": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@noble/ed25519/-/ed25519-2.3.0.tgz",
+      "integrity": "sha512-M7dvXL2B92/M7dw9+gzuydL8qn/jiqNHaoR3Q+cb1q1GHV7uwE17WCyFMG+Y+TZb5izcaXk5TdJRrDUxHXL78A==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
     "node_modules/@noble/hashes": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-2.2.0.tgz",
-      "integrity": "sha512-IYqDGiTXab6FniAgnSdZwgWbomxpy9FtYvLKs7wCUs2a8RkITG+DFGO1DM9cr+E3/RgADRpFjrKVaJ1z6sjtEg==",
-      "dev": true,
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
+      "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
       "license": "MIT",
       "engines": {
-        "node": ">= 20.19.0"
+        "node": "^14.21.3 || >=16"
       },
       "funding": {
         "url": "https://paulmillr.com/funding/"
@@ -875,6 +905,18 @@
         "undici-types": "~6.21.0"
       }
     },
+    "node_modules/@types/pg": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/@types/pg/-/pg-8.20.0.tgz",
+      "integrity": "sha512-bEPFOaMAHTEP1EzpvHTbmwR8UsFyHSKsRisLIHVMXnpNefSbGA1bD6CVy+qKjGSqmZqNqBDV2azOBo8TgkcVow==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "pg-protocol": "*",
+        "pg-types": "^2.2.0"
+      }
+    },
     "node_modules/@types/qs": {
       "version": "6.15.0",
       "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.15.0.tgz",
@@ -1023,6 +1065,39 @@
         "node": ">=0.4.0"
       }
     },
+    "node_modules/ajv": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-formats": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
+      "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/ansi-styles": {
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
@@ -1046,6 +1121,13 @@
         "node": "*"
       }
     },
+    "node_modules/base-x": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/base-x/-/base-x-5.0.1.tgz",
+      "integrity": "sha512-M7uio8Zt++eg3jPj+rHMfCC+IuygQHHCOU+IYsVtik6FWjuYpVt/+MRKcgsAMHh8mMFAwnB+Bs+mTrFiXjMzKg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/body-parser": {
       "version": "2.2.2",
       "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.2.tgz",
@@ -1068,6 +1150,16 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/bs58": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/bs58/-/bs58-6.0.0.tgz",
+      "integrity": "sha512-PD0wEnEYg6ijszw/u8s+iI3H17cTymlrwkKhDhPZq+Sokl3AU4htyBFTjAeNAlCCmg0f53g6ih3jATyCKftTfw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "base-x": "^5.0.0"
       }
     },
     "node_modules/bytes": {
@@ -1451,6 +1543,28 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "license": "MIT"
+    },
+    "node_modules/fast-uri": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
+      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
     "node_modules/finalhandler": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
@@ -1702,6 +1816,12 @@
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-9.0.1.tgz",
       "integrity": "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
       "license": "MIT"
     },
     "node_modules/local-pkg": {
@@ -2010,6 +2130,95 @@
         "node": "*"
       }
     },
+    "node_modules/pg": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/pg/-/pg-8.20.0.tgz",
+      "integrity": "sha512-ldhMxz2r8fl/6QkXnBD3CR9/xg694oT6DZQ2s6c/RI28OjtSOpxnPrUCGOBJ46RCUxcWdx3p6kw/xnDHjKvaRA==",
+      "license": "MIT",
+      "dependencies": {
+        "pg-connection-string": "^2.12.0",
+        "pg-pool": "^3.13.0",
+        "pg-protocol": "^1.13.0",
+        "pg-types": "2.2.0",
+        "pgpass": "1.0.5"
+      },
+      "engines": {
+        "node": ">= 16.0.0"
+      },
+      "optionalDependencies": {
+        "pg-cloudflare": "^1.3.0"
+      },
+      "peerDependencies": {
+        "pg-native": ">=3.0.1"
+      },
+      "peerDependenciesMeta": {
+        "pg-native": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/pg-cloudflare": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/pg-cloudflare/-/pg-cloudflare-1.3.0.tgz",
+      "integrity": "sha512-6lswVVSztmHiRtD6I8hw4qP/nDm1EJbKMRhf3HCYaqud7frGysPv7FYJ5noZQdhQtN2xJnimfMtvQq21pdbzyQ==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/pg-connection-string": {
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.12.0.tgz",
+      "integrity": "sha512-U7qg+bpswf3Cs5xLzRqbXbQl85ng0mfSV/J0nnA31MCLgvEaAo7CIhmeyrmJpOr7o+zm0rXK+hNnT5l9RHkCkQ==",
+      "license": "MIT"
+    },
+    "node_modules/pg-int8": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/pg-int8/-/pg-int8-1.0.1.tgz",
+      "integrity": "sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/pg-pool": {
+      "version": "3.13.0",
+      "resolved": "https://registry.npmjs.org/pg-pool/-/pg-pool-3.13.0.tgz",
+      "integrity": "sha512-gB+R+Xud1gLFuRD/QgOIgGOBE2KCQPaPwkzBBGC9oG69pHTkhQeIuejVIk3/cnDyX39av2AxomQiyPT13WKHQA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "pg": ">=8.0"
+      }
+    },
+    "node_modules/pg-protocol": {
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/pg-protocol/-/pg-protocol-1.13.0.tgz",
+      "integrity": "sha512-zzdvXfS6v89r6v7OcFCHfHlyG/wvry1ALxZo4LqgUoy7W9xhBDMaqOuMiF3qEV45VqsN6rdlcehHrfDtlCPc8w==",
+      "license": "MIT"
+    },
+    "node_modules/pg-types": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/pg-types/-/pg-types-2.2.0.tgz",
+      "integrity": "sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA==",
+      "license": "MIT",
+      "dependencies": {
+        "pg-int8": "1.0.1",
+        "postgres-array": "~2.0.0",
+        "postgres-bytea": "~1.0.0",
+        "postgres-date": "~1.0.4",
+        "postgres-interval": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/pgpass": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/pgpass/-/pgpass-1.0.5.tgz",
+      "integrity": "sha512-FdW9r/jQZhSeohs1Z3sI1yxFQNFvMcnmfuj4WBMUTxOrAyLMaTcE1aAMBiTlbMNaXvBCQuVi0R7hd8udDSP7ug==",
+      "license": "MIT",
+      "dependencies": {
+        "split2": "^4.1.0"
+      }
+    },
     "node_modules/picocolors": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
@@ -2063,6 +2272,45 @@
       },
       "engines": {
         "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/postgres-array": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/postgres-array/-/postgres-array-2.0.0.tgz",
+      "integrity": "sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/postgres-bytea": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/postgres-bytea/-/postgres-bytea-1.0.1.tgz",
+      "integrity": "sha512-5+5HqXnsZPE65IJZSMkZtURARZelel2oXUEO8rH83VS/hxH5vv1uHquPg5wZs8yMAfdv971IU+kcPUczi7NVBQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/postgres-date": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/postgres-date/-/postgres-date-1.0.7.tgz",
+      "integrity": "sha512-suDmjLVQg78nMK2UZ454hAG+OAW+HQPZ6n++TNDUX+L0+uUlLywnoxJKDou51Zm+zTCjrCl0Nq6J9C5hP9vK/Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/postgres-interval": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/postgres-interval/-/postgres-interval-1.2.0.tgz",
+      "integrity": "sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "xtend": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/pretty-format": {
@@ -2138,6 +2386,15 @@
       "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/rollup": {
       "version": "4.60.2",
@@ -2380,6 +2637,15 @@
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/split2": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/split2/-/split2-4.2.0.tgz",
+      "integrity": "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">= 10.x"
       }
     },
     "node_modules/stackback": {
@@ -2724,6 +2990,15 @@
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "license": "ISC"
+    },
+    "node_modules/xtend": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
+      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4"
+      }
     },
     "node_modules/yocto-queue": {
       "version": "1.2.2",

--- a/package.json
+++ b/package.json
@@ -55,12 +55,14 @@
   "devDependencies": {
     "@types/express": "^5.0.0",
     "@types/node": "^20.12.0",
+    "@types/pg": "^8.11.0",
     "bs58": "^6.0.0",
     "typescript": "^5.4.0",
     "vitest": "^1.6.0"
   },
   "dependencies": {
     "@noble/curves": "^1.4.0",
+    "pg": "^8.13.0",
     "@noble/ed25519": "^2.0.0",
     "@noble/hashes": "^1.4.0",
     "ajv": "^8.20.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,0 +1,1829 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+
+  .:
+    dependencies:
+      '@noble/curves':
+        specifier: ^1.4.0
+        version: 1.9.7
+      '@noble/ed25519':
+        specifier: ^2.0.0
+        version: 2.3.0
+      '@noble/hashes':
+        specifier: ^1.4.0
+        version: 1.8.0
+      ajv:
+        specifier: ^8.20.0
+        version: 8.20.0
+      ajv-formats:
+        specifier: ^3.0.1
+        version: 3.0.1(ajv@8.20.0)
+      express:
+        specifier: ^5.2.1
+        version: 5.2.1
+      zod:
+        specifier: ^3.25.76
+        version: 3.25.76
+    devDependencies:
+      '@types/express':
+        specifier: ^5.0.0
+        version: 5.0.6
+      '@types/node':
+        specifier: ^20.12.0
+        version: 20.19.39
+      bs58:
+        specifier: ^6.0.0
+        version: 6.0.0
+      typescript:
+        specifier: ^5.4.0
+        version: 5.9.3
+      vitest:
+        specifier: ^1.6.0
+        version: 1.6.1(@types/node@20.19.39)
+
+packages:
+
+  '@esbuild/aix-ppc64@0.21.5':
+    resolution: {integrity: sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==}
+    engines: {node: '>=12'}
+    cpu: [ppc64]
+    os: [aix]
+
+  '@esbuild/android-arm64@0.21.5':
+    resolution: {integrity: sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm@0.21.5':
+    resolution: {integrity: sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==}
+    engines: {node: '>=12'}
+    cpu: [arm]
+    os: [android]
+
+  '@esbuild/android-x64@0.21.5':
+    resolution: {integrity: sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [android]
+
+  '@esbuild/darwin-arm64@0.21.5':
+    resolution: {integrity: sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.21.5':
+    resolution: {integrity: sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@esbuild/freebsd-arm64@0.21.5':
+    resolution: {integrity: sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.21.5':
+    resolution: {integrity: sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@esbuild/linux-arm64@0.21.5':
+    resolution: {integrity: sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.21.5':
+    resolution: {integrity: sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==}
+    engines: {node: '>=12'}
+    cpu: [arm]
+    os: [linux]
+
+  '@esbuild/linux-ia32@0.21.5':
+    resolution: {integrity: sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==}
+    engines: {node: '>=12'}
+    cpu: [ia32]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.21.5':
+    resolution: {integrity: sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==}
+    engines: {node: '>=12'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@esbuild/linux-mips64el@0.21.5':
+    resolution: {integrity: sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==}
+    engines: {node: '>=12'}
+    cpu: [mips64el]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.21.5':
+    resolution: {integrity: sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==}
+    engines: {node: '>=12'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@esbuild/linux-riscv64@0.21.5':
+    resolution: {integrity: sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==}
+    engines: {node: '>=12'}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.21.5':
+    resolution: {integrity: sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==}
+    engines: {node: '>=12'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@esbuild/linux-x64@0.21.5':
+    resolution: {integrity: sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [linux]
+
+  '@esbuild/netbsd-x64@0.21.5':
+    resolution: {integrity: sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [netbsd]
+
+  '@esbuild/openbsd-x64@0.21.5':
+    resolution: {integrity: sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@esbuild/sunos-x64@0.21.5':
+    resolution: {integrity: sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [sunos]
+
+  '@esbuild/win32-arm64@0.21.5':
+    resolution: {integrity: sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@esbuild/win32-ia32@0.21.5':
+    resolution: {integrity: sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==}
+    engines: {node: '>=12'}
+    cpu: [ia32]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.21.5':
+    resolution: {integrity: sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [win32]
+
+  '@jest/schemas@29.6.3':
+    resolution: {integrity: sha512-mo5j5X+jIZmJQveBKeS/clAueipV7KgiX1vMgCxam1RNYiqE1w62n0/tJJnHtjW8ZHcQco5gY85jA3mi0L+nSA==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+
+  '@jridgewell/sourcemap-codec@1.5.5':
+    resolution: {integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==}
+
+  '@noble/curves@1.9.7':
+    resolution: {integrity: sha512-gbKGcRUYIjA3/zCCNaWDciTMFI0dCkvou3TL8Zmy5Nc7sJ47a0jtOeZoTaMxkuqRo9cRhjOdZJXegxYE5FN/xw==}
+    engines: {node: ^14.21.3 || >=16}
+
+  '@noble/ed25519@2.3.0':
+    resolution: {integrity: sha512-M7dvXL2B92/M7dw9+gzuydL8qn/jiqNHaoR3Q+cb1q1GHV7uwE17WCyFMG+Y+TZb5izcaXk5TdJRrDUxHXL78A==}
+
+  '@noble/hashes@1.8.0':
+    resolution: {integrity: sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==}
+    engines: {node: ^14.21.3 || >=16}
+
+  '@rollup/rollup-android-arm-eabi@4.60.2':
+    resolution: {integrity: sha512-dnlp69efPPg6Uaw2dVqzWRfAWRnYVb1XJ8CyyhIbZeaq4CA5/mLeZ1IEt9QqQxmbdvagjLIm2ZL8BxXv5lH4Yw==}
+    cpu: [arm]
+    os: [android]
+
+  '@rollup/rollup-android-arm64@4.60.2':
+    resolution: {integrity: sha512-OqZTwDRDchGRHHm/hwLOL7uVPB9aUvI0am/eQuWMNyFHf5PSEQmyEeYYheA0EPPKUO/l0uigCp+iaTjoLjVoHg==}
+    cpu: [arm64]
+    os: [android]
+
+  '@rollup/rollup-darwin-arm64@4.60.2':
+    resolution: {integrity: sha512-UwRE7CGpvSVEQS8gUMBe1uADWjNnVgP3Iusyda1nSRwNDCsRjnGc7w6El6WLQsXmZTbLZx9cecegumcitNfpmA==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@rollup/rollup-darwin-x64@4.60.2':
+    resolution: {integrity: sha512-gjEtURKLCC5VXm1I+2i1u9OhxFsKAQJKTVB8WvDAHF+oZlq0GTVFOlTlO1q3AlCTE/DF32c16ESvfgqR7343/g==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@rollup/rollup-freebsd-arm64@4.60.2':
+    resolution: {integrity: sha512-Bcl6CYDeAgE70cqZaMojOi/eK63h5Me97ZqAQoh77VPjMysA/4ORQBRGo3rRy45x4MzVlU9uZxs8Uwy7ZaKnBw==}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@rollup/rollup-freebsd-x64@4.60.2':
+    resolution: {integrity: sha512-LU+TPda3mAE2QB0/Hp5VyeKJivpC6+tlOXd1VMoXV/YFMvk/MNk5iXeBfB4MQGRWyOYVJ01625vjkr0Az98OJQ==}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@rollup/rollup-linux-arm-gnueabihf@4.60.2':
+    resolution: {integrity: sha512-2QxQrM+KQ7DAW4o22j+XZ6RKdxjLD7BOWTP0Bv0tmjdyhXSsr2Ul1oJDQqh9Zf5qOwTuTc7Ek83mOFaKnodPjg==}
+    cpu: [arm]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-arm-musleabihf@4.60.2':
+    resolution: {integrity: sha512-TbziEu2DVsTEOPif2mKWkMeDMLoYjx95oESa9fkQQK7r/Orta0gnkcDpzwufEcAO2BLBsD7mZkXGFqEdMRRwfw==}
+    cpu: [arm]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-linux-arm64-gnu@4.60.2':
+    resolution: {integrity: sha512-bO/rVDiDUuM2YfuCUwZ1t1cP+/yqjqz+Xf2VtkdppefuOFS2OSeAfgafaHNkFn0t02hEyXngZkxtGqXcXwO8Rg==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-arm64-musl@4.60.2':
+    resolution: {integrity: sha512-hr26p7e93Rl0Za+JwW7EAnwAvKkehh12BU1Llm9Ykiibg4uIr2rbpxG9WCf56GuvidlTG9KiiQT/TXT1yAWxTA==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-linux-loong64-gnu@4.60.2':
+    resolution: {integrity: sha512-pOjB/uSIyDt+ow3k/RcLvUAOGpysT2phDn7TTUB3n75SlIgZzM6NKAqlErPhoFU+npgY3/n+2HYIQVbF70P9/A==}
+    cpu: [loong64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-loong64-musl@4.60.2':
+    resolution: {integrity: sha512-2/w+q8jszv9Ww1c+6uJT3OwqhdmGP2/4T17cu8WuwyUuuaCDDJ2ojdyYwZzCxx0GcsZBhzi3HmH+J5pZNXnd+Q==}
+    cpu: [loong64]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-linux-ppc64-gnu@4.60.2':
+    resolution: {integrity: sha512-11+aL5vKheYgczxtPVVRhdptAM2H7fcDR5Gw4/bTcteuZBlH4oP9f5s9zYO9aGZvoGeBpqXI/9TZZihZ609wKw==}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-ppc64-musl@4.60.2':
+    resolution: {integrity: sha512-i16fokAGK46IVZuV8LIIwMdtqhin9hfYkCh8pf8iC3QU3LpwL+1FSFGej+O7l3E/AoknL6Dclh2oTdnRMpTzFQ==}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-linux-riscv64-gnu@4.60.2':
+    resolution: {integrity: sha512-49FkKS6RGQoriDSK/6E2GkAsAuU5kETFCh7pG4yD/ylj9rKhTmO3elsnmBvRD4PgJPds5W2PkhC82aVwmUcJ7A==}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-riscv64-musl@4.60.2':
+    resolution: {integrity: sha512-mjYNkHPfGpUR00DuM1ZZIgs64Hpf4bWcz9Z41+4Q+pgDx73UwWdAYyf6EG/lRFldmdHHzgrYyge5akFUW0D3mQ==}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-linux-s390x-gnu@4.60.2':
+    resolution: {integrity: sha512-ALyvJz965BQk8E9Al/JDKKDLH2kfKFLTGMlgkAbbYtZuJt9LU8DW3ZoDMCtQpXAltZxwBHevXz5u+gf0yA0YoA==}
+    cpu: [s390x]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-x64-gnu@4.60.2':
+    resolution: {integrity: sha512-UQjrkIdWrKI626Du8lCQ6MJp/6V1LAo2bOK9OTu4mSn8GGXIkPXk/Vsp4bLHCd9Z9Iz2OTEaokUE90VweJgIYQ==}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-x64-musl@4.60.2':
+    resolution: {integrity: sha512-bTsRGj6VlSdn/XD4CGyzMnzaBs9bsRxy79eTqTCBsA8TMIEky7qg48aPkvJvFe1HyzQ5oMZdg7AnVlWQSKLTnw==}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-openbsd-x64@4.60.2':
+    resolution: {integrity: sha512-6d4Z3534xitaA1FcMWP7mQPq5zGwBmGbhphh2DwaA1aNIXUu3KTOfwrWpbwI4/Gr0uANo7NTtaykFyO2hPuFLg==}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@rollup/rollup-openharmony-arm64@4.60.2':
+    resolution: {integrity: sha512-NetAg5iO2uN7eB8zE5qrZ3CSil+7IJt4WDFLcC75Ymywq1VZVD6qJ6EvNLjZ3rEm6gB7XW5JdT60c6MN35Z85Q==}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@rollup/rollup-win32-arm64-msvc@4.60.2':
+    resolution: {integrity: sha512-NCYhOotpgWZ5kdxCZsv6Iudx0wX8980Q/oW4pNFNihpBKsDbEA1zpkfxJGC0yugsUuyDZ7gL37dbzwhR0VI7pQ==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@rollup/rollup-win32-ia32-msvc@4.60.2':
+    resolution: {integrity: sha512-RXsaOqXxfoUBQoOgvmmijVxJnW2IGB0eoMO7F8FAjaj0UTywUO/luSqimWBJn04WNgUkeNhh7fs7pESXajWmkg==}
+    cpu: [ia32]
+    os: [win32]
+
+  '@rollup/rollup-win32-x64-gnu@4.60.2':
+    resolution: {integrity: sha512-qdAzEULD+/hzObedtmV6iBpdL5TIbKVztGiK7O3/KYSf+HIzU257+MX1EXJcyIiDbMAqmbwaufcYPvyRryeZtA==}
+    cpu: [x64]
+    os: [win32]
+
+  '@rollup/rollup-win32-x64-msvc@4.60.2':
+    resolution: {integrity: sha512-Nd/SgG27WoA9e+/TdK74KnHz852TLa94ovOYySo/yMPuTmpckK/jIF2jSwS3g7ELSKXK13/cVdmg1Z/DaCWKxA==}
+    cpu: [x64]
+    os: [win32]
+
+  '@sinclair/typebox@0.27.10':
+    resolution: {integrity: sha512-MTBk/3jGLNB2tVxv6uLlFh1iu64iYOQ2PbdOSK3NW8JZsmlaOh2q6sdtKowBhfw8QFLmYNzTW4/oK4uATIi6ZA==}
+
+  '@types/body-parser@1.19.6':
+    resolution: {integrity: sha512-HLFeCYgz89uk22N5Qg3dvGvsv46B8GLvKKo1zKG4NybA8U2DiEO3w9lqGg29t/tfLRJpJ6iQxnVw4OnB7MoM9g==}
+
+  '@types/connect@3.4.38':
+    resolution: {integrity: sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==}
+
+  '@types/estree@1.0.8':
+    resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
+
+  '@types/express-serve-static-core@5.1.1':
+    resolution: {integrity: sha512-v4zIMr/cX7/d2BpAEX3KNKL/JrT1s43s96lLvvdTmza1oEvDudCqK9aF/djc/SWgy8Yh0h30TZx5VpzqFCxk5A==}
+
+  '@types/express@5.0.6':
+    resolution: {integrity: sha512-sKYVuV7Sv9fbPIt/442koC7+IIwK5olP1KWeD88e/idgoJqDm3JV/YUiPwkoKK92ylff2MGxSz1CSjsXelx0YA==}
+
+  '@types/http-errors@2.0.5':
+    resolution: {integrity: sha512-r8Tayk8HJnX0FztbZN7oVqGccWgw98T/0neJphO91KkmOzug1KkofZURD4UaD5uH8AqcFLfdPErnBod0u71/qg==}
+
+  '@types/node@20.19.39':
+    resolution: {integrity: sha512-orrrD74MBUyK8jOAD/r0+lfa1I2MO6I+vAkmAWzMYbCcgrN4lCrmK52gRFQq/JRxfYPfonkr4b0jcY7Olqdqbw==}
+
+  '@types/qs@6.15.0':
+    resolution: {integrity: sha512-JawvT8iBVWpzTrz3EGw9BTQFg3BQNmwERdKE22vlTxawwtbyUSlMppvZYKLZzB5zgACXdXxbD3m1bXaMqP/9ow==}
+
+  '@types/range-parser@1.2.7':
+    resolution: {integrity: sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ==}
+
+  '@types/send@1.2.1':
+    resolution: {integrity: sha512-arsCikDvlU99zl1g69TcAB3mzZPpxgw0UQnaHeC1Nwb015xp8bknZv5rIfri9xTOcMuaVgvabfIRA7PSZVuZIQ==}
+
+  '@types/serve-static@2.2.0':
+    resolution: {integrity: sha512-8mam4H1NHLtu7nmtalF7eyBH14QyOASmcxHhSfEoRyr0nP/YdoesEtU+uSRvMe96TW/HPTtkoKqQLl53N7UXMQ==}
+
+  '@vitest/expect@1.6.1':
+    resolution: {integrity: sha512-jXL+9+ZNIJKruofqXuuTClf44eSpcHlgj3CiuNihUF3Ioujtmc0zIa3UJOW5RjDK1YLBJZnWBlPuqhYycLioog==}
+
+  '@vitest/runner@1.6.1':
+    resolution: {integrity: sha512-3nSnYXkVkf3mXFfE7vVyPmi3Sazhb/2cfZGGs0JRzFsPFvAMBEcrweV1V1GsrstdXeKCTXlJbvnQwGWgEIHmOA==}
+
+  '@vitest/snapshot@1.6.1':
+    resolution: {integrity: sha512-WvidQuWAzU2p95u8GAKlRMqMyN1yOJkGHnx3M1PL9Raf7AQ1kwLKg04ADlCa3+OXUZE7BceOhVZiuWAbzCKcUQ==}
+
+  '@vitest/spy@1.6.1':
+    resolution: {integrity: sha512-MGcMmpGkZebsMZhbQKkAf9CX5zGvjkBTqf8Zx3ApYWXr3wG+QvEu2eXWfnIIWYSJExIp4V9FCKDEeygzkYrXMw==}
+
+  '@vitest/utils@1.6.1':
+    resolution: {integrity: sha512-jOrrUvXM4Av9ZWiG1EajNto0u96kWAhJ1LmPmJhXXQx/32MecEKd10pOLYgS2BQx1TgkGhloPU1ArDW2vvaY6g==}
+
+  accepts@2.0.0:
+    resolution: {integrity: sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==}
+    engines: {node: '>= 0.6'}
+
+  acorn-walk@8.3.5:
+    resolution: {integrity: sha512-HEHNfbars9v4pgpW6SO1KSPkfoS0xVOM/9UzkJltjlsHZmJasxg8aXkuZa7SMf8vKGIBhpUsPluQSqhJFCqebw==}
+    engines: {node: '>=0.4.0'}
+
+  acorn@8.16.0:
+    resolution: {integrity: sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==}
+    engines: {node: '>=0.4.0'}
+    hasBin: true
+
+  ajv-formats@3.0.1:
+    resolution: {integrity: sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==}
+    peerDependencies:
+      ajv: ^8.0.0
+    peerDependenciesMeta:
+      ajv:
+        optional: true
+
+  ajv@8.20.0:
+    resolution: {integrity: sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==}
+
+  ansi-styles@5.2.0:
+    resolution: {integrity: sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==}
+    engines: {node: '>=10'}
+
+  assertion-error@1.1.0:
+    resolution: {integrity: sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==}
+
+  base-x@5.0.1:
+    resolution: {integrity: sha512-M7uio8Zt++eg3jPj+rHMfCC+IuygQHHCOU+IYsVtik6FWjuYpVt/+MRKcgsAMHh8mMFAwnB+Bs+mTrFiXjMzKg==}
+
+  body-parser@2.2.2:
+    resolution: {integrity: sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==}
+    engines: {node: '>=18'}
+
+  bs58@6.0.0:
+    resolution: {integrity: sha512-PD0wEnEYg6ijszw/u8s+iI3H17cTymlrwkKhDhPZq+Sokl3AU4htyBFTjAeNAlCCmg0f53g6ih3jATyCKftTfw==}
+
+  bytes@3.1.2:
+    resolution: {integrity: sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==}
+    engines: {node: '>= 0.8'}
+
+  cac@6.7.14:
+    resolution: {integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==}
+    engines: {node: '>=8'}
+
+  call-bind-apply-helpers@1.0.2:
+    resolution: {integrity: sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==}
+    engines: {node: '>= 0.4'}
+
+  call-bound@1.0.4:
+    resolution: {integrity: sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==}
+    engines: {node: '>= 0.4'}
+
+  chai@4.5.0:
+    resolution: {integrity: sha512-RITGBfijLkBddZvnn8jdqoTypxvqbOLYQkGGxXzeFjVHvudaPw0HNFD9x928/eUwYWd2dPCugVqspGALTZZQKw==}
+    engines: {node: '>=4'}
+
+  check-error@1.0.3:
+    resolution: {integrity: sha512-iKEoDYaRmd1mxM90a2OEfWhjsjPpYPuQ+lMYsoxB126+t8fw7ySEO48nmDg5COTjxDI65/Y2OWpeEHk3ZOe8zg==}
+
+  confbox@0.1.8:
+    resolution: {integrity: sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w==}
+
+  content-disposition@1.1.0:
+    resolution: {integrity: sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==}
+    engines: {node: '>=18'}
+
+  content-type@1.0.5:
+    resolution: {integrity: sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==}
+    engines: {node: '>= 0.6'}
+
+  cookie-signature@1.2.2:
+    resolution: {integrity: sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==}
+    engines: {node: '>=6.6.0'}
+
+  cookie@0.7.2:
+    resolution: {integrity: sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==}
+    engines: {node: '>= 0.6'}
+
+  cross-spawn@7.0.6:
+    resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
+    engines: {node: '>= 8'}
+
+  debug@4.4.3:
+    resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
+    engines: {node: '>=6.0'}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
+
+  deep-eql@4.1.4:
+    resolution: {integrity: sha512-SUwdGfqdKOwxCPeVYjwSyRpJ7Z+fhpwIAtmCUdZIWZ/YP5R9WAsyuSgpLVDi9bjWoN2LXHNss/dk3urXtdQxGg==}
+    engines: {node: '>=6'}
+
+  depd@2.0.0:
+    resolution: {integrity: sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==}
+    engines: {node: '>= 0.8'}
+
+  diff-sequences@29.6.3:
+    resolution: {integrity: sha512-EjePK1srD3P08o2j4f0ExnylqRs5B9tJjcp9t1krH2qRi8CCdsYfwe9JgSLurFBWwq4uOlipzfk5fHNvwFKr8Q==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+
+  dunder-proto@1.0.1:
+    resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
+    engines: {node: '>= 0.4'}
+
+  ee-first@1.1.1:
+    resolution: {integrity: sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==}
+
+  encodeurl@2.0.0:
+    resolution: {integrity: sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==}
+    engines: {node: '>= 0.8'}
+
+  es-define-property@1.0.1:
+    resolution: {integrity: sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==}
+    engines: {node: '>= 0.4'}
+
+  es-errors@1.3.0:
+    resolution: {integrity: sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==}
+    engines: {node: '>= 0.4'}
+
+  es-object-atoms@1.1.1:
+    resolution: {integrity: sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==}
+    engines: {node: '>= 0.4'}
+
+  esbuild@0.21.5:
+    resolution: {integrity: sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==}
+    engines: {node: '>=12'}
+    hasBin: true
+
+  escape-html@1.0.3:
+    resolution: {integrity: sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==}
+
+  estree-walker@3.0.3:
+    resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
+
+  etag@1.8.1:
+    resolution: {integrity: sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==}
+    engines: {node: '>= 0.6'}
+
+  execa@8.0.1:
+    resolution: {integrity: sha512-VyhnebXciFV2DESc+p6B+y0LjSm0krU4OgJN44qFAhBY0TJ+1V61tYD2+wHusZ6F9n5K+vl8k0sTy7PEfV4qpg==}
+    engines: {node: '>=16.17'}
+
+  express@5.2.1:
+    resolution: {integrity: sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==}
+    engines: {node: '>= 18'}
+
+  fast-deep-equal@3.1.3:
+    resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
+
+  fast-uri@3.1.0:
+    resolution: {integrity: sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==}
+
+  finalhandler@2.1.1:
+    resolution: {integrity: sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==}
+    engines: {node: '>= 18.0.0'}
+
+  forwarded@0.2.0:
+    resolution: {integrity: sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==}
+    engines: {node: '>= 0.6'}
+
+  fresh@2.0.0:
+    resolution: {integrity: sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==}
+    engines: {node: '>= 0.8'}
+
+  fsevents@2.3.3:
+    resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
+  function-bind@1.1.2:
+    resolution: {integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==}
+
+  get-func-name@2.0.2:
+    resolution: {integrity: sha512-8vXOvuE167CtIc3OyItco7N/dpRtBbYOsPsXCz7X/PMnlGjYjSGuZJgM1Y7mmew7BKf9BqvLX2tnOVy1BBUsxQ==}
+
+  get-intrinsic@1.3.0:
+    resolution: {integrity: sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==}
+    engines: {node: '>= 0.4'}
+
+  get-proto@1.0.1:
+    resolution: {integrity: sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==}
+    engines: {node: '>= 0.4'}
+
+  get-stream@8.0.1:
+    resolution: {integrity: sha512-VaUJspBffn/LMCJVoMvSAdmscJyS1auj5Zulnn5UoYcY531UWmdwhRWkcGKnGU93m5HSXP9LP2usOryrBtQowA==}
+    engines: {node: '>=16'}
+
+  gopd@1.2.0:
+    resolution: {integrity: sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==}
+    engines: {node: '>= 0.4'}
+
+  has-symbols@1.1.0:
+    resolution: {integrity: sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==}
+    engines: {node: '>= 0.4'}
+
+  hasown@2.0.3:
+    resolution: {integrity: sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==}
+    engines: {node: '>= 0.4'}
+
+  http-errors@2.0.1:
+    resolution: {integrity: sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==}
+    engines: {node: '>= 0.8'}
+
+  human-signals@5.0.0:
+    resolution: {integrity: sha512-AXcZb6vzzrFAUE61HnN4mpLqd/cSIwNQjtNWR0euPm6y0iqx3G4gOXaIDdtdDwZmhwe82LA6+zinmW4UBWVePQ==}
+    engines: {node: '>=16.17.0'}
+
+  iconv-lite@0.7.2:
+    resolution: {integrity: sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==}
+    engines: {node: '>=0.10.0'}
+
+  inherits@2.0.4:
+    resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
+
+  ipaddr.js@1.9.1:
+    resolution: {integrity: sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==}
+    engines: {node: '>= 0.10'}
+
+  is-promise@4.0.0:
+    resolution: {integrity: sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==}
+
+  is-stream@3.0.0:
+    resolution: {integrity: sha512-LnQR4bZ9IADDRSkvpqMGvt/tEJWclzklNgSw48V5EAaAeDd6qGvN8ei6k5p0tvxSR171VmGyHuTiAOfxAbr8kA==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+
+  isexe@2.0.0:
+    resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
+
+  js-tokens@9.0.1:
+    resolution: {integrity: sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==}
+
+  json-schema-traverse@1.0.0:
+    resolution: {integrity: sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==}
+
+  local-pkg@0.5.1:
+    resolution: {integrity: sha512-9rrA30MRRP3gBD3HTGnC6cDFpaE1kVDWxWgqWJUN0RvDNAo+Nz/9GxB+nHOH0ifbVFy0hSA1V6vFDvnx54lTEQ==}
+    engines: {node: '>=14'}
+
+  loupe@2.3.7:
+    resolution: {integrity: sha512-zSMINGVYkdpYSOBmLi0D1Uo7JU9nVdQKrHxC8eYlV+9YKK9WePqAlL7lSlorG/U2Fw1w0hTBmaa/jrQ3UbPHtA==}
+
+  magic-string@0.30.21:
+    resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
+
+  math-intrinsics@1.1.0:
+    resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
+    engines: {node: '>= 0.4'}
+
+  media-typer@1.1.0:
+    resolution: {integrity: sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==}
+    engines: {node: '>= 0.8'}
+
+  merge-descriptors@2.0.0:
+    resolution: {integrity: sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==}
+    engines: {node: '>=18'}
+
+  merge-stream@2.0.0:
+    resolution: {integrity: sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==}
+
+  mime-db@1.54.0:
+    resolution: {integrity: sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==}
+    engines: {node: '>= 0.6'}
+
+  mime-types@3.0.2:
+    resolution: {integrity: sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==}
+    engines: {node: '>=18'}
+
+  mimic-fn@4.0.0:
+    resolution: {integrity: sha512-vqiC06CuhBTUdZH+RYl8sFrL096vA45Ok5ISO6sE/Mr1jRbGH4Csnhi8f3wKVl7x8mO4Au7Ir9D3Oyv1VYMFJw==}
+    engines: {node: '>=12'}
+
+  mlly@1.8.2:
+    resolution: {integrity: sha512-d+ObxMQFmbt10sretNDytwt85VrbkhhUA/JBGm1MPaWJ65Cl4wOgLaB1NYvJSZ0Ef03MMEU/0xpPMXUIQ29UfA==}
+
+  ms@2.1.3:
+    resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
+
+  nanoid@3.3.12:
+    resolution: {integrity: sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==}
+    engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
+    hasBin: true
+
+  negotiator@1.0.0:
+    resolution: {integrity: sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==}
+    engines: {node: '>= 0.6'}
+
+  npm-run-path@5.3.0:
+    resolution: {integrity: sha512-ppwTtiJZq0O/ai0z7yfudtBpWIoxM8yE6nHi1X47eFR2EWORqfbu6CnPlNsjeN683eT0qG6H/Pyf9fCcvjnnnQ==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+
+  object-inspect@1.13.4:
+    resolution: {integrity: sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==}
+    engines: {node: '>= 0.4'}
+
+  on-finished@2.4.1:
+    resolution: {integrity: sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==}
+    engines: {node: '>= 0.8'}
+
+  once@1.4.0:
+    resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
+
+  onetime@6.0.0:
+    resolution: {integrity: sha512-1FlR+gjXK7X+AsAHso35MnyN5KqGwJRi/31ft6x0M194ht7S+rWAvd7PHss9xSKMzE0asv1pyIHaJYq+BbacAQ==}
+    engines: {node: '>=12'}
+
+  p-limit@5.0.0:
+    resolution: {integrity: sha512-/Eaoq+QyLSiXQ4lyYV23f14mZRQcXnxfHrN0vCai+ak9G0pp9iEQukIIZq5NccEvwRB8PUnZT0KsOoDCINS1qQ==}
+    engines: {node: '>=18'}
+
+  parseurl@1.3.3:
+    resolution: {integrity: sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==}
+    engines: {node: '>= 0.8'}
+
+  path-key@3.1.1:
+    resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
+    engines: {node: '>=8'}
+
+  path-key@4.0.0:
+    resolution: {integrity: sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==}
+    engines: {node: '>=12'}
+
+  path-to-regexp@8.4.2:
+    resolution: {integrity: sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==}
+
+  pathe@1.1.2:
+    resolution: {integrity: sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==}
+
+  pathe@2.0.3:
+    resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
+
+  pathval@1.1.1:
+    resolution: {integrity: sha512-Dp6zGqpTdETdR63lehJYPeIOqpiNBNtc7BpWSLrOje7UaIsE5aY92r/AunQA7rsXvet3lrJ3JnZX29UPTKXyKQ==}
+
+  picocolors@1.1.1:
+    resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
+
+  pkg-types@1.3.1:
+    resolution: {integrity: sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ==}
+
+  postcss@8.5.13:
+    resolution: {integrity: sha512-qif0+jGGZoLWdHey3UFHHWP0H7Gbmsk8T5VEqyYFbWqPr1XqvLGBbk/sl8V5exGmcYJklJOhOQq1pV9IcsiFag==}
+    engines: {node: ^10 || ^12 || >=14}
+
+  pretty-format@29.7.0:
+    resolution: {integrity: sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+
+  proxy-addr@2.0.7:
+    resolution: {integrity: sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==}
+    engines: {node: '>= 0.10'}
+
+  qs@6.15.1:
+    resolution: {integrity: sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg==}
+    engines: {node: '>=0.6'}
+
+  range-parser@1.2.1:
+    resolution: {integrity: sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==}
+    engines: {node: '>= 0.6'}
+
+  raw-body@3.0.2:
+    resolution: {integrity: sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==}
+    engines: {node: '>= 0.10'}
+
+  react-is@18.3.1:
+    resolution: {integrity: sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==}
+
+  require-from-string@2.0.2:
+    resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
+    engines: {node: '>=0.10.0'}
+
+  rollup@4.60.2:
+    resolution: {integrity: sha512-J9qZyW++QK/09NyN/zeO0dG/1GdGfyp9lV8ajHnRVLfo/uFsbji5mHnDgn/qYdUHyCkM2N+8VyspgZclfAh0eQ==}
+    engines: {node: '>=18.0.0', npm: '>=8.0.0'}
+    hasBin: true
+
+  router@2.2.0:
+    resolution: {integrity: sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==}
+    engines: {node: '>= 18'}
+
+  safer-buffer@2.1.2:
+    resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
+
+  send@1.2.1:
+    resolution: {integrity: sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==}
+    engines: {node: '>= 18'}
+
+  serve-static@2.2.1:
+    resolution: {integrity: sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==}
+    engines: {node: '>= 18'}
+
+  setprototypeof@1.2.0:
+    resolution: {integrity: sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==}
+
+  shebang-command@2.0.0:
+    resolution: {integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==}
+    engines: {node: '>=8'}
+
+  shebang-regex@3.0.0:
+    resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
+    engines: {node: '>=8'}
+
+  side-channel-list@1.0.1:
+    resolution: {integrity: sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==}
+    engines: {node: '>= 0.4'}
+
+  side-channel-map@1.0.1:
+    resolution: {integrity: sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==}
+    engines: {node: '>= 0.4'}
+
+  side-channel-weakmap@1.0.2:
+    resolution: {integrity: sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==}
+    engines: {node: '>= 0.4'}
+
+  side-channel@1.1.0:
+    resolution: {integrity: sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==}
+    engines: {node: '>= 0.4'}
+
+  siginfo@2.0.0:
+    resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
+
+  signal-exit@4.1.0:
+    resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
+    engines: {node: '>=14'}
+
+  source-map-js@1.2.1:
+    resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
+    engines: {node: '>=0.10.0'}
+
+  stackback@0.0.2:
+    resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+
+  statuses@2.0.2:
+    resolution: {integrity: sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==}
+    engines: {node: '>= 0.8'}
+
+  std-env@3.10.0:
+    resolution: {integrity: sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==}
+
+  strip-final-newline@3.0.0:
+    resolution: {integrity: sha512-dOESqjYr96iWYylGObzd39EuNTa5VJxyvVAEm5Jnh7KGo75V43Hk1odPQkNDyXNmUR6k+gEiDVXnjB8HJ3crXw==}
+    engines: {node: '>=12'}
+
+  strip-literal@2.1.1:
+    resolution: {integrity: sha512-631UJ6O00eNGfMiWG78ck80dfBab8X6IVFB51jZK5Icd7XAs60Z5y7QdSd/wGIklnWvRbUNloVzhOKKmutxQ6Q==}
+
+  tinybench@2.9.0:
+    resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
+
+  tinypool@0.8.4:
+    resolution: {integrity: sha512-i11VH5gS6IFeLY3gMBQ00/MmLncVP7JLXOw1vlgkytLmJK7QnEr7NXf0LBdxfmNPAeyetukOk0bOYrJrFGjYJQ==}
+    engines: {node: '>=14.0.0'}
+
+  tinyspy@2.2.1:
+    resolution: {integrity: sha512-KYad6Vy5VDWV4GH3fjpseMQ/XU2BhIYP7Vzd0LG44qRWm/Yt2WCOTicFdvmgo6gWaqooMQCawTtILVQJupKu7A==}
+    engines: {node: '>=14.0.0'}
+
+  toidentifier@1.0.1:
+    resolution: {integrity: sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==}
+    engines: {node: '>=0.6'}
+
+  type-detect@4.1.0:
+    resolution: {integrity: sha512-Acylog8/luQ8L7il+geoSxhEkazvkslg7PSNKOX59mbB9cOveP5aq9h74Y7YU8yDpJwetzQQrfIwtf4Wp4LKcw==}
+    engines: {node: '>=4'}
+
+  type-is@2.0.1:
+    resolution: {integrity: sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==}
+    engines: {node: '>= 0.6'}
+
+  typescript@5.9.3:
+    resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
+    engines: {node: '>=14.17'}
+    hasBin: true
+
+  ufo@1.6.4:
+    resolution: {integrity: sha512-JFNbkD1Svwe0KvGi8GOeLcP4kAWQ609twvCdcHxq1oSL8svv39ZuSvajcD8B+5D0eL4+s1Is2D/O6KN3qcTeRA==}
+
+  undici-types@6.21.0:
+    resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
+
+  unpipe@1.0.0:
+    resolution: {integrity: sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==}
+    engines: {node: '>= 0.8'}
+
+  vary@1.1.2:
+    resolution: {integrity: sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==}
+    engines: {node: '>= 0.8'}
+
+  vite-node@1.6.1:
+    resolution: {integrity: sha512-YAXkfvGtuTzwWbDSACdJSg4A4DZiAqckWe90Zapc/sEX3XvHcw1NdurM/6od8J207tSDqNbSsgdCacBgvJKFuA==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+    hasBin: true
+
+  vite@5.4.21:
+    resolution: {integrity: sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+    hasBin: true
+    peerDependencies:
+      '@types/node': ^18.0.0 || >=20.0.0
+      less: '*'
+      lightningcss: ^1.21.0
+      sass: '*'
+      sass-embedded: '*'
+      stylus: '*'
+      sugarss: '*'
+      terser: ^5.4.0
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      less:
+        optional: true
+      lightningcss:
+        optional: true
+      sass:
+        optional: true
+      sass-embedded:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      terser:
+        optional: true
+
+  vitest@1.6.1:
+    resolution: {integrity: sha512-Ljb1cnSJSivGN0LqXd/zmDbWEM0RNNg2t1QW/XUhYl/qPqyu7CsqeWtqQXHVaJsecLPuDoak2oJcZN2QoRIOag==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@types/node': ^18.0.0 || >=20.0.0
+      '@vitest/browser': 1.6.1
+      '@vitest/ui': 1.6.1
+      happy-dom: '*'
+      jsdom: '*'
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+
+  which@2.0.2:
+    resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
+    engines: {node: '>= 8'}
+    hasBin: true
+
+  why-is-node-running@2.3.0:
+    resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
+    engines: {node: '>=8'}
+    hasBin: true
+
+  wrappy@1.0.2:
+    resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
+
+  yocto-queue@1.2.2:
+    resolution: {integrity: sha512-4LCcse/U2MHZ63HAJVE+v71o7yOdIe4cZ70Wpf8D/IyjDKYQLV5GD46B+hSTjJsvV5PztjvHoU580EftxjDZFQ==}
+    engines: {node: '>=12.20'}
+
+  zod@3.25.76:
+    resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
+
+snapshots:
+
+  '@esbuild/aix-ppc64@0.21.5':
+    optional: true
+
+  '@esbuild/android-arm64@0.21.5':
+    optional: true
+
+  '@esbuild/android-arm@0.21.5':
+    optional: true
+
+  '@esbuild/android-x64@0.21.5':
+    optional: true
+
+  '@esbuild/darwin-arm64@0.21.5':
+    optional: true
+
+  '@esbuild/darwin-x64@0.21.5':
+    optional: true
+
+  '@esbuild/freebsd-arm64@0.21.5':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.21.5':
+    optional: true
+
+  '@esbuild/linux-arm64@0.21.5':
+    optional: true
+
+  '@esbuild/linux-arm@0.21.5':
+    optional: true
+
+  '@esbuild/linux-ia32@0.21.5':
+    optional: true
+
+  '@esbuild/linux-loong64@0.21.5':
+    optional: true
+
+  '@esbuild/linux-mips64el@0.21.5':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.21.5':
+    optional: true
+
+  '@esbuild/linux-riscv64@0.21.5':
+    optional: true
+
+  '@esbuild/linux-s390x@0.21.5':
+    optional: true
+
+  '@esbuild/linux-x64@0.21.5':
+    optional: true
+
+  '@esbuild/netbsd-x64@0.21.5':
+    optional: true
+
+  '@esbuild/openbsd-x64@0.21.5':
+    optional: true
+
+  '@esbuild/sunos-x64@0.21.5':
+    optional: true
+
+  '@esbuild/win32-arm64@0.21.5':
+    optional: true
+
+  '@esbuild/win32-ia32@0.21.5':
+    optional: true
+
+  '@esbuild/win32-x64@0.21.5':
+    optional: true
+
+  '@jest/schemas@29.6.3':
+    dependencies:
+      '@sinclair/typebox': 0.27.10
+
+  '@jridgewell/sourcemap-codec@1.5.5': {}
+
+  '@noble/curves@1.9.7':
+    dependencies:
+      '@noble/hashes': 1.8.0
+
+  '@noble/ed25519@2.3.0': {}
+
+  '@noble/hashes@1.8.0': {}
+
+  '@rollup/rollup-android-arm-eabi@4.60.2':
+    optional: true
+
+  '@rollup/rollup-android-arm64@4.60.2':
+    optional: true
+
+  '@rollup/rollup-darwin-arm64@4.60.2':
+    optional: true
+
+  '@rollup/rollup-darwin-x64@4.60.2':
+    optional: true
+
+  '@rollup/rollup-freebsd-arm64@4.60.2':
+    optional: true
+
+  '@rollup/rollup-freebsd-x64@4.60.2':
+    optional: true
+
+  '@rollup/rollup-linux-arm-gnueabihf@4.60.2':
+    optional: true
+
+  '@rollup/rollup-linux-arm-musleabihf@4.60.2':
+    optional: true
+
+  '@rollup/rollup-linux-arm64-gnu@4.60.2':
+    optional: true
+
+  '@rollup/rollup-linux-arm64-musl@4.60.2':
+    optional: true
+
+  '@rollup/rollup-linux-loong64-gnu@4.60.2':
+    optional: true
+
+  '@rollup/rollup-linux-loong64-musl@4.60.2':
+    optional: true
+
+  '@rollup/rollup-linux-ppc64-gnu@4.60.2':
+    optional: true
+
+  '@rollup/rollup-linux-ppc64-musl@4.60.2':
+    optional: true
+
+  '@rollup/rollup-linux-riscv64-gnu@4.60.2':
+    optional: true
+
+  '@rollup/rollup-linux-riscv64-musl@4.60.2':
+    optional: true
+
+  '@rollup/rollup-linux-s390x-gnu@4.60.2':
+    optional: true
+
+  '@rollup/rollup-linux-x64-gnu@4.60.2':
+    optional: true
+
+  '@rollup/rollup-linux-x64-musl@4.60.2':
+    optional: true
+
+  '@rollup/rollup-openbsd-x64@4.60.2':
+    optional: true
+
+  '@rollup/rollup-openharmony-arm64@4.60.2':
+    optional: true
+
+  '@rollup/rollup-win32-arm64-msvc@4.60.2':
+    optional: true
+
+  '@rollup/rollup-win32-ia32-msvc@4.60.2':
+    optional: true
+
+  '@rollup/rollup-win32-x64-gnu@4.60.2':
+    optional: true
+
+  '@rollup/rollup-win32-x64-msvc@4.60.2':
+    optional: true
+
+  '@sinclair/typebox@0.27.10': {}
+
+  '@types/body-parser@1.19.6':
+    dependencies:
+      '@types/connect': 3.4.38
+      '@types/node': 20.19.39
+
+  '@types/connect@3.4.38':
+    dependencies:
+      '@types/node': 20.19.39
+
+  '@types/estree@1.0.8': {}
+
+  '@types/express-serve-static-core@5.1.1':
+    dependencies:
+      '@types/node': 20.19.39
+      '@types/qs': 6.15.0
+      '@types/range-parser': 1.2.7
+      '@types/send': 1.2.1
+
+  '@types/express@5.0.6':
+    dependencies:
+      '@types/body-parser': 1.19.6
+      '@types/express-serve-static-core': 5.1.1
+      '@types/serve-static': 2.2.0
+
+  '@types/http-errors@2.0.5': {}
+
+  '@types/node@20.19.39':
+    dependencies:
+      undici-types: 6.21.0
+
+  '@types/qs@6.15.0': {}
+
+  '@types/range-parser@1.2.7': {}
+
+  '@types/send@1.2.1':
+    dependencies:
+      '@types/node': 20.19.39
+
+  '@types/serve-static@2.2.0':
+    dependencies:
+      '@types/http-errors': 2.0.5
+      '@types/node': 20.19.39
+
+  '@vitest/expect@1.6.1':
+    dependencies:
+      '@vitest/spy': 1.6.1
+      '@vitest/utils': 1.6.1
+      chai: 4.5.0
+
+  '@vitest/runner@1.6.1':
+    dependencies:
+      '@vitest/utils': 1.6.1
+      p-limit: 5.0.0
+      pathe: 1.1.2
+
+  '@vitest/snapshot@1.6.1':
+    dependencies:
+      magic-string: 0.30.21
+      pathe: 1.1.2
+      pretty-format: 29.7.0
+
+  '@vitest/spy@1.6.1':
+    dependencies:
+      tinyspy: 2.2.1
+
+  '@vitest/utils@1.6.1':
+    dependencies:
+      diff-sequences: 29.6.3
+      estree-walker: 3.0.3
+      loupe: 2.3.7
+      pretty-format: 29.7.0
+
+  accepts@2.0.0:
+    dependencies:
+      mime-types: 3.0.2
+      negotiator: 1.0.0
+
+  acorn-walk@8.3.5:
+    dependencies:
+      acorn: 8.16.0
+
+  acorn@8.16.0: {}
+
+  ajv-formats@3.0.1(ajv@8.20.0):
+    optionalDependencies:
+      ajv: 8.20.0
+
+  ajv@8.20.0:
+    dependencies:
+      fast-deep-equal: 3.1.3
+      fast-uri: 3.1.0
+      json-schema-traverse: 1.0.0
+      require-from-string: 2.0.2
+
+  ansi-styles@5.2.0: {}
+
+  assertion-error@1.1.0: {}
+
+  base-x@5.0.1: {}
+
+  body-parser@2.2.2:
+    dependencies:
+      bytes: 3.1.2
+      content-type: 1.0.5
+      debug: 4.4.3
+      http-errors: 2.0.1
+      iconv-lite: 0.7.2
+      on-finished: 2.4.1
+      qs: 6.15.1
+      raw-body: 3.0.2
+      type-is: 2.0.1
+    transitivePeerDependencies:
+      - supports-color
+
+  bs58@6.0.0:
+    dependencies:
+      base-x: 5.0.1
+
+  bytes@3.1.2: {}
+
+  cac@6.7.14: {}
+
+  call-bind-apply-helpers@1.0.2:
+    dependencies:
+      es-errors: 1.3.0
+      function-bind: 1.1.2
+
+  call-bound@1.0.4:
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      get-intrinsic: 1.3.0
+
+  chai@4.5.0:
+    dependencies:
+      assertion-error: 1.1.0
+      check-error: 1.0.3
+      deep-eql: 4.1.4
+      get-func-name: 2.0.2
+      loupe: 2.3.7
+      pathval: 1.1.1
+      type-detect: 4.1.0
+
+  check-error@1.0.3:
+    dependencies:
+      get-func-name: 2.0.2
+
+  confbox@0.1.8: {}
+
+  content-disposition@1.1.0: {}
+
+  content-type@1.0.5: {}
+
+  cookie-signature@1.2.2: {}
+
+  cookie@0.7.2: {}
+
+  cross-spawn@7.0.6:
+    dependencies:
+      path-key: 3.1.1
+      shebang-command: 2.0.0
+      which: 2.0.2
+
+  debug@4.4.3:
+    dependencies:
+      ms: 2.1.3
+
+  deep-eql@4.1.4:
+    dependencies:
+      type-detect: 4.1.0
+
+  depd@2.0.0: {}
+
+  diff-sequences@29.6.3: {}
+
+  dunder-proto@1.0.1:
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      es-errors: 1.3.0
+      gopd: 1.2.0
+
+  ee-first@1.1.1: {}
+
+  encodeurl@2.0.0: {}
+
+  es-define-property@1.0.1: {}
+
+  es-errors@1.3.0: {}
+
+  es-object-atoms@1.1.1:
+    dependencies:
+      es-errors: 1.3.0
+
+  esbuild@0.21.5:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.21.5
+      '@esbuild/android-arm': 0.21.5
+      '@esbuild/android-arm64': 0.21.5
+      '@esbuild/android-x64': 0.21.5
+      '@esbuild/darwin-arm64': 0.21.5
+      '@esbuild/darwin-x64': 0.21.5
+      '@esbuild/freebsd-arm64': 0.21.5
+      '@esbuild/freebsd-x64': 0.21.5
+      '@esbuild/linux-arm': 0.21.5
+      '@esbuild/linux-arm64': 0.21.5
+      '@esbuild/linux-ia32': 0.21.5
+      '@esbuild/linux-loong64': 0.21.5
+      '@esbuild/linux-mips64el': 0.21.5
+      '@esbuild/linux-ppc64': 0.21.5
+      '@esbuild/linux-riscv64': 0.21.5
+      '@esbuild/linux-s390x': 0.21.5
+      '@esbuild/linux-x64': 0.21.5
+      '@esbuild/netbsd-x64': 0.21.5
+      '@esbuild/openbsd-x64': 0.21.5
+      '@esbuild/sunos-x64': 0.21.5
+      '@esbuild/win32-arm64': 0.21.5
+      '@esbuild/win32-ia32': 0.21.5
+      '@esbuild/win32-x64': 0.21.5
+
+  escape-html@1.0.3: {}
+
+  estree-walker@3.0.3:
+    dependencies:
+      '@types/estree': 1.0.8
+
+  etag@1.8.1: {}
+
+  execa@8.0.1:
+    dependencies:
+      cross-spawn: 7.0.6
+      get-stream: 8.0.1
+      human-signals: 5.0.0
+      is-stream: 3.0.0
+      merge-stream: 2.0.0
+      npm-run-path: 5.3.0
+      onetime: 6.0.0
+      signal-exit: 4.1.0
+      strip-final-newline: 3.0.0
+
+  express@5.2.1:
+    dependencies:
+      accepts: 2.0.0
+      body-parser: 2.2.2
+      content-disposition: 1.1.0
+      content-type: 1.0.5
+      cookie: 0.7.2
+      cookie-signature: 1.2.2
+      debug: 4.4.3
+      depd: 2.0.0
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      etag: 1.8.1
+      finalhandler: 2.1.1
+      fresh: 2.0.0
+      http-errors: 2.0.1
+      merge-descriptors: 2.0.0
+      mime-types: 3.0.2
+      on-finished: 2.4.1
+      once: 1.4.0
+      parseurl: 1.3.3
+      proxy-addr: 2.0.7
+      qs: 6.15.1
+      range-parser: 1.2.1
+      router: 2.2.0
+      send: 1.2.1
+      serve-static: 2.2.1
+      statuses: 2.0.2
+      type-is: 2.0.1
+      vary: 1.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  fast-deep-equal@3.1.3: {}
+
+  fast-uri@3.1.0: {}
+
+  finalhandler@2.1.1:
+    dependencies:
+      debug: 4.4.3
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      on-finished: 2.4.1
+      parseurl: 1.3.3
+      statuses: 2.0.2
+    transitivePeerDependencies:
+      - supports-color
+
+  forwarded@0.2.0: {}
+
+  fresh@2.0.0: {}
+
+  fsevents@2.3.3:
+    optional: true
+
+  function-bind@1.1.2: {}
+
+  get-func-name@2.0.2: {}
+
+  get-intrinsic@1.3.0:
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      es-define-property: 1.0.1
+      es-errors: 1.3.0
+      es-object-atoms: 1.1.1
+      function-bind: 1.1.2
+      get-proto: 1.0.1
+      gopd: 1.2.0
+      has-symbols: 1.1.0
+      hasown: 2.0.3
+      math-intrinsics: 1.1.0
+
+  get-proto@1.0.1:
+    dependencies:
+      dunder-proto: 1.0.1
+      es-object-atoms: 1.1.1
+
+  get-stream@8.0.1: {}
+
+  gopd@1.2.0: {}
+
+  has-symbols@1.1.0: {}
+
+  hasown@2.0.3:
+    dependencies:
+      function-bind: 1.1.2
+
+  http-errors@2.0.1:
+    dependencies:
+      depd: 2.0.0
+      inherits: 2.0.4
+      setprototypeof: 1.2.0
+      statuses: 2.0.2
+      toidentifier: 1.0.1
+
+  human-signals@5.0.0: {}
+
+  iconv-lite@0.7.2:
+    dependencies:
+      safer-buffer: 2.1.2
+
+  inherits@2.0.4: {}
+
+  ipaddr.js@1.9.1: {}
+
+  is-promise@4.0.0: {}
+
+  is-stream@3.0.0: {}
+
+  isexe@2.0.0: {}
+
+  js-tokens@9.0.1: {}
+
+  json-schema-traverse@1.0.0: {}
+
+  local-pkg@0.5.1:
+    dependencies:
+      mlly: 1.8.2
+      pkg-types: 1.3.1
+
+  loupe@2.3.7:
+    dependencies:
+      get-func-name: 2.0.2
+
+  magic-string@0.30.21:
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.5
+
+  math-intrinsics@1.1.0: {}
+
+  media-typer@1.1.0: {}
+
+  merge-descriptors@2.0.0: {}
+
+  merge-stream@2.0.0: {}
+
+  mime-db@1.54.0: {}
+
+  mime-types@3.0.2:
+    dependencies:
+      mime-db: 1.54.0
+
+  mimic-fn@4.0.0: {}
+
+  mlly@1.8.2:
+    dependencies:
+      acorn: 8.16.0
+      pathe: 2.0.3
+      pkg-types: 1.3.1
+      ufo: 1.6.4
+
+  ms@2.1.3: {}
+
+  nanoid@3.3.12: {}
+
+  negotiator@1.0.0: {}
+
+  npm-run-path@5.3.0:
+    dependencies:
+      path-key: 4.0.0
+
+  object-inspect@1.13.4: {}
+
+  on-finished@2.4.1:
+    dependencies:
+      ee-first: 1.1.1
+
+  once@1.4.0:
+    dependencies:
+      wrappy: 1.0.2
+
+  onetime@6.0.0:
+    dependencies:
+      mimic-fn: 4.0.0
+
+  p-limit@5.0.0:
+    dependencies:
+      yocto-queue: 1.2.2
+
+  parseurl@1.3.3: {}
+
+  path-key@3.1.1: {}
+
+  path-key@4.0.0: {}
+
+  path-to-regexp@8.4.2: {}
+
+  pathe@1.1.2: {}
+
+  pathe@2.0.3: {}
+
+  pathval@1.1.1: {}
+
+  picocolors@1.1.1: {}
+
+  pkg-types@1.3.1:
+    dependencies:
+      confbox: 0.1.8
+      mlly: 1.8.2
+      pathe: 2.0.3
+
+  postcss@8.5.13:
+    dependencies:
+      nanoid: 3.3.12
+      picocolors: 1.1.1
+      source-map-js: 1.2.1
+
+  pretty-format@29.7.0:
+    dependencies:
+      '@jest/schemas': 29.6.3
+      ansi-styles: 5.2.0
+      react-is: 18.3.1
+
+  proxy-addr@2.0.7:
+    dependencies:
+      forwarded: 0.2.0
+      ipaddr.js: 1.9.1
+
+  qs@6.15.1:
+    dependencies:
+      side-channel: 1.1.0
+
+  range-parser@1.2.1: {}
+
+  raw-body@3.0.2:
+    dependencies:
+      bytes: 3.1.2
+      http-errors: 2.0.1
+      iconv-lite: 0.7.2
+      unpipe: 1.0.0
+
+  react-is@18.3.1: {}
+
+  require-from-string@2.0.2: {}
+
+  rollup@4.60.2:
+    dependencies:
+      '@types/estree': 1.0.8
+    optionalDependencies:
+      '@rollup/rollup-android-arm-eabi': 4.60.2
+      '@rollup/rollup-android-arm64': 4.60.2
+      '@rollup/rollup-darwin-arm64': 4.60.2
+      '@rollup/rollup-darwin-x64': 4.60.2
+      '@rollup/rollup-freebsd-arm64': 4.60.2
+      '@rollup/rollup-freebsd-x64': 4.60.2
+      '@rollup/rollup-linux-arm-gnueabihf': 4.60.2
+      '@rollup/rollup-linux-arm-musleabihf': 4.60.2
+      '@rollup/rollup-linux-arm64-gnu': 4.60.2
+      '@rollup/rollup-linux-arm64-musl': 4.60.2
+      '@rollup/rollup-linux-loong64-gnu': 4.60.2
+      '@rollup/rollup-linux-loong64-musl': 4.60.2
+      '@rollup/rollup-linux-ppc64-gnu': 4.60.2
+      '@rollup/rollup-linux-ppc64-musl': 4.60.2
+      '@rollup/rollup-linux-riscv64-gnu': 4.60.2
+      '@rollup/rollup-linux-riscv64-musl': 4.60.2
+      '@rollup/rollup-linux-s390x-gnu': 4.60.2
+      '@rollup/rollup-linux-x64-gnu': 4.60.2
+      '@rollup/rollup-linux-x64-musl': 4.60.2
+      '@rollup/rollup-openbsd-x64': 4.60.2
+      '@rollup/rollup-openharmony-arm64': 4.60.2
+      '@rollup/rollup-win32-arm64-msvc': 4.60.2
+      '@rollup/rollup-win32-ia32-msvc': 4.60.2
+      '@rollup/rollup-win32-x64-gnu': 4.60.2
+      '@rollup/rollup-win32-x64-msvc': 4.60.2
+      fsevents: 2.3.3
+
+  router@2.2.0:
+    dependencies:
+      debug: 4.4.3
+      depd: 2.0.0
+      is-promise: 4.0.0
+      parseurl: 1.3.3
+      path-to-regexp: 8.4.2
+    transitivePeerDependencies:
+      - supports-color
+
+  safer-buffer@2.1.2: {}
+
+  send@1.2.1:
+    dependencies:
+      debug: 4.4.3
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      etag: 1.8.1
+      fresh: 2.0.0
+      http-errors: 2.0.1
+      mime-types: 3.0.2
+      ms: 2.1.3
+      on-finished: 2.4.1
+      range-parser: 1.2.1
+      statuses: 2.0.2
+    transitivePeerDependencies:
+      - supports-color
+
+  serve-static@2.2.1:
+    dependencies:
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      parseurl: 1.3.3
+      send: 1.2.1
+    transitivePeerDependencies:
+      - supports-color
+
+  setprototypeof@1.2.0: {}
+
+  shebang-command@2.0.0:
+    dependencies:
+      shebang-regex: 3.0.0
+
+  shebang-regex@3.0.0: {}
+
+  side-channel-list@1.0.1:
+    dependencies:
+      es-errors: 1.3.0
+      object-inspect: 1.13.4
+
+  side-channel-map@1.0.1:
+    dependencies:
+      call-bound: 1.0.4
+      es-errors: 1.3.0
+      get-intrinsic: 1.3.0
+      object-inspect: 1.13.4
+
+  side-channel-weakmap@1.0.2:
+    dependencies:
+      call-bound: 1.0.4
+      es-errors: 1.3.0
+      get-intrinsic: 1.3.0
+      object-inspect: 1.13.4
+      side-channel-map: 1.0.1
+
+  side-channel@1.1.0:
+    dependencies:
+      es-errors: 1.3.0
+      object-inspect: 1.13.4
+      side-channel-list: 1.0.1
+      side-channel-map: 1.0.1
+      side-channel-weakmap: 1.0.2
+
+  siginfo@2.0.0: {}
+
+  signal-exit@4.1.0: {}
+
+  source-map-js@1.2.1: {}
+
+  stackback@0.0.2: {}
+
+  statuses@2.0.2: {}
+
+  std-env@3.10.0: {}
+
+  strip-final-newline@3.0.0: {}
+
+  strip-literal@2.1.1:
+    dependencies:
+      js-tokens: 9.0.1
+
+  tinybench@2.9.0: {}
+
+  tinypool@0.8.4: {}
+
+  tinyspy@2.2.1: {}
+
+  toidentifier@1.0.1: {}
+
+  type-detect@4.1.0: {}
+
+  type-is@2.0.1:
+    dependencies:
+      content-type: 1.0.5
+      media-typer: 1.1.0
+      mime-types: 3.0.2
+
+  typescript@5.9.3: {}
+
+  ufo@1.6.4: {}
+
+  undici-types@6.21.0: {}
+
+  unpipe@1.0.0: {}
+
+  vary@1.1.2: {}
+
+  vite-node@1.6.1(@types/node@20.19.39):
+    dependencies:
+      cac: 6.7.14
+      debug: 4.4.3
+      pathe: 1.1.2
+      picocolors: 1.1.1
+      vite: 5.4.21(@types/node@20.19.39)
+    transitivePeerDependencies:
+      - '@types/node'
+      - less
+      - lightningcss
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+
+  vite@5.4.21(@types/node@20.19.39):
+    dependencies:
+      esbuild: 0.21.5
+      postcss: 8.5.13
+      rollup: 4.60.2
+    optionalDependencies:
+      '@types/node': 20.19.39
+      fsevents: 2.3.3
+
+  vitest@1.6.1(@types/node@20.19.39):
+    dependencies:
+      '@vitest/expect': 1.6.1
+      '@vitest/runner': 1.6.1
+      '@vitest/snapshot': 1.6.1
+      '@vitest/spy': 1.6.1
+      '@vitest/utils': 1.6.1
+      acorn-walk: 8.3.5
+      chai: 4.5.0
+      debug: 4.4.3
+      execa: 8.0.1
+      local-pkg: 0.5.1
+      magic-string: 0.30.21
+      pathe: 1.1.2
+      picocolors: 1.1.1
+      std-env: 3.10.0
+      strip-literal: 2.1.1
+      tinybench: 2.9.0
+      tinypool: 0.8.4
+      vite: 5.4.21(@types/node@20.19.39)
+      vite-node: 1.6.1(@types/node@20.19.39)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/node': 20.19.39
+    transitivePeerDependencies:
+      - less
+      - lightningcss
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+
+  which@2.0.2:
+    dependencies:
+      isexe: 2.0.0
+
+  why-is-node-running@2.3.0:
+    dependencies:
+      siginfo: 2.0.0
+      stackback: 0.0.2
+
+  wrappy@1.0.2: {}
+
+  yocto-queue@1.2.2: {}
+
+  zod@3.25.76: {}

--- a/scripts/migrations/001_kyt_events.sql
+++ b/scripts/migrations/001_kyt_events.sql
@@ -1,0 +1,52 @@
+-- Migration 001: KYT audit-trail event tables
+-- FATF Recommendation 11 requires five-year retention of all records
+-- related to virtual-asset transfers. These tables provide the durable
+-- backing store for the ETO audit-trail indexer (FN-130 / FN-083).
+--
+-- Apply with:
+--   psql "$AUDIT_DB_URL" -f scripts/migrations/001_kyt_events.sql
+
+-- ---------------------------------------------------------------------
+-- kyt_events: one row per on-chain KytTrace event
+-- ---------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS kyt_events (
+    id               BIGSERIAL PRIMARY KEY,
+    tx_signature     TEXT       NOT NULL UNIQUE,
+    slot             BIGINT     NOT NULL,
+    stage            TEXT       NOT NULL CHECK (stage IN ('init', 'confirm', 'rate')),
+    chain_timestamp  BIGINT     NOT NULL,   -- unix seconds from KytTraceEvent.timestamp
+    bap_authority    TEXT       NOT NULL,
+    bpp_authority    TEXT       NOT NULL,
+    bap_cred_pointers TEXT[]    NOT NULL DEFAULT '{}',
+    bpp_cred_pointers TEXT[]    NOT NULL DEFAULT '{}',
+    ingested_at      TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS kyt_events_slot_idx
+    ON kyt_events (slot);
+
+CREATE INDEX IF NOT EXISTS kyt_events_bap_authority_slot_idx
+    ON kyt_events (bap_authority, slot);
+
+CREATE INDEX IF NOT EXISTS kyt_events_bpp_authority_slot_idx
+    ON kyt_events (bpp_authority, slot);
+
+-- ---------------------------------------------------------------------
+-- revocation_events: one row per RevocationRootUpdated event
+-- ---------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS revocation_events (
+    id           BIGSERIAL PRIMARY KEY,
+    oracle       TEXT       NOT NULL,
+    network      TEXT       NOT NULL,
+    root         TEXT       NOT NULL,
+    leaves       BIGINT     NOT NULL,
+    slot         BIGINT     NOT NULL,
+    ingested_at  TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    UNIQUE (oracle, root, slot)   -- idempotency key
+);
+
+CREATE INDEX IF NOT EXISTS revocation_events_slot_idx
+    ON revocation_events (slot);
+
+CREATE INDEX IF NOT EXISTS revocation_events_oracle_slot_idx
+    ON revocation_events (oracle, slot);

--- a/scripts/migrations/README.md
+++ b/scripts/migrations/README.md
@@ -1,0 +1,22 @@
+# Audit-Trail Migrations
+
+## Applying migrations
+
+Run the following command against your target database to create the KYT audit-trail tables:
+
+```sh
+psql "$AUDIT_DB_URL" -f scripts/migrations/001_kyt_events.sql
+```
+
+The migration is idempotent (`CREATE TABLE IF NOT EXISTS` / `CREATE INDEX IF NOT EXISTS`), so it is safe to re-run.
+
+## Tables
+
+| Table | Purpose |
+|---|---|
+| `kyt_events` | One row per on-chain `KytTrace` event (BAP/BPP authority pair, stage, cred pointers, slot). |
+| `revocation_events` | One row per `RevocationRootUpdated` event (oracle, root, leaves, slot). |
+
+## FATF R.11 retention
+
+FATF Recommendation 11 requires virtual-asset service providers to retain records of all VA transfers for **at least five years**. These tables fulfil that requirement by providing durable, append-only storage for every `init`, `confirm`, and `rate` KYT trace as well as all credential-revocation root updates observed on-chain. Do **not** DELETE or TRUNCATE these tables in production; implement row-level archival (e.g. moving to cold storage) only if storage costs require it, and only after verifying compliance with applicable jurisdiction-specific retention obligations.

--- a/spec/memo-schemas/README.md
+++ b/spec/memo-schemas/README.md
@@ -1,0 +1,19 @@
+# Memo schema examples
+
+Example JSON Schema (Draft 2020-12) files for the v1 memo schemas registered
+in [`docs/memo-schema-registry.md`](../../docs/memo-schema-registry.md).
+
+Each file validates the **payload** portion of a memo envelope; the envelope
+shape itself (`type`, `schema`, `v`, `ts`, `payload`) is described in §2 of the
+registry document and will be implemented as a separate shared schema by the
+runtime follow-up task.
+
+| File                          | Label                            | Description                                                          |
+|-------------------------------|----------------------------------|----------------------------------------------------------------------|
+| `eval_score.v1.json`          | `eto.memo.eval_score.v1`         | Score one agent against a named metric (LLM-judge, oracle).          |
+| `payment.v1.json`             | `eto.memo.payment.v1`            | Structured payment metadata (purpose, invoice id, optional task ref).|
+| `coordination_log.v1.json`    | `eto.memo.coordination_log.v1`   | A2A coordination lifecycle event (offered/accepted/completed/…).     |
+
+See [`docs/memo-schema-registry.md`](../../docs/memo-schema-registry.md) for
+naming conventions, validation rules, versioning policy, and the procedure for
+adding new schemas.

--- a/spec/memo-schemas/coordination_log.v1.json
+++ b/spec/memo-schemas/coordination_log.v1.json
@@ -1,0 +1,40 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://eto.fdn/spec/memo-schemas/coordination_log.v1.json",
+  "title": "eto.memo.coordination_log.v1",
+  "description": "Payload schema for an A2A coordination log memo. Validates the `payload` portion of an eto.memo.coordination_log.v1 envelope; envelope shape is defined in docs/memo-schema-registry.md §2.",
+  "type": "object",
+  "required": ["event", "task_id", "actor"],
+  "additionalProperties": false,
+  "properties": {
+    "event": {
+      "type": "string",
+      "enum": ["task_offered", "task_accepted", "task_completed", "task_cancelled"],
+      "description": "Lifecycle event type."
+    },
+    "task_id": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 128,
+      "description": "Stable identifier of the coordinated task."
+    },
+    "actor": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 128,
+      "description": "Agent emitting the event (DID or address)."
+    },
+    "peer": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 128,
+      "description": "Optional counterparty agent."
+    },
+    "parent_event": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 128,
+      "description": "Optional reference to a prior coordination_log event (e.g. tx signature or content digest) that this event responds to."
+    }
+  }
+}

--- a/spec/memo-schemas/eval_score.v1.json
+++ b/spec/memo-schemas/eval_score.v1.json
@@ -1,0 +1,46 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://eto.fdn/spec/memo-schemas/eval_score.v1.json",
+  "title": "eto.memo.eval_score.v1",
+  "description": "Payload schema for an evaluation score memo: one agent or oracle scoring a subject against a named metric. Validates the `payload` portion of an eto.memo.eval_score.v1 envelope; envelope shape is defined in docs/memo-schema-registry.md §2.",
+  "type": "object",
+  "required": ["subject", "metric", "score", "evaluator"],
+  "additionalProperties": false,
+  "properties": {
+    "subject": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 128,
+      "description": "Agent under evaluation. Either a DID (e.g. did:eto:...) or an SVM/EVM address."
+    },
+    "metric": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 64,
+      "description": "Short metric identifier, e.g. 'helpfulness', 'latency_p95', 'task_success'."
+    },
+    "score": {
+      "type": "number",
+      "minimum": 0,
+      "maximum": 1,
+      "description": "Normalized score in [0, 1]. Producers are responsible for any per-metric scaling."
+    },
+    "evaluator": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 128,
+      "description": "Identity of the evaluator (DID or address)."
+    },
+    "evidence_uri": {
+      "type": "string",
+      "format": "uri",
+      "maxLength": 256,
+      "description": "Optional pointer to off-chain evidence (logs, transcripts) for records that exceed the on-chain memo size budget."
+    },
+    "notes": {
+      "type": "string",
+      "maxLength": 280,
+      "description": "Optional free-form note (≤ 280 chars)."
+    }
+  }
+}

--- a/spec/memo-schemas/payment.v1.json
+++ b/spec/memo-schemas/payment.v1.json
@@ -1,0 +1,38 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://eto.fdn/spec/memo-schemas/payment.v1.json",
+  "title": "eto.memo.payment.v1",
+  "description": "Payload schema for a structured payment memo. Validates the `payload` portion of an eto.memo.payment.v1 envelope; envelope shape is defined in docs/memo-schema-registry.md §2.",
+  "type": "object",
+  "required": ["purpose", "invoice_id"],
+  "additionalProperties": false,
+  "properties": {
+    "purpose": {
+      "type": "string",
+      "enum": ["service", "escrow", "refund", "tip"],
+      "description": "What this payment is for."
+    },
+    "invoice_id": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 128,
+      "description": "Producer-issued invoice identifier; unique per producer."
+    },
+    "task_id": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 128,
+      "description": "Optional reference to a coordination_log task this payment fulfills."
+    },
+    "unit_price_lamports": {
+      "type": "integer",
+      "minimum": 0,
+      "description": "Optional per-unit price in lamports."
+    },
+    "quantity": {
+      "type": "integer",
+      "minimum": 1,
+      "description": "Optional unit count; total = unit_price_lamports * quantity."
+    }
+  }
+}

--- a/src/a2a/counterparty-verifier.ts
+++ b/src/a2a/counterparty-verifier.ts
@@ -1,0 +1,352 @@
+/**
+ * A2A Counterparty Verifier — FN-052
+ *
+ * Reference module: how an A2A peer fetches a remote MCP origin's JWKS,
+ * verifies a `model_attestation_jws` compact JWS, checks the `aud` claim,
+ * and projects the result into a `ModelAttestation` value.
+ *
+ * Consumed by FN-060 A2A wire format. All crypto is Ed25519 via @noble/ed25519.
+ *
+ * JWS payload shape (standard JWT claims + model fields):
+ * {
+ *   iss: string;           // issuing MCP origin (e.g. "https://peer.example.com")
+ *   aud: string;           // intended recipient MCP origin — MUST equal expectedAudience
+ *   iat: number;           // issued-at (Unix seconds)
+ *   exp: number;           // expiry (Unix seconds)
+ *   jti?: string;          // optional nonce / replay protection
+ *   model: string;         // model identifier (e.g. "claude-opus-4")
+ *   model_version?: string;
+ *   sig_alg?: string;      // e.g. "EdDSA"
+ * }
+ */
+
+import * as ed from "@noble/ed25519";
+
+/* -------------------------------------------------------------------------- */
+/* Public types                                                                */
+/* -------------------------------------------------------------------------- */
+
+export interface ModelAttestation {
+  readonly iss: string;
+  readonly aud: string;
+  readonly iat: number;
+  readonly exp: number;
+  readonly jti?: string;
+  readonly model: string;
+  readonly model_version?: string;
+  readonly sig_alg?: string;
+}
+
+export type VerifyErrorCode =
+  | "malformed-jws"
+  | "unknown-kid"
+  | "bad-aud"
+  | "expired"
+  | "tampered-signature"
+  | "jwks-fetch-failed";
+
+export interface VerifyError {
+  readonly code: VerifyErrorCode;
+  readonly message: string;
+}
+
+export type VerifyResult =
+  | { readonly ok: true; readonly attestation: ModelAttestation }
+  | { readonly ok: false; readonly error: VerifyError };
+
+/* -------------------------------------------------------------------------- */
+/* JWKS types                                                                  */
+/* -------------------------------------------------------------------------- */
+
+export interface JwkEd25519 {
+  readonly kty: string;
+  readonly crv: string;
+  readonly kid: string;
+  readonly x: string; // base64url-encoded 32-byte public key
+}
+
+export interface Jwks {
+  readonly keys: JwkEd25519[];
+}
+
+/* -------------------------------------------------------------------------- */
+/* Cache                                                                       */
+/* -------------------------------------------------------------------------- */
+
+export interface JwksCacheEntry {
+  etag?: string;
+  jwks: Jwks;
+  fetchedAt: number;
+}
+
+/** Pass a shared Map instance across calls to enable ETag / 304 caching. */
+export type JwksCache = Map<string, JwksCacheEntry>;
+
+/* -------------------------------------------------------------------------- */
+/* Deps interface                                                              */
+/* -------------------------------------------------------------------------- */
+
+export interface VerifierDeps {
+  /** Injected fetch so tests don't hit the network. */
+  readonly fetch: typeof globalThis.fetch;
+  /** Shared JWKS cache across calls. Create once and reuse. */
+  readonly cache: JwksCache;
+  /** Clock injection for expiry checks. Defaults to () => Date.now(). */
+  readonly now?: () => number;
+}
+
+/* -------------------------------------------------------------------------- */
+/* Base64url helpers                                                           */
+/* -------------------------------------------------------------------------- */
+
+function base64urlDecode(input: string): Uint8Array {
+  // Convert base64url → base64, then decode
+  const b64 = input.replace(/-/g, "+").replace(/_/g, "/");
+  const padded = b64.padEnd(b64.length + ((4 - (b64.length % 4)) % 4), "=");
+  const binary = atob(padded);
+  const bytes = new Uint8Array(binary.length);
+  for (let i = 0; i < binary.length; i++) {
+    bytes[i] = binary.charCodeAt(i);
+  }
+  return bytes;
+}
+
+function base64urlDecodeToString(input: string): string | null {
+  try {
+    const bytes = base64urlDecode(input);
+    return new TextDecoder().decode(bytes);
+  } catch {
+    return null;
+  }
+}
+
+/* -------------------------------------------------------------------------- */
+/* JWS parsing                                                                 */
+/* -------------------------------------------------------------------------- */
+
+interface ParsedJws {
+  header: Record<string, unknown>;
+  payload: Record<string, unknown>;
+  signingInput: Uint8Array;
+  signature: Uint8Array;
+}
+
+function parseJwsCompact(jws: string): ParsedJws | null {
+  const parts = jws.split(".");
+  if (parts.length !== 3) return null;
+
+  const [headerB64, payloadB64, sigB64] = parts;
+  if (!headerB64 || !payloadB64 || !sigB64) return null;
+
+  const headerStr = base64urlDecodeToString(headerB64);
+  if (!headerStr) return null;
+
+  const payloadStr = base64urlDecodeToString(payloadB64);
+  if (!payloadStr) return null;
+
+  let header: Record<string, unknown>;
+  let payload: Record<string, unknown>;
+
+  try {
+    header = JSON.parse(headerStr) as Record<string, unknown>;
+  } catch {
+    return null;
+  }
+
+  try {
+    payload = JSON.parse(payloadStr) as Record<string, unknown>;
+  } catch {
+    return null;
+  }
+
+  let signature: Uint8Array;
+  try {
+    signature = base64urlDecode(sigB64);
+  } catch {
+    return null;
+  }
+
+  const signingInput = new TextEncoder().encode(`${headerB64}.${payloadB64}`);
+
+  return { header, payload, signingInput, signature };
+}
+
+/* -------------------------------------------------------------------------- */
+/* JWKS fetch with ETag cache                                                  */
+/* -------------------------------------------------------------------------- */
+
+async function fetchJwksWithCache(
+  url: string,
+  deps: VerifierDeps,
+): Promise<Jwks | { error: string }> {
+  const cached = deps.cache.get(url);
+  const headers: Record<string, string> = {};
+
+  if (cached?.etag) {
+    headers["If-None-Match"] = cached.etag;
+  }
+
+  let response: Response;
+  try {
+    response = await deps.fetch(url, { headers });
+  } catch (err) {
+    if (cached) {
+      // Network failure — serve stale cache rather than failing
+      return cached.jwks;
+    }
+    return { error: `fetch failed: ${String(err)}` };
+  }
+
+  if (response.status === 304) {
+    if (cached) {
+      // Bump fetchedAt to track when the 304 was received
+      const updated: JwksCacheEntry = { jwks: cached.jwks, fetchedAt: (deps.now ?? Date.now)() };
+      if (cached.etag !== undefined) {
+        updated.etag = cached.etag;
+      }
+      deps.cache.set(url, updated);
+      return cached.jwks;
+    }
+    return { error: "received 304 but no cached JWKS available" };
+  }
+
+  if (!response.ok) {
+    return { error: `JWKS endpoint returned HTTP ${response.status}` };
+  }
+
+  let jwks: Jwks;
+  try {
+    jwks = (await response.json()) as Jwks;
+  } catch {
+    return { error: "JWKS response is not valid JSON" };
+  }
+
+  const entry: JwksCacheEntry = { jwks, fetchedAt: (deps.now ?? Date.now)() };
+  const etag = response.headers.get("etag");
+  if (etag !== null) {
+    entry.etag = etag;
+  }
+  deps.cache.set(url, entry);
+
+  return jwks;
+}
+
+/* -------------------------------------------------------------------------- */
+/* Public API                                                                  */
+/* -------------------------------------------------------------------------- */
+
+export interface VerifyCounterpartyAttestationArgs {
+  /** Compact JWS string (header.payload.signature). */
+  readonly jws: string;
+  /** The verifying peer's MCP origin — must match `aud` claim. */
+  readonly expectedAudience: string;
+  /** Full URL to the remote peer's JWKS endpoint. */
+  readonly jwksUrl: string;
+  /** Injected fetch function. */
+  readonly fetch: typeof globalThis.fetch;
+  /** Shared JWKS cache. */
+  readonly cache: JwksCache;
+  /** Clock override for expiry tests. */
+  readonly now?: () => number;
+}
+
+/**
+ * Verify a `model_attestation_jws` from an A2A counterparty.
+ *
+ * Returns `{ ok: true, attestation }` on success or `{ ok: false, error }` on
+ * any failure — never throws.
+ */
+export async function verifyCounterpartyAttestation(
+  args: VerifyCounterpartyAttestationArgs,
+): Promise<VerifyResult> {
+  const nowMs = (args.now ?? Date.now)();
+  const nowSec = Math.floor(nowMs / 1000);
+
+  const deps: VerifierDeps = { fetch: args.fetch, cache: args.cache, now: args.now };
+
+  // 1. Parse the compact JWS
+  const parsed = parseJwsCompact(args.jws);
+  if (!parsed) {
+    return { ok: false, error: { code: "malformed-jws", message: "JWS is not a valid compact serialization" } };
+  }
+
+  const { header, payload, signingInput, signature } = parsed;
+
+  // 2. Extract kid from header
+  const kid = header["kid"];
+  if (typeof kid !== "string" || kid.length === 0) {
+    return { ok: false, error: { code: "malformed-jws", message: "JWS header missing or invalid `kid`" } };
+  }
+
+  // 3. Fetch JWKS (with ETag cache)
+  const jwksResult = await fetchJwksWithCache(args.jwksUrl, deps);
+  if ("error" in jwksResult) {
+    return { ok: false, error: { code: "jwks-fetch-failed", message: jwksResult.error } };
+  }
+
+  // 4. Find the key by kid
+  const jwk = jwksResult.keys.find((k) => k.kid === kid);
+  if (!jwk) {
+    return { ok: false, error: { code: "unknown-kid", message: `No key with kid="${kid}" in JWKS` } };
+  }
+
+  // 5. Decode the public key
+  let pubKey: Uint8Array;
+  try {
+    pubKey = base64urlDecode(jwk.x);
+  } catch {
+    return { ok: false, error: { code: "malformed-jws", message: "JWK `x` is not valid base64url" } };
+  }
+
+  // 6. Verify signature
+  let valid: boolean;
+  try {
+    valid = await ed.verifyAsync(signature, signingInput, pubKey);
+  } catch {
+    return { ok: false, error: { code: "tampered-signature", message: "Signature verification threw an error" } };
+  }
+
+  if (!valid) {
+    return { ok: false, error: { code: "tampered-signature", message: "Signature verification failed" } };
+  }
+
+  // 7. Check aud
+  const aud = payload["aud"];
+  if (typeof aud !== "string" || aud !== args.expectedAudience) {
+    return {
+      ok: false,
+      error: {
+        code: "bad-aud",
+        message: `Expected aud="${args.expectedAudience}", got "${String(aud)}"`,
+      },
+    };
+  }
+
+  // 8. Check exp
+  const exp = payload["exp"];
+  if (typeof exp !== "number" || exp < nowSec) {
+    return { ok: false, error: { code: "expired", message: `JWS expired at ${String(exp)} (now ${nowSec})` } };
+  }
+
+  // 9. Project into ModelAttestation
+  const iss = payload["iss"];
+  const iat = payload["iat"];
+  const model = payload["model"];
+
+  if (typeof iss !== "string" || typeof iat !== "number" || typeof model !== "string") {
+    return { ok: false, error: { code: "malformed-jws", message: "JWS payload missing required fields: iss, iat, model" } };
+  }
+
+  const attestation: ModelAttestation = {
+    iss,
+    aud,
+    iat,
+    exp: exp as number,
+    model,
+    ...(typeof payload["jti"] === "string" ? { jti: payload["jti"] } : {}),
+    ...(typeof payload["model_version"] === "string" ? { model_version: payload["model_version"] } : {}),
+    ...(typeof payload["sig_alg"] === "string" ? { sig_alg: payload["sig_alg"] } : {}),
+  };
+
+  return { ok: true, attestation };
+}

--- a/src/config.ts
+++ b/src/config.ts
@@ -110,6 +110,16 @@ export const config = {
     defaultTimeoutMs: 30_000,
     maxRetries: 3,
     confirmationPollMs: 400,
+    /**
+     * FN-197: maximum number of consecutive non-"not found" errors that
+     * `TransactionSubmitter.pollConfirmation` tolerates before bubbling
+     * the error to the outer retry classifier. Override via env
+     * `ETO_TX_MAX_POLL_ERRORS` (positive integer).
+     */
+    maxPollErrors: (() => {
+      const v = parseInt(process.env.ETO_TX_MAX_POLL_ERRORS ?? "", 10);
+      return Number.isFinite(v) && v > 0 ? v : 3;
+    })(),
   },
 
   auth: {
@@ -208,6 +218,11 @@ export interface GatewayConfig {
     readonly defaultTimeoutMs: number;
     readonly maxRetries: number;
     readonly confirmationPollMs: number;
+    /**
+     * FN-197: max consecutive non-"not found" RPC failures tolerated by
+     * `pollConfirmation` before bubbling. Env: `ETO_TX_MAX_POLL_ERRORS`.
+     */
+    readonly maxPollErrors: number;
   };
   readonly chain: {
     readonly id: number;
@@ -257,6 +272,7 @@ function loadGatewayConfig(): GatewayConfig {
       defaultTimeoutMs: readEnvInt("ETO_TX_TIMEOUT_MS", 30_000),
       maxRetries: readEnvInt("ETO_TX_MAX_RETRIES", 3),
       confirmationPollMs: readEnvInt("ETO_TX_POLL_MS", 400),
+      maxPollErrors: readEnvInt("ETO_TX_MAX_POLL_ERRORS", 3),
     },
     chain: {
       id: readEnvInt("ETO_EVM_CHAIN_ID", 9001),

--- a/src/gateway/beckn-schemas.ts
+++ b/src/gateway/beckn-schemas.ts
@@ -102,6 +102,8 @@ export const becknContextSchema = {
     timestamp: { type: "string", format: "date-time" },
     ttl: {
       type: "string",
+      // Permissive on Y/M components; parseIso8601DurationMs in inbound-bap.ts
+      // is the authoritative gate and rejects Y/M with BAD_TTL. See FN-188 / FN-074.
       pattern:
         "^P(?!$)(\d+Y)?(\d+M)?(\d+W)?(\d+D)?(T(?=\d)(\d+H)?(\d+M)?(\d+(?:\.\d+)?S)?)?$",
     },

--- a/src/gateway/beckn.ts
+++ b/src/gateway/beckn.ts
@@ -205,5 +205,41 @@ export function createBecknApp(): express.Express {
   });
 
   app.use(becknRouter);
+
+  // FN-092 — Convert express body-parser's PayloadTooLargeError (1 MiB
+  // limit, set on the per-route json parser above) from Express's default
+  // HTML/plain-text 413 into a Beckn NACK envelope. This must be a
+  // 4-arg error-handling middleware so Express dispatches errors here.
+  // Mounted AFTER becknRouter so any 413 thrown during body parsing on
+  // a Beckn route is caught and reshaped before the default handler runs.
+  app.use(
+    (
+      err: { type?: string; status?: number; statusCode?: number; message?: string } | undefined,
+      _req: Request,
+      res: Response,
+      next: (e?: unknown) => void,
+    ): void => {
+      if (!err) {
+        next();
+        return;
+      }
+      const status = err.status ?? err.statusCode ?? 0;
+      const isOversized =
+        err.type === "entity.too.large" || status === 413;
+      if (isOversized) {
+        const { status: nackStatus, body } = becknError(
+          "PAYLOAD_TOO_LARGE",
+          "Request body exceeds 1 MiB limit",
+          413,
+        );
+        if (!res.headersSent) {
+          res.status(nackStatus).json(body);
+        }
+        return;
+      }
+      next(err);
+    },
+  );
+
   return app;
 }

--- a/src/gateway/chain-client.ts
+++ b/src/gateway/chain-client.ts
@@ -1,0 +1,141 @@
+/**
+ * FN-091 — Beckn gateway chain client.
+ *
+ * Replaces the inline `stubSubmit` in `inbound-bap.ts` / `inbound-bpp.ts`
+ * with a swappable `ChainClient` so the bridge can submit real on-chain
+ * `BecknProgram::{Search,Select,Init,Confirm}` instructions when an
+ * `ETO_RPC_ENDPOINT` is configured.
+ *
+ * Default behaviour (no env): `StubChainClient` returns deterministic
+ * `stub-<hex>` signatures so existing tests stay green.
+ *
+ * v0 SvmChainClient: serializes the args as JSON and submits via
+ * `EtoRpcClient.sendTransaction`. Real Borsh-encoded instruction
+ * data lands in a follow-up (FN-091 §details "Real Borsh encoding").
+ * The wiring layer (this file + the dep injection) is what FN-091 asks
+ * for; the encoding is a downstream task that can land without
+ * touching the gateway again.
+ */
+import { createHash } from "node:crypto";
+import { rpc as defaultRpc, EtoRpcClient } from "../read/rpc-client.js";
+import type { BecknAction } from "./beckn.js";
+import { config } from "../config.js";
+
+export interface ChainSubmitResult {
+  tx_signature: string;
+  /** Slot at which the tx was accepted (best-effort; 0n for stub). */
+  submitted_at_slot?: bigint;
+}
+
+/**
+ * Chain action — narrow type for /search /select /init /confirm
+ * (Beckn-side) plus the BPP-side completion calls.
+ */
+export type ChainAction = BecknAction | "CompleteTask" | "FailTask";
+
+export interface ChainClient {
+  submit(action: ChainAction, args: unknown): Promise<ChainSubmitResult>;
+  submitSearch(args: unknown): Promise<ChainSubmitResult & { intent_pda?: string; deadline_slot?: bigint }>;
+  submitSelect(args: unknown): Promise<ChainSubmitResult>;
+  submitInit(args: unknown): Promise<ChainSubmitResult>;
+  submitConfirm(args: unknown): Promise<ChainSubmitResult>;
+}
+
+/* -------------------------------------------------------------------------- */
+/* StubChainClient — backward-compatible default                              */
+/* -------------------------------------------------------------------------- */
+
+/** Deterministic synthetic signature in the existing `stub-<hex>` shape. */
+function stubSig(action: ChainAction, args: unknown): string {
+  const h = createHash("sha256")
+    .update(action)
+    .update("|")
+    .update(JSON.stringify(args ?? {}))
+    .digest("hex")
+    .slice(0, 32);
+  return `stub-${h}`;
+}
+
+export class StubChainClient implements ChainClient {
+  async submit(action: ChainAction, args: unknown): Promise<ChainSubmitResult> {
+    return { tx_signature: stubSig(action, args), submitted_at_slot: 0n };
+  }
+  async submitSearch(args: unknown) {
+    const r = await this.submit("search", args);
+    // Stub-derived intent_pda for testability.
+    const intent_pda = createHash("sha256")
+      .update("intent_pda|stub|")
+      .update(JSON.stringify(args ?? {}))
+      .digest("hex");
+    return { ...r, intent_pda, deadline_slot: 0n };
+  }
+  submitSelect(args: unknown) { return this.submit("select", args); }
+  submitInit(args: unknown) { return this.submit("init", args); }
+  submitConfirm(args: unknown) { return this.submit("confirm", args); }
+}
+
+/* -------------------------------------------------------------------------- */
+/* SvmChainClient — real wiring (v0: JSON payload, real RPC)                  */
+/* -------------------------------------------------------------------------- */
+
+export interface SvmChainClientOpts {
+  /** Defaults to the module-level `rpc` singleton from src/read/rpc-client.ts. */
+  rpc?: EtoRpcClient;
+}
+
+export class SvmChainClient implements ChainClient {
+  private rpc: EtoRpcClient;
+  constructor(opts: SvmChainClientOpts = {}) {
+    this.rpc = opts.rpc ?? defaultRpc;
+  }
+
+  async submit(action: ChainAction, args: unknown): Promise<ChainSubmitResult> {
+    // v0 placeholder: serializes args as base64-encoded JSON instead of
+    // Borsh-encoded instruction data. The runtime currently accepts
+    // arbitrary opaque payloads on the BecknProgram entrypoint per the
+    // FN-050 instruction frame; real Borsh encoding is the next task to
+    // land on top of this wiring (see FN-091 follow-up note).
+    const payload = Buffer.from(JSON.stringify({ action, args }), "utf8").toString("base64");
+    const tx_signature = await this.rpc.sendTransaction(payload);
+    let submitted_at_slot: bigint | undefined;
+    try {
+      submitted_at_slot = BigInt(await this.rpc.getSlot());
+    } catch {
+      // best-effort
+    }
+    return { tx_signature, submitted_at_slot };
+  }
+
+  async submitSearch(args: unknown) {
+    const r = await this.submit("search", args);
+    // intent_pda + deadline_slot will be derived by the runtime; the
+    // bridge does not need to compute them here. Returned as undefined
+    // until FN-050 surfaces them in the tx receipt.
+    return r;
+  }
+  submitSelect(args: unknown) { return this.submit("select", args); }
+  submitInit(args: unknown) { return this.submit("init", args); }
+  submitConfirm(args: unknown) { return this.submit("confirm", args); }
+}
+
+/* -------------------------------------------------------------------------- */
+/* Factory                                                                    */
+/* -------------------------------------------------------------------------- */
+
+/**
+ * Returns SvmChainClient when `ETO_RPC_ENDPOINT` is set in the environment,
+ * else StubChainClient. Idempotent — safe to call from many places.
+ */
+export function createDefaultChainClient(): ChainClient {
+  const endpoint = process.env.ETO_RPC_ENDPOINT?.trim();
+  if (endpoint && endpoint.length > 0) {
+    return new SvmChainClient();
+  }
+  // Also honour config.etoRpcUrl when explicitly set to a non-localhost
+  // endpoint — covers production deployments that wire via config.
+  const url = config?.etoRpcUrl?.trim?.();
+  if (url && !/^https?:\/\/(127\.0\.0\.1|localhost)\b/.test(url)) {
+    return new SvmChainClient();
+  }
+  return new StubChainClient();
+}

--- a/src/gateway/inbound-bap.test.ts
+++ b/src/gateway/inbound-bap.test.ts
@@ -324,8 +324,11 @@ describe("validateBecknEnvelope + freshness (four defect cases)", () => {
     app.use(express.json());
     const mock = vi.fn().mockResolvedValue({ tx_signature: "dead".repeat(16) });
     mountInboundBap(app, { submitOnChain: mock });
-    const localServer = app.listen(0, "127.0.0.1");
-    const addr = localServer.address() as { port: number };
+    const localServer = await new Promise<http.Server>((resolve) => {
+      const s = app.listen(0, "127.0.0.1", () => resolve(s));
+    });
+    const addr = localServer.address() as { port: number } | null;
+    if (!addr) throw new Error("listen returned null address");
     try {
       const bad = { ...base, context: { ...base.context, version: "1.0.0" } };
       const { status, body } = await new Promise<{ status: number; body: unknown }>((resolve, reject) => {

--- a/src/gateway/inbound-bap.ts
+++ b/src/gateway/inbound-bap.ts
@@ -231,13 +231,40 @@ export function validateBecknEnvelopeFreshness(
 export type { BecknAction };
 
 export interface InboundBapDeps {
-  /** Submit an on-chain Beckn instruction. STUBBED today. */
-  submitOnChain: (action: BecknAction, args: unknown) => Promise<{ tx_signature: string }>;
+  /**
+   * Submit an on-chain Beckn instruction. Optional — when omitted the
+   * deps default to the ambient `ChainClient` (FN-091): real
+   * `SvmChainClient` if `ETO_RPC_ENDPOINT` is set, otherwise the
+   * `StubChainClient` that returns deterministic `stub-<hex>` sigs.
+   *
+   * Existing callers that pass an explicit `submitOnChain` continue to
+   * work unchanged — preserves the dep-injection seam used by tests.
+   */
+  submitOnChain?: (action: BecknAction, args: unknown) => Promise<{ tx_signature: string }>;
+  /**
+   * FN-091: optional chain client. If neither this nor `submitOnChain`
+   * is provided, the bridge constructs one via `createDefaultChainClient()`.
+   */
+  chainClient?: import("./chain-client.js").ChainClient;
   /** Resolve catalog responses for a SearchIntent. STUBBED today. */
   pollCatalogResponses?: (intent_hash: string, max: number) => Promise<unknown[]>;
 }
 
 export function mountInboundBap(app: Express, deps: InboundBapDeps): void {
+  // FN-091: resolve effective submit function once at mount time.
+  // Priority: explicit submitOnChain (legacy / test override) > injected
+  // chainClient > ambient default (Stub or Svm depending on env).
+  const resolvedSubmit: (action: BecknAction, args: unknown) => Promise<{ tx_signature: string }> =
+    deps.submitOnChain ??
+    (async (action, args) => {
+      const cc = deps.chainClient ?? (await import("./chain-client.js")).createDefaultChainClient();
+      const r = await cc.submit(action, args);
+      return { tx_signature: r.tx_signature };
+    });
+  // Wrap deps so existing handler bodies keep using `deps.submitOnChain`
+  // without a code shape change.
+  deps = { ...deps, submitOnChain: resolvedSubmit };
+
   app.post("/search", async (req: Request, res: Response) => {
     const now = Date.now();
     const envResult = validateBecknEnvelope((req.body as Record<string, unknown> | undefined)?.context, now);

--- a/src/gateway/inbound-bpp.test.ts
+++ b/src/gateway/inbound-bpp.test.ts
@@ -7,8 +7,14 @@
  *  - /on_confirm with order.state=CANCELLED -> submits FailTask
  *  - /on_confirm with invalid body -> 400 with errors
  *  - fulfillment_uri extraction from tracking.url and artifacts[0].url fallback
+ *
+ * FN-036: Gateway ownership hardening
+ *  - unknown bpp_id rejected with 403 when expectedBpps is set
+ *  - duplicate transaction_id rejected with 409 (replay dedup, always on)
+ *  - missing Authorization header rejected with 401 when requireSignature=true
  */
 
+import { randomUUID } from 'node:crypto';
 import type { AddressInfo } from 'node:net';
 import type { Server } from 'node:http';
 import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
@@ -144,7 +150,7 @@ async function postOnConfirm(body: unknown) {
   });
 }
 
-function buildOnConfirmBody(orderState: string, extra: Record<string, unknown> = {}) {
+function buildOnConfirmBody(orderState: string, extra: Record<string, unknown> = {}, overrideContext: Record<string, unknown> = {}) {
   return {
     context: {
       domain: 'retail',
@@ -154,9 +160,11 @@ function buildOnConfirmBody(orderState: string, extra: Record<string, unknown> =
       bap_uri: 'https://bap.example.com',
       bpp_id: 'bpp.example.com',
       bpp_uri: 'https://bpp.example.com',
-      transaction_id: 'a1b2c3d4-e5f6-7890-abcd-ef1234567890',
-      message_id: 'a1b2c3d4-e5f6-7890-abcd-ef1234567891',
+      // Generate unique IDs per call so replay dedup doesn't reject subsequent tests
+      transaction_id: randomUUID(),
+      message_id: randomUUID(),
       timestamp: '2026-04-30T00:00:00.000Z',
+      ...overrideContext,
     },
     message: {
       order: {
@@ -235,5 +243,170 @@ describe('fulfillment_uri extraction', () => {
     await postOnConfirm(body);
     const [, args] = (deps.submitOnChain as ReturnType<typeof vi.fn>).mock.calls[0] as [string, any];
     expect(args.fulfillment_uri).toBe('');
+  });
+});
+
+// ---------- FN-036: Gateway ownership hardening ----------
+
+describe('FN-036: BPP allowlist (expectedBpps)', () => {
+  let hardenedServer: Server;
+  let hardenedUrl: string;
+
+  beforeAll(async () => {
+    const app = express();
+    app.use(express.json());
+    const hardenedDeps = makeDeps({
+      expectedBpps: new Set(['trusted-bpp.example.com']),
+    });
+    mountOnConfirmCallback(app, hardenedDeps);
+    await new Promise<void>((resolve) => {
+      hardenedServer = app.listen(0, '127.0.0.1', () => resolve());
+    });
+    const addr = hardenedServer.address() as AddressInfo;
+    hardenedUrl = `http://127.0.0.1:${addr.port}`;
+  });
+
+  afterAll(async () => {
+    await new Promise<void>((resolve, reject) => {
+      hardenedServer.close((err) => (err ? reject(err) : resolve()));
+    });
+  });
+
+  it('rejects callback with unknown bpp_id with 403', async () => {
+    const body = buildOnConfirmBody('COMPLETED', {}, { bpp_id: 'unknown-bpp.example.com', bpp_uri: 'https://unknown-bpp.example.com' });
+    const res = await fetch(`${hardenedUrl}/on_confirm`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+    });
+    expect(res.status).toBe(403);
+    const json = await res.json() as any;
+    expect(json.error).toBe('unknown_bpp');
+  });
+
+  it('accepts callback from trusted bpp_id with 200', async () => {
+    const body = buildOnConfirmBody('COMPLETED', {}, { bpp_id: 'trusted-bpp.example.com', bpp_uri: 'https://trusted-bpp.example.com' });
+    const res = await fetch(`${hardenedUrl}/on_confirm`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+    });
+    expect(res.status).toBe(200);
+    const json = await res.json() as any;
+    expect(json.message.ack.status).toBe('ACK');
+  });
+});
+
+describe('FN-036: Replay dedup (seenTransactions)', () => {
+  let dedupServer: Server;
+  let dedupUrl: string;
+  let dedupDeps: InboundBppDeps;
+
+  beforeAll(async () => {
+    const app = express();
+    app.use(express.json());
+    dedupDeps = makeDeps();
+    mountOnConfirmCallback(app, dedupDeps);
+    await new Promise<void>((resolve) => {
+      dedupServer = app.listen(0, '127.0.0.1', () => resolve());
+    });
+    const addr = dedupServer.address() as AddressInfo;
+    dedupUrl = `http://127.0.0.1:${addr.port}`;
+  });
+
+  afterAll(async () => {
+    await new Promise<void>((resolve, reject) => {
+      dedupServer.close((err) => (err ? reject(err) : resolve()));
+    });
+  });
+
+  it('rejects duplicate transaction_id with 409', async () => {
+    const fixedTxnId = randomUUID();
+    const body = buildOnConfirmBody('COMPLETED', {}, { transaction_id: fixedTxnId });
+
+    // First call should succeed
+    const first = await fetch(`${dedupUrl}/on_confirm`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+    });
+    expect(first.status).toBe(200);
+
+    // Second call with same transaction_id must be rejected
+    const second = await fetch(`${dedupUrl}/on_confirm`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+    });
+    expect(second.status).toBe(409);
+    const json = await second.json() as any;
+    expect(json.error).toBe('duplicate_transaction');
+  });
+
+  it('accepts two callbacks with distinct transaction_ids', async () => {
+    const body1 = buildOnConfirmBody('COMPLETED');
+    const body2 = buildOnConfirmBody('CANCELLED');
+
+    const r1 = await fetch(`${dedupUrl}/on_confirm`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body1),
+    });
+    const r2 = await fetch(`${dedupUrl}/on_confirm`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body2),
+    });
+    expect(r1.status).toBe(200);
+    expect(r2.status).toBe(200);
+  });
+});
+
+describe('FN-036: Signature gate (requireSignature)', () => {
+  let sigServer: Server;
+  let sigUrl: string;
+
+  beforeAll(async () => {
+    const app = express();
+    app.use(express.json());
+    mountOnConfirmCallback(app, makeDeps({ requireSignature: true }));
+    await new Promise<void>((resolve) => {
+      sigServer = app.listen(0, '127.0.0.1', () => resolve());
+    });
+    const addr = sigServer.address() as AddressInfo;
+    sigUrl = `http://127.0.0.1:${addr.port}`;
+  });
+
+  afterAll(async () => {
+    await new Promise<void>((resolve, reject) => {
+      sigServer.close((err) => (err ? reject(err) : resolve()));
+    });
+  });
+
+  it('rejects request with no Authorization header with 401', async () => {
+    const body = buildOnConfirmBody('COMPLETED');
+    const res = await fetch(`${sigUrl}/on_confirm`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+    });
+    expect(res.status).toBe(401);
+    const json = await res.json() as any;
+    expect(json.error).toBe('missing_signature');
+  });
+
+  it('accepts request with Authorization header present', async () => {
+    const body = buildOnConfirmBody('COMPLETED');
+    const res = await fetch(`${sigUrl}/on_confirm`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'Authorization': 'Signature keyId="bpp.example.com",signature="stub"',
+      },
+      body: JSON.stringify(body),
+    });
+    expect(res.status).toBe(200);
+    const json = await res.json() as any;
+    expect(json.message.ack.status).toBe('ACK');
   });
 });

--- a/src/gateway/inbound-bpp.ts
+++ b/src/gateway/inbound-bpp.ts
@@ -6,6 +6,24 @@
  *
  * Spec: T-2.8.2.3 (FN-090). Sibling roles: inbound-bap (FN-088),
  * outbound-bap (FN-089).
+ *
+ * ## Gateway ownership hardening (FN-036)
+ *
+ * Three security controls added to mountOnConfirmCallback:
+ *
+ *   1. BPP allowlist  — when `expectedBpps` is provided, callbacks from
+ *      unknown `context.bpp_id` values are rejected with HTTP 403.
+ *
+ *   2. Replay dedup   — ON BY DEFAULT. The seen-transaction set is keyed on
+ *      `context.transaction_id`. Duplicate callbacks are rejected with HTTP 409.
+ *      Pass `seenTransactions` to inject a pre-populated set (e.g. in tests).
+ *      The txn_id is committed to the set *before* `submitOnChain` is called
+ *      to prevent any double-trigger under concurrent requests.
+ *
+ *   3. Signature gate — when `requireSignature: true`, the handler rejects
+ *      requests that lack an `Authorization` header with HTTP 401.
+ *      Full Beckn Ed25519 signature verification is deferred; this is a
+ *      presence-only guard that prevents entirely unsigned inbound traffic.
  */
 
 import { createHash } from 'node:crypto';
@@ -39,6 +57,29 @@ export interface InboundBppDeps {
   chainClient?: import("./chain-client.js").ChainClient;
   /** Look up off-chain order details by terms_hash. */
   loadOrderByTermsHash?: (terms_hash: string) => Promise<object | null>;
+
+  // ---- FN-036: Gateway ownership hardening ----
+
+  /**
+   * Allowlist of trusted BPP identifiers (context.bpp_id values).
+   * When provided, callbacks from BPPs not in this set are rejected 403.
+   * When absent (default), all bpp_ids are accepted.
+   */
+  expectedBpps?: Set<string>;
+
+  /**
+   * Inject a pre-populated seen-transactions set.
+   * Defaults to a fresh Set created at mount time (replay dedup is always on).
+   * Callers can pass their own Set to share state across mount calls or to
+   * pre-seed transactions that must be treated as already seen.
+   */
+  seenTransactions?: Set<string>;
+
+  /**
+   * When true, requests without an `Authorization` header are rejected 401.
+   * Defaults to false. Full Beckn Ed25519 verification is deferred (stub-level).
+   */
+  requireSignature?: boolean;
 }
 
 /** Handle an outbound /confirm produced by an on-chain Confirm AgentTrigger. */
@@ -78,11 +119,36 @@ export function mountOnConfirmCallback(app: Express, deps: InboundBppDeps): void
       return { tx_signature: r.tx_signature };
     });
 
+  // FN-036: replay dedup set — always on; caller may inject a pre-populated set.
+  const seenTransactions: Set<string> = deps.seenTransactions ?? new Set();
+
   app.post('/on_confirm', async (req: Request, res: Response) => {
+    // 1. Schema validation (existing)
     const v = validateBecknRequest('on_confirm', req.body);
     if (!v.ok) {
       return res.status(400).json({ error: 'beckn_validation_failed', details: (v as { ok: false; errors: unknown }).errors });
     }
+
+    // 2. FN-036: Signature presence gate (optional, off by default)
+    if (deps.requireSignature && !req.headers['authorization']) {
+      return res.status(401).json({ error: 'missing_signature', details: 'Authorization header required' });
+    }
+
+    // 3. FN-036: BPP allowlist check (optional, off by default)
+    const bppId: string | undefined = req.body.context?.bpp_id;
+    if (deps.expectedBpps && (!bppId || !deps.expectedBpps.has(bppId))) {
+      return res.status(403).json({ error: 'unknown_bpp', details: `bpp_id not in allowlist: ${bppId ?? '(missing)'}` });
+    }
+
+    // 4. FN-036: Replay dedup (always on — commit before submit to prevent double-trigger)
+    const txnId: string | undefined = req.body.context?.transaction_id;
+    if (txnId) {
+      if (seenTransactions.has(txnId)) {
+        return res.status(409).json({ error: 'duplicate_transaction', details: `transaction_id already processed: ${txnId}` });
+      }
+      seenTransactions.add(txnId);
+    }
+
     try {
       const order = req.body.message?.order;
       const success = order?.state === 'COMPLETED' || order?.state === 'FULFILLED';

--- a/src/gateway/inbound-bpp.ts
+++ b/src/gateway/inbound-bpp.ts
@@ -28,8 +28,15 @@ export interface InboundBppDeps {
   resolveBppEndpoint: (bpp_pubkey: string) => string;
   /** POST a Beckn JSON body to a URL. */
   postBecknRequest: (url: string, body: object) => Promise<{ status: number; body: unknown }>;
-  /** Submit on-chain instruction. STUBBED today. */
-  submitOnChain: (action: 'CompleteTask' | 'FailTask', args: unknown) => Promise<{ tx_signature: string }>;
+  /**
+   * Submit on-chain instruction. Optional — when omitted, the deps default
+   * to the ambient ChainClient (FN-091): real `SvmChainClient` if
+   * `ETO_RPC_ENDPOINT` is set, otherwise `StubChainClient`. Existing
+   * callers that pass an explicit `submitOnChain` continue to work.
+   */
+  submitOnChain?: (action: 'CompleteTask' | 'FailTask', args: unknown) => Promise<{ tx_signature: string }>;
+  /** FN-091: optional chain client; falls back to createDefaultChainClient(). */
+  chainClient?: import("./chain-client.js").ChainClient;
   /** Look up off-chain order details by terms_hash. */
   loadOrderByTermsHash?: (terms_hash: string) => Promise<object | null>;
 }
@@ -62,6 +69,15 @@ export async function handleConfirmTrigger(trigger: ConfirmTrigger, deps: Inboun
 
 /** Mount the /on_confirm callback receiver on the bridge express app. */
 export function mountOnConfirmCallback(app: Express, deps: InboundBppDeps): void {
+  // FN-091: resolve effective submit function once at mount time.
+  const resolvedSubmit: NonNullable<InboundBppDeps['submitOnChain']> =
+    deps.submitOnChain ??
+    (async (action, args) => {
+      const cc = deps.chainClient ?? (await import('./chain-client.js')).createDefaultChainClient();
+      const r = await cc.submit(action, args);
+      return { tx_signature: r.tx_signature };
+    });
+
   app.post('/on_confirm', async (req: Request, res: Response) => {
     const v = validateBecknRequest('on_confirm', req.body);
     if (!v.ok) {
@@ -71,7 +87,7 @@ export function mountOnConfirmCallback(app: Express, deps: InboundBppDeps): void
       const order = req.body.message?.order;
       const success = order?.state === 'COMPLETED' || order?.state === 'FULFILLED';
       const args = becknOnConfirmToTaskOutcome(req.body);
-      const { tx_signature } = await deps.submitOnChain(success ? 'CompleteTask' : 'FailTask', args);
+      const { tx_signature } = await resolvedSubmit(success ? 'CompleteTask' : 'FailTask', args);
       res.status(200).json({ message: { ack: { status: 'ACK' } }, tx_signature });
     } catch (err) {
       res.status(500).json({ error: 'submission_failed', details: String(err) });

--- a/src/gateway/outbound-bpp.ts
+++ b/src/gateway/outbound-bpp.ts
@@ -31,9 +31,43 @@
  *  - `ETO_BECKN_ALLOW_PRIVATE_CALLBACKS=1` — bypass SSRF guard (test/dev only)
  */
 import { isIP } from "node:net";
+import { lookup as dnsLookup } from "node:dns/promises";
 import { randomUUID as nodeRandomUUID } from "node:crypto";
 import { z } from "zod";
 import type { BecknContext } from "./beckn.js";
+
+/**
+ * FN-079: DNS-aware SSRF guard. The string-only `isPrivateOrLoopbackHost`
+ * is bypassable via DNS rebinding (`attacker.com` resolving to 127.0.0.1
+ * at request time passes the string check). This async helper resolves the
+ * hostname and checks the resolved IP against the same private/reserved
+ * ranges, closing the rebinding hole.
+ *
+ * `lookup` is injectable for tests so they don't hit real DNS.
+ */
+export type DnsLookupFn = (hostname: string) => Promise<{ address: string; family: number }>;
+
+export async function isPrivateOrLoopbackHostResolved(
+  hostname: string,
+  lookup: DnsLookupFn = (h) => dnsLookup(h),
+): Promise<boolean> {
+  // First, the synchronous IP-literal / localhost / .local check still applies
+  // — these never need DNS resolution.
+  if (isPrivateOrLoopbackHost(hostname)) return true;
+  // If hostname is already a literal IP that the sync check ruled "public",
+  // we're done — no DNS resolution needed.
+  const stripped = hostname.startsWith("[") ? hostname.slice(1, -1) : hostname;
+  if (isIP(stripped) !== 0) return false;
+  // Otherwise the hostname is a DNS name; resolve it and re-check.
+  let resolved: { address: string; family: number };
+  try {
+    resolved = await lookup(hostname);
+  } catch {
+    // Refuse to ship to a host we cannot resolve — fail closed.
+    return true;
+  }
+  return isPrivateOrLoopbackHost(resolved.address);
+}
 
 // ---------------------------------------------------------------------------
 // Types
@@ -145,6 +179,13 @@ export interface OutboundBppDeps {
    * @default false
    */
   allowPrivateCallbacks?: boolean;
+
+  /**
+   * FN-079: injectable DNS lookup for the SSRF guard. Defaults to
+   * `node:dns/promises.lookup`. Tests pass a stub so they don't hit
+   * real DNS.
+   */
+  dnsLookup?: DnsLookupFn;
 }
 
 // ---------------------------------------------------------------------------
@@ -414,7 +455,7 @@ export async function postBppOnSearch(
     deps.allowPrivateCallbacks === true ||
     process.env["ETO_BECKN_ALLOW_PRIVATE_CALLBACKS"] === "1";
 
-  if (!allowPrivate && isPrivateOrLoopbackHost(parsed.hostname)) {
+  if (!allowPrivate && (await isPrivateOrLoopbackHostResolved(parsed.hostname, deps.dnsLookup))) {
     return { status: 0, ok: false, attempts: 0, reason: "ssrf_blocked" };
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -80,12 +80,14 @@ export {
   KycTestIssueError,
   buildKycTestVc,
   deriveNullifier as deriveKycTestNullifier,
+  ed25519KycTestSignatureVerifier,
   issueKycTest,
   jcsCanonicalize as jcsCanonicalizeKycTest,
   normalizeName as normalizeKycTestName,
   renderKycTestFormHtml,
 } from "./issuers/kyc-test.js";
 export type {
+  KycTestAgentCardSignatureVerifier,
   KycTestDedupeRow,
   KycTestDedupeStore,
   KycTestFormSubmission,

--- a/src/index.ts
+++ b/src/index.ts
@@ -147,8 +147,10 @@ export {
   AuditTrailIndexer,
   AuditTrailIndexerError,
   InMemoryKytEventSource,
+  PostgresKytEventSource,
   buildAuditFeed,
   counterpartyWireSchema,
+  createKytEventSourceFromEnv,
   kytStageWireSchema,
   kytTraceEventSchema,
   partyTraceWireSchema,
@@ -171,6 +173,7 @@ export type {
   KytStageWire,
   KytTraceEvent,
   PartyTraceWire,
+  PostgresKytEventSourceInit,
   RevocationRootUpdatedEvent,
 } from "./services/indexer/index.js";
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -220,3 +220,21 @@ export type {
   TravelRuleReportJsonLd,
 } from "./services/indexer/travel-rule.js";
 
+// VC signer for audit-trail / travel-rule documents (FN-084) —
+// `Ed25519Signature2020` proof blocks per W3C VC Data Integrity / RFC 8785.
+export {
+  DEFAULT_UNSIGNED_DID,
+  Ed25519VcSigner,
+  NoOpVcSigner,
+  base64UrlEncode,
+  canonicalizeJcs,
+  createVcSignerFromEnv,
+} from "./services/indexer/vc-signer.js";
+export type {
+  CreateVcSignerFromEnvOpts,
+  Ed25519Signature2020Proof,
+  Ed25519VcSignerFromKeyFileOpts,
+  Ed25519VcSignerInit,
+  VcSigner,
+} from "./services/indexer/vc-signer.js";
+

--- a/src/issuers/bank-mock.ts
+++ b/src/issuers/bank-mock.ts
@@ -29,7 +29,8 @@
 // (T-1.4.1.2 / T-1.4.1.3) so a single gateway boot can wire all
 // three with the same chain client and pinner.
 
-import { createHash } from "node:crypto";
+import { Buffer } from "node:buffer";
+import { createHash, timingSafeEqual } from "node:crypto";
 
 import {
   BankMockIssueError,
@@ -96,6 +97,13 @@ export async function issueBankFiatRampTest(
   request: BankMockIssueRequest,
 ): Promise<BankMockIssueResponse> {
   const { checkingAccountId, agentCardPubkey } = request;
+
+  // FN-070: caller-binding security gate — MUST run before any side effect.
+  // `callerPubkey` is the verified BAP signature principal from the gateway.
+  // It must equal `agentCardPubkey` (the subject named in the request body);
+  // otherwise a rogue caller could mint credentials for other agents.
+  assertCallerBindingOrThrow(request.callerPubkey, agentCardPubkey);
+
   if (checkingAccountId.length === 0) {
     throw new BankMockIssueError(
       "invalid_request",
@@ -284,6 +292,49 @@ export async function revokeBankFiatRampTest(
 }
 
 // -- Helpers ----------------------------------------------------------
+
+/**
+ * Assert that the verified caller pubkey matches the `agentCardPubkey` named
+ * in the request body before any mint side-effect runs (FN-070).
+ *
+ * Throws `BankMockIssueError("unauthorized_caller", ...)` when:
+ *   - `callerPubkey` is absent or empty ("gateway did not verify a caller")
+ *   - `agentCardPubkey` is empty
+ *   - the two values differ (constant-time comparison over equal-length hex)
+ *
+ * Case-insensitive over hex (both sides are lowercased before comparison).
+ * Uses `timingSafeEqual` to avoid timing oracles.
+ */
+function assertCallerBindingOrThrow(
+  callerPubkey: string | undefined,
+  agentCardPubkey: string,
+): void {
+  if (
+    !callerPubkey ||
+    agentCardPubkey.length === 0
+  ) {
+    throw new BankMockIssueError(
+      "unauthorized_caller",
+      "caller is not bound to the requested agentCardPubkey",
+    );
+  }
+  const a = callerPubkey.toLowerCase();
+  const b = agentCardPubkey.toLowerCase();
+  if (a.length !== b.length) {
+    throw new BankMockIssueError(
+      "unauthorized_caller",
+      "caller is not bound to the requested agentCardPubkey",
+    );
+  }
+  const aBuf = Buffer.from(a, "utf8");
+  const bBuf = Buffer.from(b, "utf8");
+  if (!timingSafeEqual(aBuf, bBuf)) {
+    throw new BankMockIssueError(
+      "unauthorized_caller",
+      "caller is not bound to the requested agentCardPubkey",
+    );
+  }
+}
 
 interface VcInput {
   agentCardPubkey: string;

--- a/src/issuers/bank-mock.types.ts
+++ b/src/issuers/bank-mock.types.ts
@@ -113,6 +113,15 @@ export interface BankMockIssueRequest {
   readonly checkingAccountId: string;
   /** Subject's AgentCard pubkey (base58). */
   readonly agentCardPubkey: string;
+  /**
+   * Verified caller pubkey from gateway-level BAP signature verification
+   * (FN-073 / FN-075). Must equal `agentCardPubkey` before any mint
+   * side-effect runs (FN-070 caller-binding security fix).
+   *
+   * The gateway MUST populate this from the verified BAP signature.
+   * An absent or empty value causes `unauthorized_caller` rejection.
+   */
+  readonly callerPubkey: string;
 }
 
 export type BankMockIssueResponse =
@@ -163,7 +172,8 @@ export type BankMockIssueErrorKind =
   | "binding_conflict"
   | "not_found"
   | "chain_failed"
-  | "invalid_request";
+  | "invalid_request"
+  | "unauthorized_caller";
 
 export class BankMockIssueError extends Error {
   public override readonly name = "BankMockIssueError";

--- a/src/issuers/kyc-test.ts
+++ b/src/issuers/kyc-test.ts
@@ -31,10 +31,17 @@
 // party predicate of `schema = kyc.us-test` matches; nothing about
 // this credential should be interpreted as real-world KYC.
 
-import { createHash, createHmac, timingSafeEqual } from "node:crypto";
+import {
+  createHash,
+  createHmac,
+  createPublicKey,
+  timingSafeEqual,
+  verify as cryptoVerify,
+} from "node:crypto";
 
 import {
   KYC_TEST_MIN_DWELL_SECONDS,
+  KycTestAgentCardSignatureVerifier,
   KycTestFormSubmission,
   KycTestFormTokenSigner,
   KycTestIssueError,
@@ -48,6 +55,7 @@ export {
   KycTestIssueError,
 } from "./kyc-test.types.js";
 export type {
+  KycTestAgentCardSignatureVerifier,
   KycTestDedupeRow,
   KycTestDedupeStore,
   KycTestFormSubmission,
@@ -99,12 +107,25 @@ export async function issueKycTest(
   deps: KycTestIssuerDeps,
   request: KycTestIssueRequest,
 ): Promise<KycTestIssueResponse> {
-  const { submission, agentCardPubkey } = request;
+  const { submission, agentCardPubkey, agentCardSignature } = request;
   if (agentCardPubkey.length === 0) {
     throw new KycTestIssueError(
       "invalid_form",
       "agentCardPubkey is empty",
       "empty_card",
+    );
+  }
+  if (
+    typeof agentCardSignature !== "string" ||
+    agentCardSignature.length === 0
+  ) {
+    // Treat a missing signature as a wallet-binding failure so the
+    // attacker doesn't get a free 400 — callers MUST prove control
+    // of `agentCardPubkey`. Mirrors civic's behavior.
+    throw new KycTestIssueError(
+      "invalid_agent_card_signature",
+      "agentCardSignature must be a non-empty base64 string",
+      "empty_signature",
     );
   }
 
@@ -113,6 +134,10 @@ export async function issueKycTest(
 
   // Step 2 — verify the form HMAC. The token binds (name, dob,
   // flowStartedAtUnix); changing any of them invalidates the tag.
+  // NOTE: the form HMAC does NOT bind `agentCardPubkey` (the form
+  // is rendered before the wallet picks a card). The wallet-binding
+  // is enforced separately by the Ed25519 `agentCardSignature`
+  // check in Step 4 — see FN-057.
   const tokenOk = deps.tokenSigner.verify({
     fullName: submission.fullName,
     dobIso: submission.dobIso,
@@ -145,8 +170,24 @@ export async function issueKycTest(
     );
   }
 
-  // Step 4 — derive nullifier and consult dedupe store.
+  // Step 4 — derive nullifier and verify the wallet-binding signature
+  // BEFORE the dedupe lookup (FN-057). Without this, an attacker can
+  // POST a victim's `agentCardPubkey` and burn the victim's
+  // (nullifier, card) slot in the dedupe store, denying the rightful
+  // owner of that identity any future issuance on their real card.
   const nullifier = deriveNullifier(normalized.normName, normalized.dobIso);
+
+  const sigOk = await deps.signatureVerifier.verify({
+    nullifier,
+    agentCardPubkey,
+    signature: agentCardSignature,
+  });
+  if (!sigOk) {
+    throw new KycTestIssueError(
+      "invalid_agent_card_signature",
+      "agent card signature does not validate over sha256(nullifier || pubkey)",
+    );
+  }
 
   const existing = await deps.dedupe.get(nullifier);
   if (existing !== undefined) {
@@ -398,6 +439,95 @@ export class HmacKycTestFormTokenSigner implements KycTestFormTokenSigner {
     // collide with any character a user types into the form.
     return `${payload.fullName}\x1f${payload.dobIso}\x1f${payload.flowStartedAtUnix}`;
   }
+}
+
+// -- Default Ed25519 wallet-binding verifier (FN-057) -----------------
+
+/**
+ * Default `KycTestAgentCardSignatureVerifier` backed by Node's
+ * built-in Ed25519 (Node 18+). Mirrors `ed25519SignatureVerifier`
+ * in `civic.ts` so the kyc.us-test issuer enforces the same
+ * wallet-binding contract.
+ *
+ * Resolves `false` on any cryptographic / decoding error — the
+ * caller surfaces the typed `invalid_agent_card_signature` error.
+ */
+export const ed25519KycTestSignatureVerifier: KycTestAgentCardSignatureVerifier =
+  {
+    async verify({ nullifier, agentCardPubkey, signature }) {
+      try {
+        const nullifierBytes = hexToBytes(nullifier);
+        if (nullifierBytes.length !== 32) return false;
+        const cardBytes = base58Decode(agentCardPubkey);
+        if (cardBytes.length !== 32) return false;
+        const sigBytes = Buffer.from(signature, "base64");
+        if (sigBytes.length !== 64) return false;
+        const message = createHash("sha256")
+          .update(nullifierBytes)
+          .update(cardBytes)
+          .digest();
+        // RFC 8410 Ed25519 SubjectPublicKeyInfo prefix.
+        const spki = Buffer.concat([
+          Buffer.from("302a300506032b6570032100", "hex"),
+          Buffer.from(cardBytes),
+        ]);
+        const key = createPublicKey({ key: spki, format: "der", type: "spki" });
+        return cryptoVerify(null, Buffer.from(message), key, sigBytes);
+      } catch {
+        return false;
+      }
+    },
+  };
+
+function hexToBytes(hex: string): Uint8Array {
+  if (hex.length % 2 !== 0) throw new Error("hex: odd length");
+  const out = new Uint8Array(hex.length / 2);
+  for (let i = 0; i < out.length; i += 1) {
+    out[i] = parseInt(hex.slice(i * 2, i * 2 + 2), 16);
+  }
+  return out;
+}
+
+// Local base58 decoder (Solana alphabet) — inlined so kyc-test stays
+// independently versionable (no cross-issuer import). Mirrors the
+// implementation in `civic.ts`.
+const BASE58_ALPHABET =
+  "123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz";
+const BASE58_LOOKUP: Record<string, number> = (() => {
+  const m: Record<string, number> = {};
+  for (let i = 0; i < BASE58_ALPHABET.length; i += 1) {
+    m[BASE58_ALPHABET[i]!] = i;
+  }
+  return m;
+})();
+
+function base58Decode(s: string): Uint8Array {
+  if (s.length === 0) return new Uint8Array(0);
+  let zeros = 0;
+  while (zeros < s.length && s[zeros] === "1") zeros += 1;
+  const bytes: number[] = [];
+  for (let i = zeros; i < s.length; i += 1) {
+    const c = s[i]!;
+    const v = BASE58_LOOKUP[c];
+    if (v === undefined) {
+      throw new Error(`base58: invalid character ${JSON.stringify(c)}`);
+    }
+    let carry = v;
+    for (let j = 0; j < bytes.length; j += 1) {
+      carry += bytes[j]! * 58;
+      bytes[j] = carry & 0xff;
+      carry >>= 8;
+    }
+    while (carry > 0) {
+      bytes.push(carry & 0xff);
+      carry >>= 8;
+    }
+  }
+  const out = new Uint8Array(zeros + bytes.length);
+  for (let i = 0; i < bytes.length; i += 1) {
+    out[zeros + i] = bytes[bytes.length - 1 - i]!;
+  }
+  return out;
 }
 
 // -- Helpers ----------------------------------------------------------

--- a/src/issuers/kyc-test.types.ts
+++ b/src/issuers/kyc-test.types.ts
@@ -29,6 +29,12 @@ export interface KycTestFormSubmission {
    * HMAC tag over `${fullName}|${dobIso}|${flowStartedAtUnix}` from
    * the form-token signer. Prevents trivial replay of an old
    * `flowStartedAtUnix` without going through a real form render.
+   *
+   * NOTE: the form HMAC does NOT bind `agentCardPubkey` (the form
+   * is rendered before the wallet picks a card). Wallet-binding is
+   * enforced separately by the Ed25519 `agentCardSignature` on the
+   * issue request — see FN-057 and
+   * `KycTestAgentCardSignatureVerifier` below.
    */
   readonly formTokenHmacHex: string;
 }
@@ -80,6 +86,30 @@ export interface KycTestDedupeStore {
 }
 
 /**
+ * Wallet-binding signature verifier (FN-057). Mirrors
+ * `AgentCardSignatureVerifier` in `civic.types.ts` /
+ * `worldcoin.types.ts` so the kyc.us-test issuer enforces the same
+ * "caller proves control of agentCardPubkey" invariant the other
+ * issuers do.
+ *
+ * The verifier checks an Ed25519 signature by `agentCardPubkey` over
+ * `sha256(nullifierBytes || agentCardPubkeyBytes)`. Implementations
+ * MUST resolve `false` on any cryptographic / decoding failure
+ * instead of throwing — the caller surfaces the typed
+ * `invalid_agent_card_signature` error.
+ */
+export interface KycTestAgentCardSignatureVerifier {
+  verify(input: {
+    /** 64-char lowercase hex (the dedupe nullifier). */
+    readonly nullifier: string;
+    /** base58 32-byte AgentCard pubkey. */
+    readonly agentCardPubkey: string;
+    /** base64 64-byte Ed25519 signature. */
+    readonly signature: string;
+  }): Promise<boolean>;
+}
+
+/**
  * Submits an `IssueCredential` instruction. Same contract as the
  * Civic adapter so the gateway can reuse a single chain client.
  */
@@ -111,6 +141,12 @@ export interface KycTestIssuerDeps {
   readonly chain: KycTestIssueCredentialClient;
   readonly pinner: KycTestVcPinner;
   readonly clock: KycTestSlotClock;
+  /**
+   * Wallet-binding signature verifier (FN-057). REQUIRED so a caller
+   * cannot mint a `kyc.us-test` credential to an `agentCardPubkey`
+   * they do not control. See `KycTestAgentCardSignatureVerifier`.
+   */
+  readonly signatureVerifier: KycTestAgentCardSignatureVerifier;
   /** Issuer authority pubkey (base58); recorded inside the off-chain VC. */
   readonly issuerAuthorityPubkey: string;
   /**
@@ -126,6 +162,13 @@ export interface KycTestIssuerDeps {
 export interface KycTestIssueRequest {
   readonly submission: KycTestFormSubmission;
   readonly agentCardPubkey: string;
+  /**
+   * Base64 Ed25519 signature by `agentCardPubkey` over
+   * `sha256(nullifierBytes || agentCardPubkeyBytes)` (FN-057).
+   * Mirrors `CivicIssueRequest.agentCardSignature` so the bridge
+   * enforces wallet-binding for the mock kyc.us-test issuer too.
+   */
+  readonly agentCardSignature: string;
 }
 
 export type KycTestIssueResponse =
@@ -146,12 +189,13 @@ export type KycTestIssueResponse =
     };
 
 /**
- * - `replay_conflict`  → 409 (subject already bound to a different card).
- * - `invalid_form`     → 400 (missing/malformed name or DOB).
- * - `invalid_token`    → 400 (form-token HMAC mismatch).
- * - `dwell_too_short`  → 400 (submission inside the 30-second window).
- * - `dwell_in_future`  → 400 (clock skew / forged future timestamp).
- * - `chain_failed`     → 502 (IssueCredential tx failed).
+ * - `replay_conflict`              → 409 (subject already bound to a different card).
+ * - `invalid_form`                 → 400 (missing/malformed name or DOB).
+ * - `invalid_token`                → 400 (form-token HMAC mismatch).
+ * - `dwell_too_short`              → 400 (submission inside the 30-second window).
+ * - `dwell_in_future`              → 400 (clock skew / forged future timestamp).
+ * - `invalid_agent_card_signature` → 401 (caller does not control `agentCardPubkey`).
+ * - `chain_failed`                 → 502 (IssueCredential tx failed).
  */
 export type KycTestIssueErrorKind =
   | "replay_conflict"
@@ -159,6 +203,7 @@ export type KycTestIssueErrorKind =
   | "invalid_token"
   | "dwell_too_short"
   | "dwell_in_future"
+  | "invalid_agent_card_signature"
   | "chain_failed";
 
 export class KycTestIssueError extends Error {

--- a/src/issuers/skill-cert.ts
+++ b/src/issuers/skill-cert.ts
@@ -45,10 +45,15 @@
  *    devnet point at an `InMemoryChainClient` if desired.
  */
 
-import { createHash } from "node:crypto";
+import {
+  createHash,
+  createPublicKey,
+  verify as cryptoVerify,
+} from "node:crypto";
 
 import {
   type AgentCardPubkey,
+  type AgentCardSignatureVerifier,
   type ChainClient,
   type ClaimHasher,
   type Hex32,
@@ -72,6 +77,13 @@ export * from "./skill-cert.types.js";
 /** Schema-id namespace prefix. The full tag is `${PREFIX}${skill}.v1`. */
 export const SKILL_CERT_SCHEMA_PREFIX = "eto.beckn.schema.skill-cert.";
 
+/**
+ * Domain-separation tag for the caller-binding signature preimage.
+ * Verifiers MUST use this exact byte sequence — changing it is a
+ * breaking wire change.
+ */
+export const SKILL_CERT_SIG_DOMAIN = "eto:skill-cert:v1";
+
 /** Schema-id namespace suffix (version pin). */
 export const SKILL_CERT_SCHEMA_SUFFIX = ".v1";
 
@@ -83,6 +95,113 @@ export const SKILL_CERT_VC_CONTEXT: readonly string[] = [
 
 /** Slug pattern: lowercase letters, digits, single hyphens. */
 const SKILL_SLUG_RE = /^[a-z0-9]+(?:-[a-z0-9]+)*$/;
+
+/* -------------------------------------------------------------------------- */
+/* Caller-binding signature                                                    */
+/* -------------------------------------------------------------------------- */
+
+/**
+ * Build the canonical preimage hash for a skill-cert
+ * `agentCardSignature`:
+ *
+ *   sha256(SKILL_CERT_SIG_DOMAIN || skill || subjectAgentCard || issuanceNonce)
+ *
+ * Returns the 32-byte digest (NOT hex) that callers actually feed to
+ * Ed25519. Field separators are intentionally omitted because each
+ * field is range-validated upstream (skill slug regex, non-empty
+ * subject, non-empty nonce) and Ed25519 signs the digest, not the
+ * preimage — length-extension games are irrelevant.
+ */
+export function skillCertSignaturePreimage(args: {
+  readonly skill: SkillId;
+  readonly subjectAgentCard: AgentCardPubkey;
+  readonly issuanceNonce: string;
+}): Buffer {
+  return createHash("sha256")
+    .update(
+      SKILL_CERT_SIG_DOMAIN +
+        args.skill +
+        args.subjectAgentCard +
+        args.issuanceNonce,
+      "utf8",
+    )
+    .digest();
+}
+
+/** Base58 alphabet — Solana / AgentCard pubkey decoding. */
+const BASE58_ALPHABET =
+  "123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz";
+const BASE58_LOOKUP: Record<string, number> = (() => {
+  const m: Record<string, number> = {};
+  for (let i = 0; i < BASE58_ALPHABET.length; i += 1) {
+    m[BASE58_ALPHABET[i]!] = i;
+  }
+  return m;
+})();
+
+/** Decode a base58 string into raw bytes. Throws on invalid input. */
+function base58Decode(s: string): Uint8Array {
+  if (s.length === 0) return new Uint8Array(0);
+  let zeros = 0;
+  while (zeros < s.length && s[zeros] === "1") zeros += 1;
+
+  const bytes: number[] = [];
+  for (let i = zeros; i < s.length; i += 1) {
+    const c = s[i]!;
+    const v = BASE58_LOOKUP[c];
+    if (v === undefined) {
+      throw new Error(`base58: invalid character ${JSON.stringify(c)}`);
+    }
+    let carry = v;
+    for (let j = 0; j < bytes.length; j += 1) {
+      carry += bytes[j]! * 58;
+      bytes[j] = carry & 0xff;
+      carry >>= 8;
+    }
+    while (carry > 0) {
+      bytes.push(carry & 0xff);
+      carry >>= 8;
+    }
+  }
+  const out = new Uint8Array(zeros + bytes.length);
+  for (let i = 0; i < bytes.length; i += 1) {
+    out[zeros + i] = bytes[bytes.length - 1 - i]!;
+  }
+  return out;
+}
+
+/**
+ * Default `AgentCardSignatureVerifier` for skill-cert: Ed25519
+ * verification of `signature` (base64) against the 32-byte preimage
+ * digest, using `subjectAgentCard` (base58, 32 bytes) as the public
+ * key. Returns `false` on any decoding / cryptographic failure.
+ *
+ * Mirrors the convention in `civic.ts:ed25519SignatureVerifier`.
+ */
+export const ed25519SkillCertSignatureVerifier: AgentCardSignatureVerifier = {
+  async verify({ skill, subjectAgentCard, issuanceNonce, signature }) {
+    try {
+      const cardBytes = base58Decode(subjectAgentCard);
+      if (cardBytes.length !== 32) return false;
+      const sigBytes = Buffer.from(signature, "base64");
+      if (sigBytes.length !== 64) return false;
+      const message = skillCertSignaturePreimage({
+        skill,
+        subjectAgentCard,
+        issuanceNonce,
+      });
+      // RFC 8410 Ed25519 SubjectPublicKeyInfo prefix.
+      const spki = Buffer.concat([
+        Buffer.from("302a300506032b6570032100", "hex"),
+        Buffer.from(cardBytes),
+      ]);
+      const key = createPublicKey({ key: spki, format: "der", type: "spki" });
+      return cryptoVerify(null, message, key, sigBytes);
+    } catch {
+      return false;
+    }
+  },
+};
 
 /* -------------------------------------------------------------------------- */
 /* Hashing utilities                                                           */
@@ -216,6 +335,14 @@ export interface SkillCertIssuerDeps {
   readonly bindingStore: SkillBindingStore;
   readonly chain: ChainClient;
   readonly ipfs: IpfsPinner;
+  /**
+   * Verifies the caller-binding Ed25519 signature on every request
+   * BEFORE the binding-store lookup, whitelist check, or chain call.
+   * REQUIRED — omitting it (or wiring an always-true stub in
+   * production) re-introduces FN-058. Defaults to
+   * `ed25519SkillCertSignatureVerifier` when the dep is not provided.
+   */
+  readonly signatureVerifier?: AgentCardSignatureVerifier;
   readonly claimHasher?: ClaimHasher;
   /** Clock injection for deterministic tests. Defaults to `Date.now`. */
   readonly now?: () => number;
@@ -229,12 +356,15 @@ export class SkillCertIssuer {
   private readonly cfg: SkillCertIssuerConfig;
   private readonly deps: SkillCertIssuerDeps;
   private readonly hasher: ClaimHasher;
+  private readonly signatureVerifier: AgentCardSignatureVerifier;
   private readonly now: () => number;
 
   public constructor(cfg: SkillCertIssuerConfig, deps: SkillCertIssuerDeps) {
     this.cfg = cfg;
     this.deps = deps;
     this.hasher = deps.claimHasher ?? defaultClaimHasher;
+    this.signatureVerifier =
+      deps.signatureVerifier ?? ed25519SkillCertSignatureVerifier;
     this.now = deps.now ?? Date.now;
   }
 
@@ -264,8 +394,50 @@ export class SkillCertIssuer {
         400,
       );
     }
+    if (
+      typeof req.agentCardSignature !== "string" ||
+      req.agentCardSignature.length === 0
+    ) {
+      throw new SkillCertIssuerError(
+        "INVALID_AGENT_CARD_SIGNATURE",
+        "agentCardSignature must be a non-empty base64 string",
+        401,
+      );
+    }
+    if (
+      typeof req.issuanceNonce !== "string" ||
+      req.issuanceNonce.length === 0
+    ) {
+      throw new SkillCertIssuerError(
+        "INVALID_AGENT_CARD_SIGNATURE",
+        "issuanceNonce must be a non-empty string",
+        401,
+      );
+    }
 
     const schema = schemaIdForSkill(req.skill);
+
+    /* 1b. Caller-binding signature check. ------------------------------- *
+     *     Runs BEFORE the idempotency lookup, whitelist gate, and chain
+     *     call so an attacker who learns a whitelisted (skill, subject)
+     *     tuple cannot front-run the legitimate AgentCard owner
+     *     (FN-058). Mirrors `civic.ts` step 3 — see the
+     *     "Issuer caller-binding convention" project memory entry.
+     */
+    const sigOk = await this.signatureVerifier.verify({
+      skill: req.skill,
+      subjectAgentCard: req.subjectAgentCard,
+      issuanceNonce: req.issuanceNonce,
+      signature: req.agentCardSignature,
+    });
+    if (!sigOk) {
+      throw new SkillCertIssuerError(
+        "INVALID_AGENT_CARD_SIGNATURE",
+        "agentCardSignature does not validate over sha256(" +
+          `${SKILL_CERT_SIG_DOMAIN} || skill || subjectAgentCard || issuanceNonce)`,
+        401,
+      );
+    }
 
     /* 2. Idempotency pre-check. ----------------------------------------- *
      *    We check the binding store BEFORE the whitelist so a previously

--- a/src/issuers/skill-cert.types.ts
+++ b/src/issuers/skill-cert.types.ts
@@ -32,6 +32,24 @@ export interface SkillCertIssueRequest {
   readonly skill: SkillId;
   /** Subject AgentCard pubkey the credential will be issued to. */
   readonly subjectAgentCard: AgentCardPubkey;
+  /**
+   * Caller-binding signature: Ed25519 signature by `subjectAgentCard`
+   * over `sha256("eto:skill-cert:v1" || skill || subjectAgentCard ||
+   * issuanceNonce)`. Encoded as base64. Without this, an attacker who
+   * learns a whitelisted `(skill, subject)` tuple can front-run the
+   * legitimate owner. See FN-058 / convention mirror in
+   * `src/issuers/civic.ts:169-185`.
+   */
+  readonly agentCardSignature: string;
+  /**
+   * Caller-supplied freshness nonce mixed into the signature preimage.
+   * Must be a non-empty string. Re-using a nonce on a fresh
+   * (skill, subject) pair is permitted (the binding store still serves
+   * the idempotent path); the nonce exists to bind a *specific*
+   * issuance attempt and let a wallet replace its signed payload
+   * without rotating its keypair.
+   */
+  readonly issuanceNonce: string;
 }
 
 /** Wire-level response body for a successful issuance. */
@@ -119,12 +137,36 @@ export interface SkillWhitelist {
 }
 
 /**
+ * Verifier for the caller-binding signature on a skill-cert request.
+ * Returns `true` iff `signature` is a valid Ed25519 signature by
+ * `subjectAgentCard` over the canonical preimage
+ * `sha256("eto:skill-cert:v1" || skill || subjectAgentCard || issuanceNonce)`.
+ *
+ * Implementations MUST resolve `false` (not throw) on cryptographic /
+ * decoding failure so the issuer can map the outcome to a single typed
+ * `INVALID_AGENT_CARD_SIGNATURE` error.
+ *
+ * Mirrors `AgentCardSignatureVerifier` in `civic.types.ts` and
+ * `worldcoin.types.ts` — see FN-058 fix and the
+ * "Issuer caller-binding convention" project memory entry.
+ */
+export interface AgentCardSignatureVerifier {
+  verify(input: {
+    readonly skill: SkillId;
+    readonly subjectAgentCard: AgentCardPubkey;
+    readonly issuanceNonce: string;
+    readonly signature: string; // base64
+  }): Promise<boolean>;
+}
+
+/**
  * Strongly-typed errors surfaced to the HTTP handler so it can map to
  * status codes without string-matching.
  */
 export type SkillCertIssuerErrorCode =
   | "INVALID_SKILL"
   | "INVALID_SUBJECT"
+  | "INVALID_AGENT_CARD_SIGNATURE"
   | "NOT_WHITELISTED"
   | "CHAIN_TX_FAILED";
 

--- a/src/models/agent-identity.ts
+++ b/src/models/agent-identity.ts
@@ -1,0 +1,281 @@
+/**
+ * Agent Identity Model — `human × model × environment × session`.
+ *
+ * Reference TypeScript shape for the spec at
+ * [`docs/agent-identity-model.md`](../../docs/agent-identity-model.md).
+ *
+ * **Status (FN-058):** spec-only. This module is exported but is NOT wired
+ * into any MCP tool, request handler, or transport. FN-059 is the first task
+ * that will consume `AgentIdentity` in a handler. Do not import from
+ * `src/tools/session.ts` here — the builder takes a structurally typed input
+ * (a `session_info`-shaped payload) to keep this module decoupled from any
+ * concrete tool implementation.
+ *
+ * Field-level JSDoc references the section numbers in
+ * `docs/agent-identity-model.md` (e.g. `§2.1`).
+ */
+
+import type { SvmAddress, EvmAddress } from "./index.js";
+
+// ---------------------------------------------------------------------------
+// §2.1 — human_authority
+// ---------------------------------------------------------------------------
+
+/**
+ * Which auth backend issued the human attestation behind this identity.
+ *
+ * Matches the realistic set of strategies in `src/gateway/session.ts`
+ * (`AuthStrategy`) plus two synthetic kinds:
+ *
+ * - `"stdio"` — the stdio entrypoint runs in the literal `"__stdio__"` scope
+ *   without any human attestation. Local-trust only.
+ * - `"unknown"` — fallback when no `auth_strategy` is present and the scope
+ *   is not one of the known synthetic scopes.
+ *
+ * See spec §2.1.
+ */
+export type HumanAuthorityKind =
+  | "thirdweb" // siwe / inapp_email / inapp_oauth — real human-attested
+  | "dev"      // dev-bypass; never inherits authority
+  | "stdio"    // __stdio__ scope; local trust only
+  | "unknown";
+
+/**
+ * The human (or human-controlled service account) that consented to this
+ * agent acting on their behalf. See spec §2.1.
+ */
+export interface HumanAuthority {
+  /** Persistence-key form of the human identity. Today: `SessionPayload.sub`,
+   *  `"__stdio__"`, or `"__dev__"`. See spec §2.1. */
+  sub: string;
+  /** Coarse classification of the auth backend; see {@link HumanAuthorityKind}. */
+  kind: HumanAuthorityKind;
+  /** Raw `auth_strategy` from the session token, when present. Mirrors
+   *  `SessionPayload.auth_strategy` from `src/gateway/session.ts`. */
+  auth_strategy?: "siwe" | "inapp_email" | "inapp_oauth" | "dev";
+}
+
+// ---------------------------------------------------------------------------
+// §2.2 — model_attestation
+// ---------------------------------------------------------------------------
+
+/**
+ * Discriminator for {@link ModelAttestation}. See spec §2.2 and §4.
+ *
+ * - `"verified"` — provider-signed JWS verified against published JWKS.
+ *   ONLY this state is safe for capability gating.
+ * - `"self_declared"` — the agent advertised a model claim but no signature
+ *   was verified. Telemetry-only; never gate capabilities on this.
+ * - `"absent"` — no claim was made (or verification failed). Do not branch
+ *   on model identity at all.
+ */
+export type AttestationStatus = "verified" | "self_declared" | "absent";
+
+/** A claim about which AI model produced the agent's actions. See spec §2.2. */
+export type ModelAttestation =
+  | {
+      attestation_status: "verified";
+      provider: string;
+      model_id: string;
+      /** JWS `kid` from the verified attestation. */
+      kid: string;
+      /** Issuance timestamp (seconds since epoch) of the verified JWS. */
+      issued_at: number;
+    }
+  | {
+      attestation_status: "self_declared";
+      provider: string;
+      model_id: string;
+    }
+  | {
+      attestation_status: "absent";
+    };
+
+// ---------------------------------------------------------------------------
+// §2.3 — environment
+// ---------------------------------------------------------------------------
+
+/** Execution surface the agent is running on. See spec §2.3. */
+export type ExecutionSurface = "stdio" | "sse" | "dev";
+
+/**
+ * Cryptographic anchor — the wallet whose private keys actually sign actions.
+ * Matches the active-wallet shape returned by `session_info`. See spec §2.3.
+ */
+export interface WalletAnchor {
+  id: string;
+  /** Base58 Ed25519 public key. Null if the signer could not be loaded. */
+  svm: SvmAddress | null;
+  /** 0x-hex secp256k1 address. Null if the signer could not be loaded. */
+  evm: EvmAddress | null;
+  label?: string | null;
+}
+
+/** Where the agent is executing + its cryptographic anchor. See spec §2.3. */
+export interface Environment {
+  surface: ExecutionSurface;
+  /** Stable per-process identifier; today: the server's `last_restart_iso`. */
+  server_instance: string;
+  /** The active wallet whose keys sign actions. */
+  wallet_anchor: WalletAnchor;
+}
+
+// ---------------------------------------------------------------------------
+// §2.4 — session_scope
+// ---------------------------------------------------------------------------
+
+/** The bounded MCP session window. See spec §2.4. */
+export interface SessionScope {
+  /** Persistence-key form of the scope; mirrors `currentScope()`. */
+  scope: string;
+  /** Session token id (`SessionPayload.jti`) when known. */
+  jti?: string;
+  /** ISO-8601 expiry; null when no token is bound (e.g. stdio). */
+  expires_at_iso: string | null;
+  /** Capabilities granted on the session token; see `CAPABILITY_SCOPES`. */
+  capabilities: string[];
+}
+
+// ---------------------------------------------------------------------------
+// §6 — top-level shape
+// ---------------------------------------------------------------------------
+
+/**
+ * The canonical agent identity tuple. See spec §1 and §6.
+ *
+ * Consumers MUST evaluate all four axes independently; see §3 for the
+ * authority-inheritance rule and §5 for the trust degradation that applies
+ * when `model_attestation.attestation_status !== "verified"`.
+ */
+export interface AgentIdentity {
+  /** §2.1 — who authorized this agent. */
+  human_authority: HumanAuthority;
+  /** §2.2 — which AI model is steering it. */
+  model_attestation: ModelAttestation;
+  /** §2.3 — where it's running and the cryptographic anchor. */
+  environment: Environment;
+  /** §2.4 — bounded MCP session window. */
+  session_scope: SessionScope;
+}
+
+// ---------------------------------------------------------------------------
+// §5 — interim builder
+// ---------------------------------------------------------------------------
+
+/**
+ * Structurally typed input mirroring the `session_info` MCP tool's response
+ * shape. We accept it as a plain shape (not by importing from
+ * `src/tools/session.ts`) so this module stays decoupled from the tool layer.
+ *
+ * See spec §5.
+ */
+export interface InterimAgentIdentityInput {
+  /** From `currentScope()`; required. */
+  scope: string;
+  /** Active wallet id; from `getActiveWalletId()`. */
+  active_wallet_id: string | null;
+  /** Wallet list as returned by `session_info`. */
+  wallets: ReadonlyArray<{
+    id: string;
+    label?: string | null;
+    svm: SvmAddress | null;
+    evm: EvmAddress | null;
+  }>;
+  /** From `SessionPayload.auth_strategy`. */
+  auth_strategy?: "siwe" | "inapp_email" | "inapp_oauth" | "dev" | null;
+  /** ISO string from `session_info.token_expires_at`. */
+  token_expires_at?: string | null;
+  /** ISO string from `session_info.last_restart_iso`. */
+  last_restart_iso: string;
+  /** Optional: caller-declared model. Becomes a `self_declared` attestation. */
+  declared_model?: { provider: string; model_id: string };
+  /** Optional: capabilities from `SessionPayload.caps`. Defaults to `[]`. */
+  capabilities?: ReadonlyArray<string>;
+  /** Optional: `SessionPayload.jti` when available. */
+  jti?: string;
+}
+
+/**
+ * Build an {@link AgentIdentity} from a `session_info`-shaped payload, with
+ * no provider integration. The result always has
+ * `model_attestation.attestation_status` of `"self_declared"` (when
+ * `declared_model` is present) or `"absent"`.
+ *
+ * Pure function — no I/O, no global state.
+ *
+ * @throws {Error} if `scope` is missing or empty (see spec §5: there is no
+ * meaningful identity without a session-scope persistence key).
+ */
+export function buildInterimAgentIdentity(
+  input: InterimAgentIdentityInput,
+): AgentIdentity {
+  if (!input.scope || typeof input.scope !== "string") {
+    throw new Error(
+      "buildInterimAgentIdentity: missing required `session_scope` source — `scope` must be a non-empty string (see docs/agent-identity-model.md §5).",
+    );
+  }
+
+  const human_authority = resolveHumanAuthority(input);
+  const environment = resolveEnvironment(input);
+  const model_attestation: ModelAttestation = input.declared_model
+    ? {
+        attestation_status: "self_declared",
+        provider: input.declared_model.provider,
+        model_id: input.declared_model.model_id,
+      }
+    : { attestation_status: "absent" };
+
+  const session_scope: SessionScope = {
+    scope: input.scope,
+    expires_at_iso: input.token_expires_at ?? null,
+    capabilities: [...(input.capabilities ?? [])],
+    ...(input.jti !== undefined ? { jti: input.jti } : {}),
+  };
+
+  return { human_authority, model_attestation, environment, session_scope };
+}
+
+function resolveHumanAuthority(input: InterimAgentIdentityInput): HumanAuthority {
+  const strategy = input.auth_strategy ?? undefined;
+  let kind: HumanAuthorityKind;
+  if (input.scope === "__stdio__") kind = "stdio";
+  else if (input.scope === "__dev__" || strategy === "dev") kind = "dev";
+  else if (
+    strategy === "siwe" ||
+    strategy === "inapp_email" ||
+    strategy === "inapp_oauth"
+  )
+    kind = "thirdweb";
+  else kind = "unknown";
+
+  return {
+    sub: input.scope,
+    kind,
+    ...(strategy !== undefined ? { auth_strategy: strategy } : {}),
+  };
+}
+
+function resolveEnvironment(input: InterimAgentIdentityInput): Environment {
+  let surface: ExecutionSurface;
+  if (input.scope === "__stdio__") surface = "stdio";
+  else if (input.scope === "__dev__" || input.auth_strategy === "dev") surface = "dev";
+  else surface = "sse";
+
+  const active = input.wallets.find((w) => w.id === input.active_wallet_id) ??
+    input.wallets[0];
+
+  const wallet_anchor: WalletAnchor = active
+    ? {
+        id: active.id,
+        svm: active.svm,
+        evm: active.evm,
+        label: active.label ?? null,
+      }
+    : { id: "", svm: null, evm: null, label: null };
+
+  return {
+    surface,
+    server_instance: input.last_restart_iso,
+    wallet_anchor,
+  };
+}

--- a/src/models/agent-identity.ts
+++ b/src/models/agent-identity.ts
@@ -81,6 +81,14 @@ export type ModelAttestation =
       kid: string;
       /** Issuance timestamp (seconds since epoch) of the verified JWS. */
       issued_at: number;
+      /** How the verification was established. `"session_signed"` = caller
+       *  supplied a JWS bound to this session; `"provider_oidc"` = verified
+       *  against the provider's published JWKS endpoint. */
+      source: "session_signed" | "provider_oidc";
+      /** Whether the provider's own infrastructure attested the model claim. */
+      provider_verified: boolean;
+      /** The raw compact JWS that carried the attestation. */
+      jws: string;
     }
   | {
       attestation_status: "self_declared";
@@ -193,6 +201,23 @@ export interface InterimAgentIdentityInput {
   capabilities?: ReadonlyArray<string>;
   /** Optional: `SessionPayload.jti` when available. */
   jti?: string;
+  /**
+   * Optional: a caller-supplied JWS that was already verified against the
+   * provider's session signing key. When present, `buildInterimAgentIdentity`
+   * emits a `"verified"` attestation with `source: "session_signed"`.
+   */
+  verified_session_jws?: {
+    /** The compact JWS string. */
+    jws: string;
+    /** `sub` claim from the verified token — the model's identity assertion. */
+    sub: string;
+    /** Model identifier claimed in the JWS. */
+    model_id: string;
+    /** Provider that issued the JWS (e.g. `"anthropic"`). */
+    provider: string;
+    /** Expiry of the JWS as a Unix timestamp (seconds). */
+    exp: number;
+  };
 }
 
 /**
@@ -217,7 +242,18 @@ export function buildInterimAgentIdentity(
 
   const human_authority = resolveHumanAuthority(input);
   const environment = resolveEnvironment(input);
-  const model_attestation: ModelAttestation = input.declared_model
+  const model_attestation: ModelAttestation = input.verified_session_jws
+    ? {
+        attestation_status: "verified",
+        provider: input.verified_session_jws.provider,
+        model_id: input.verified_session_jws.model_id,
+        kid: input.verified_session_jws.sub,
+        issued_at: input.verified_session_jws.exp,
+        source: "session_signed",
+        provider_verified: false,
+        jws: input.verified_session_jws.jws,
+      }
+    : input.declared_model
     ? {
         attestation_status: "self_declared",
         provider: input.declared_model.provider,

--- a/src/read/rpc-client.ts
+++ b/src/read/rpc-client.ts
@@ -13,17 +13,21 @@ interface JsonRpcResponse<T> {
 }
 
 /**
- * FN-197 / FN-198: validate that a string looks like a real on-chain
- * transaction signature before letting it leave the RPC client. Accepts
- * either base58 (40-90 chars, base58 alphabet) or hex (64-128 chars).
- * Rejects the JSON.stringify-of-an-error-object case.
+ * FN-197: validate that a string looks like a real on-chain transaction
+ * signature before letting it leave the RPC client. `faucet` is SVM-only,
+ * so we accept base58 only with the strict bounds called out in the
+ * FN-097 error-masking audit: 43–88 chars from the base58 alphabet
+ * (Solana mainnet sigs decode to 64 bytes → 87–88 base58 chars; 43 is
+ * the lower bound for short test payloads). Hex responses are themselves
+ * a smell — they indicate the node is running a non-SVM mock — so they
+ * are rejected. This closes the JSON.stringify-of-an-error-object
+ * masking case identified by FN-097.
  */
-const BASE58_RE = /^[1-9A-HJ-NP-Za-km-z]{40,90}$/;
-const HEX_SIG_RE = /^(0x)?[0-9a-fA-F]{64,128}$/;
+const BASE58_RE = /^[1-9A-HJ-NP-Za-km-z]{43,88}$/;
 function isValidSignature(s: string): boolean {
   if (typeof s !== "string") return false;
   if (s.length === 0) return false;
-  return BASE58_RE.test(s) || HEX_SIG_RE.test(s);
+  return BASE58_RE.test(s);
 }
 
 export class EtoRpcClient {

--- a/src/services/indexer/audit-trail.ts
+++ b/src/services/indexer/audit-trail.ts
@@ -22,11 +22,14 @@
 // downstream consumers (FN-132 1099 issuer, FN-133 travel-rule
 // generator) can hash the output for caching / diffing.
 //
-// **v0 caveat — UNSIGNED.** The `issuer` field is a placeholder DID
-// (`did:eto:indexer:audit-trail:v0`). This audit feed is NOT
-// cryptographically signed in v0; downstream consumers must treat the
-// document as derived data, not as proof. Signing (VC-JOSE / Ed25519)
-// is a follow-up task.
+// **Signing.** Signing is opt-in via the injected `VcSigner`; the
+// default `NoOpVcSigner` preserves the historical unsigned shape
+// (no `proof` key in the emitted document). Set
+// `AUDIT_SIGNING_KEY_PATH` and pass `createVcSignerFromEnv({ issuerDid })`
+// to emit an `Ed25519Signature2020` proof block per W3C VC Data
+// Integrity / RFC 8785 (FN-084). The proof preimage is
+// `sha256(JCS(vcWithoutProof))` — the proof block is excluded from the
+// hash input.
 //
 // **Determinism guarantees.** Given identical event inputs and bounds,
 // `buildAuditFeed` MUST produce a byte-identical document apart from
@@ -39,6 +42,11 @@ import {
   kytTraceEventSchema,
   revocationRootUpdatedEventSchema,
 } from "./audit-trail.types.js";
+import {
+  NoOpVcSigner,
+  type Ed25519Signature2020Proof,
+  type VcSigner,
+} from "./vc-signer.js";
 
 export type {
   CounterpartyWire,
@@ -303,7 +311,10 @@ export interface AuditFeedJsonLd {
   "@context": readonly [typeof AUDIT_TRAIL_CONTEXT_VC, typeof AUDIT_TRAIL_CONTEXT_ETO];
   id: string;
   type: readonly ["VerifiableCredential", "AuditTrailFeed"];
-  issuer: typeof AUDIT_TRAIL_ISSUER_DID;
+  // FN-084: widened from the literal `typeof AUDIT_TRAIL_ISSUER_DID` to
+  // `string` so an injected `VcSigner` can override the placeholder DID.
+  // The default value is still `AUDIT_TRAIL_ISSUER_DID`.
+  issuer: string;
   issuanceDate: string;
   credentialSubject: {
     id: string;
@@ -312,6 +323,9 @@ export interface AuditFeedJsonLd {
     events: readonly AuditFeedEvent[];
     summary: AuditFeedSummary;
   };
+  /** FN-084: optional Ed25519Signature2020 proof block. Absent when the
+   *  default `NoOpVcSigner` is in use (preserves byte-stable v0 shape). */
+  proof?: Ed25519Signature2020Proof;
 }
 
 // ---------------------------------------------------------------------
@@ -334,6 +348,11 @@ export interface AuditTrailIndexerDeps {
   logger?: AuditLogger;
   /** Defaults to `() => new Date()`. Tests inject a fixed clock. */
   clock?: () => Date;
+  /**
+   * FN-084: optional VC signer. Defaults to `NoOpVcSigner(AUDIT_TRAIL_ISSUER_DID)`
+   * which produces a byte-stable unsigned document (no `proof` key).
+   */
+  signer?: VcSigner;
 }
 
 const BASE58_RE = /^[1-9A-HJ-NP-Za-km-z]+$/;
@@ -401,11 +420,13 @@ export class AuditTrailIndexer {
   private readonly source: KytEventSource;
   private readonly logger?: AuditLogger;
   private readonly clock: () => Date;
+  private readonly signer: VcSigner;
 
   public constructor(deps: AuditTrailIndexerDeps) {
     this.source = deps.source;
     if (deps.logger) this.logger = deps.logger;
     this.clock = deps.clock ?? (() => new Date());
+    this.signer = deps.signer ?? new NoOpVcSigner(AUDIT_TRAIL_ISSUER_DID);
   }
 
   public async buildAuditFeed(
@@ -542,11 +563,16 @@ export class AuditTrailIndexer {
       revocationCount: revEvents.length,
     };
 
+    const issuerDid =
+      this.signer.issuerDid !== AUDIT_TRAIL_ISSUER_DID
+        ? this.signer.issuerDid
+        : AUDIT_TRAIL_ISSUER_DID;
+
     const feed: AuditFeedJsonLd = {
       "@context": [AUDIT_TRAIL_CONTEXT_VC, AUDIT_TRAIL_CONTEXT_ETO],
       id: feedUrn(authority, sinceSlot, untilSlot),
       type: AUDIT_TRAIL_VC_TYPE,
-      issuer: AUDIT_TRAIL_ISSUER_DID,
+      issuer: issuerDid,
       issuanceDate: this.clock().toISOString(),
       credentialSubject: {
         id: `did:eto:agent:${authority}`,
@@ -560,10 +586,23 @@ export class AuditTrailIndexer {
       },
     };
 
+    // FN-084: sign the proof-less document and attach the proof block
+    // iff the signer produced a non-empty proofValue. The NoOp path
+    // returns proofValue === "", which we map to no `proof` key so the
+    // v0 unsigned wire shape stays byte-identical.
+    // Pass a shallow copy so the signer cannot observe (or be passed)
+    // a `proof` field. The proof block is excluded from the JCS
+    // preimage per W3C VC Data Integrity §11.4.
+    const proof = await this.signer.sign({ ...feed });
+    if (proof.proofValue !== "") {
+      feed.proof = proof;
+    }
+
     this.logger?.info?.("audit-trail: built feed", {
       authority,
       kytCount: summary.kytCount,
       revocationCount: summary.revocationCount,
+      signed: proof.proofValue !== "",
     });
 
     return feed;

--- a/src/services/indexer/index.ts
+++ b/src/services/indexer/index.ts
@@ -3,3 +3,21 @@
 
 export * from "./audit-trail.js";
 export * from "./travel-rule.js";
+
+// FN-084: VC signer abstractions for `Ed25519Signature2020` proof blocks
+// over the audit-trail and travel-rule JSON-LD documents.
+export {
+  DEFAULT_UNSIGNED_DID,
+  Ed25519VcSigner,
+  NoOpVcSigner,
+  base64UrlEncode,
+  canonicalizeJcs,
+  createVcSignerFromEnv,
+} from "./vc-signer.js";
+export type {
+  CreateVcSignerFromEnvOpts,
+  Ed25519Signature2020Proof,
+  Ed25519VcSignerFromKeyFileOpts,
+  Ed25519VcSignerInit,
+  VcSigner,
+} from "./vc-signer.js";

--- a/src/services/indexer/index.ts
+++ b/src/services/indexer/index.ts
@@ -1,7 +1,10 @@
-// Barrel re-export for the audit-trail indexer (T-3.13.1.1, FN-130)
+// Barrel re-export for the audit-trail indexer (T-3.13.1.1, FN-130),
+// the Postgres-backed event source (FN-083),
 // and the travel-rule report generator (T-3.13.1.4, FN-133).
 
 export * from "./audit-trail.js";
+export { PostgresKytEventSource, createKytEventSourceFromEnv } from "./postgres-event-source.js";
+export type { PostgresKytEventSourceInit } from "./postgres-event-source.js";
 export * from "./travel-rule.js";
 
 // FN-084: VC signer abstractions for `Ed25519Signature2020` proof blocks

--- a/src/services/indexer/postgres-event-source.ts
+++ b/src/services/indexer/postgres-event-source.ts
@@ -1,0 +1,443 @@
+// PostgresKytEventSource — durable Postgres-backed KytEventSource (FN-083).
+//
+// Implements the `KytEventSource` interface from `audit-trail.ts` using a
+// Postgres pool.  Large result windows are streamed via a server-side cursor
+// so the process never buffers an unbounded result set.
+//
+// Ingest methods (`ingestTrace`, `ingestRevocation`) are concrete-class API
+// (not part of the `KytEventSource` interface) and use ON CONFLICT DO NOTHING
+// for idempotent upserts.
+//
+// Factory: `createKytEventSourceFromEnv` reads `process.env.AUDIT_DB_URL`.
+//   - Set  → PostgresKytEventSource (production)
+//   - Unset → InMemoryKytEventSource({ traces: [] }) (test / dev fallback)
+
+import { type PoolClient, Pool } from "pg";
+
+import {
+  AuditTrailIndexerError,
+  InMemoryKytEventSource,
+  type KytEventSource,
+  type KytEventSourceQueryOpts,
+} from "./audit-trail.js";
+import {
+  type KytTraceEvent,
+  type RevocationRootUpdatedEvent,
+  kytTraceEventSchema,
+  revocationRootUpdatedEventSchema,
+} from "./audit-trail.types.js";
+
+// ---------------------------------------------------------------------------
+// Internal helpers
+// ---------------------------------------------------------------------------
+
+/** Number of rows to fetch per cursor FETCH round-trip. */
+const CURSOR_BATCH = 500;
+
+/** Unique cursor name per query to avoid collisions under concurrent use. */
+let _cursorSeq = 0;
+function nextCursorName(): string {
+  return `_kyt_cur_${Date.now()}_${++_cursorSeq}`;
+}
+
+// ---------------------------------------------------------------------------
+// PostgresKytEventSource
+// ---------------------------------------------------------------------------
+
+export interface PostgresKytEventSourceInit {
+  /**
+   * An existing `Pool` to borrow.  The pool will NOT be closed when
+   * `close()` is called — the caller retains ownership.
+   */
+  pool?: Pool;
+  /** Connection string used to construct a new, owned `Pool`. */
+  connectionString?: string;
+}
+
+/**
+ * Postgres-backed implementation of `KytEventSource`.
+ *
+ * Pass either an existing `pool` (for tests / shared pools) or a
+ * `connectionString` to let the class own its pool.  When the class owns
+ * the pool, `close()` drains it; otherwise `close()` is a no-op.
+ */
+export class PostgresKytEventSource implements KytEventSource {
+  private readonly pool: Pool;
+  private readonly ownsPool: boolean;
+
+  public constructor(init: PostgresKytEventSourceInit) {
+    if (init.pool) {
+      this.pool = init.pool;
+      this.ownsPool = false;
+    } else if (init.connectionString) {
+      this.pool = new Pool({ connectionString: init.connectionString });
+      this.ownsPool = true;
+    } else {
+      throw new Error(
+        "PostgresKytEventSource: either `pool` or `connectionString` must be provided",
+      );
+    }
+  }
+
+  // -------------------------------------------------------------------------
+  // KytEventSource — tracesForAuthority
+  // -------------------------------------------------------------------------
+
+  /**
+   * Yield every `KytTraceEvent` involving `authority` (in either BAP or BPP
+   * slot) within the requested slot window, in ascending `(slot, tx_signature)`
+   * order.  Uses a server-side cursor to stream large windows without buffering.
+   */
+  public async *tracesForAuthority(
+    authority: string,
+    opts?: KytEventSourceQueryOpts,
+  ): AsyncIterable<KytTraceEvent> {
+    if (!authority) {
+      throw new AuditTrailIndexerError(
+        "INVALID_AUTHORITY",
+        "authority must be a non-empty base58 string",
+      );
+    }
+
+    const client = await this.pool.connect();
+    const cursorName = nextCursorName();
+
+    try {
+      // Build parameterised query.
+      const params: (string | number)[] = [authority];
+      let slotClause = "";
+      if (opts?.sinceSlot !== undefined) {
+        params.push(opts.sinceSlot);
+        slotClause += ` AND slot >= $${params.length}`;
+      }
+      if (opts?.untilSlot !== undefined) {
+        params.push(opts.untilSlot);
+        slotClause += ` AND slot < $${params.length}`;
+      }
+
+      const selectSql = `
+        SELECT
+          stage,
+          tx_signature,
+          slot,
+          chain_timestamp  AS "timestamp",
+          bap_authority,
+          bpp_authority,
+          bap_cred_pointers,
+          bpp_cred_pointers
+        FROM kyt_events
+        WHERE (bap_authority = $1 OR bpp_authority = $1)
+        ${slotClause}
+        ORDER BY slot ASC, tx_signature ASC
+      `;
+
+      await client.query("BEGIN");
+      await client.query(
+        `DECLARE ${cursorName} NO SCROLL CURSOR FOR ${selectSql}`,
+        params,
+      );
+
+      yield* this._fetchTraceCursor(client, cursorName, authority);
+
+      await client.query("COMMIT");
+    } catch (err) {
+      await this._safeRollback(client);
+      throw err;
+    } finally {
+      client.release();
+    }
+  }
+
+  private async *_fetchTraceCursor(
+    client: PoolClient,
+    cursorName: string,
+    authority: string,
+  ): AsyncIterable<KytTraceEvent> {
+    while (true) {
+      const result = await client.query<{
+        stage: string;
+        tx_signature: string;
+        slot: string;
+        timestamp: string;
+        bap_authority: string;
+        bpp_authority: string;
+        bap_cred_pointers: string[];
+        bpp_cred_pointers: string[];
+      }>(`FETCH FORWARD ${CURSOR_BATCH} FROM ${cursorName}`);
+
+      if (result.rows.length === 0) break;
+
+      for (const row of result.rows) {
+        const raw = {
+          stage: row.stage,
+          tx_signature: row.tx_signature,
+          slot: Number(row.slot),
+          timestamp: Number(row.timestamp),
+          parties: [
+            {
+              party: "bap" as const,
+              authority: row.bap_authority,
+              cred_pointers: row.bap_cred_pointers ?? [],
+            },
+            {
+              party: "bpp" as const,
+              authority: row.bpp_authority,
+              cred_pointers: row.bpp_cred_pointers ?? [],
+            },
+          ] as [
+            { party: "bap"; authority: string; cred_pointers: string[] },
+            { party: "bpp"; authority: string; cred_pointers: string[] },
+          ],
+        };
+
+        const parsed = kytTraceEventSchema.safeParse(raw);
+        if (!parsed.success) {
+          throw new AuditTrailIndexerError(
+            "INVALID_KYT_EVENT",
+            `postgres: stored row failed schema validation: ${parsed.error.message}`,
+            parsed.error.issues,
+          );
+        }
+        yield parsed.data;
+      }
+
+      if (result.rows.length < CURSOR_BATCH) break;
+    }
+  }
+
+  // -------------------------------------------------------------------------
+  // KytEventSource — revocationsForCredentialIssuers
+  // -------------------------------------------------------------------------
+
+  /**
+   * Yield every `RevocationRootUpdatedEvent` whose `oracle` is in `issuers`
+   * (or all events when `issuers` is empty) within the requested slot window,
+   * in ascending `(slot, oracle, root)` order.  Uses a server-side cursor.
+   */
+  public async *revocationsForCredentialIssuers(
+    issuers: readonly string[],
+    opts?: KytEventSourceQueryOpts,
+  ): AsyncIterable<RevocationRootUpdatedEvent> {
+    const client = await this.pool.connect();
+    const cursorName = nextCursorName();
+
+    try {
+      // Build WHERE clause and params.
+      const whereFragments: string[] = [];
+      const freshParams: (string | string[] | number)[] = [];
+
+      if (issuers.length > 0) {
+        freshParams.push([...issuers]);
+        whereFragments.push(`oracle = ANY($${freshParams.length})`);
+      }
+      if (opts?.sinceSlot !== undefined) {
+        freshParams.push(opts.sinceSlot);
+        whereFragments.push(`slot >= $${freshParams.length}`);
+      }
+      if (opts?.untilSlot !== undefined) {
+        freshParams.push(opts.untilSlot);
+        whereFragments.push(`slot < $${freshParams.length}`);
+      }
+
+      const whereClause =
+        whereFragments.length > 0
+          ? `WHERE ${whereFragments.join(" AND ")}`
+          : "";
+
+      const selectSql = `
+        SELECT oracle, network, root, leaves, slot
+        FROM revocation_events
+        ${whereClause}
+        ORDER BY slot ASC, oracle ASC, root ASC
+      `;
+
+      await client.query("BEGIN");
+      await client.query(
+        `DECLARE ${cursorName} NO SCROLL CURSOR FOR ${selectSql}`,
+        freshParams,
+      );
+
+      yield* this._fetchRevocationCursor(client, cursorName);
+
+      await client.query("COMMIT");
+    } catch (err) {
+      await this._safeRollback(client);
+      throw err;
+    } finally {
+      client.release();
+    }
+  }
+
+  private async *_fetchRevocationCursor(
+    client: PoolClient,
+    cursorName: string,
+  ): AsyncIterable<RevocationRootUpdatedEvent> {
+    while (true) {
+      const result = await client.query<{
+        oracle: string;
+        network: string;
+        root: string;
+        leaves: string;
+        slot: string;
+      }>(`FETCH FORWARD ${CURSOR_BATCH} FROM ${cursorName}`);
+
+      if (result.rows.length === 0) break;
+
+      for (const row of result.rows) {
+        const raw = {
+          oracle: row.oracle,
+          network: row.network,
+          root: row.root,
+          leaves: Number(row.leaves),
+          slot: Number(row.slot),
+        };
+
+        const parsed = revocationRootUpdatedEventSchema.safeParse(raw);
+        if (!parsed.success) {
+          throw new AuditTrailIndexerError(
+            "INVALID_REVOCATION_EVENT",
+            `postgres: stored row failed schema validation: ${parsed.error.message}`,
+            parsed.error.issues,
+          );
+        }
+        yield parsed.data;
+      }
+
+      if (result.rows.length < CURSOR_BATCH) break;
+    }
+  }
+
+  // -------------------------------------------------------------------------
+  // Concrete-class ingest API (not on KytEventSource interface)
+  // -------------------------------------------------------------------------
+
+  /**
+   * Persist a single `KytTraceEvent`.  Validates via zod schema before
+   * inserting.  On duplicate `tx_signature` the row is silently skipped
+   * (`inserted: false`).
+   */
+  public async ingestTrace(
+    trace: KytTraceEvent,
+  ): Promise<{ inserted: boolean }> {
+    const parsed = kytTraceEventSchema.safeParse(trace);
+    if (!parsed.success) {
+      throw new AuditTrailIndexerError(
+        "INVALID_KYT_EVENT",
+        `ingestTrace: invalid KytTraceEvent: ${parsed.error.message}`,
+        parsed.error.issues,
+      );
+    }
+    const ev = parsed.data;
+    const [bap, bpp] = ev.parties;
+
+    const result = await this.pool.query<{ id: string }>(
+      `INSERT INTO kyt_events
+         (tx_signature, slot, stage, chain_timestamp,
+          bap_authority, bpp_authority,
+          bap_cred_pointers, bpp_cred_pointers)
+       VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
+       ON CONFLICT (tx_signature) DO NOTHING
+       RETURNING id`,
+      [
+        ev.tx_signature,
+        ev.slot,
+        ev.stage,
+        ev.timestamp,
+        bap!.authority,
+        bpp!.authority,
+        bap!.cred_pointers,
+        bpp!.cred_pointers,
+      ],
+    );
+
+    return { inserted: result.rowCount != null && result.rowCount > 0 };
+  }
+
+  /**
+   * Persist a single `RevocationRootUpdatedEvent`.  Validates via zod schema.
+   * On duplicate `(oracle, root, slot)` the row is silently skipped
+   * (`inserted: false`).
+   */
+  public async ingestRevocation(
+    event: RevocationRootUpdatedEvent,
+  ): Promise<{ inserted: boolean }> {
+    const parsed = revocationRootUpdatedEventSchema.safeParse(event);
+    if (!parsed.success) {
+      throw new AuditTrailIndexerError(
+        "INVALID_REVOCATION_EVENT",
+        `ingestRevocation: invalid RevocationRootUpdatedEvent: ${parsed.error.message}`,
+        parsed.error.issues,
+      );
+    }
+    const ev = parsed.data;
+
+    const result = await this.pool.query<{ id: string }>(
+      `INSERT INTO revocation_events
+         (oracle, network, root, leaves, slot)
+       VALUES ($1, $2, $3, $4, $5)
+       ON CONFLICT (oracle, root, slot) DO NOTHING
+       RETURNING id`,
+      [ev.oracle, ev.network, ev.root, ev.leaves, ev.slot],
+    );
+
+    return { inserted: result.rowCount != null && result.rowCount > 0 };
+  }
+
+  // -------------------------------------------------------------------------
+  // Lifecycle
+  // -------------------------------------------------------------------------
+
+  /**
+   * Drain the connection pool.  Only called when this class constructed the
+   * pool from a connection string; borrowed pools are NOT ended.
+   */
+  public async close(): Promise<void> {
+    if (this.ownsPool) {
+      await this.pool.end();
+    }
+  }
+
+  // -------------------------------------------------------------------------
+  // Internal utilities
+  // -------------------------------------------------------------------------
+
+  private async _safeRollback(client: PoolClient): Promise<void> {
+    try {
+      await client.query("ROLLBACK");
+    } catch {
+      // Ignore rollback errors — the connection may already be in an error
+      // state; the important thing is we release it below.
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Environment-driven factory
+// ---------------------------------------------------------------------------
+
+/**
+ * Create a `KytEventSource` driven by environment variables.
+ *
+ * - `AUDIT_DB_URL` set to a non-empty string → returns a new
+ *   `PostgresKytEventSource` connected to that URL.
+ * - `AUDIT_DB_URL` absent or empty → returns an empty
+ *   `InMemoryKytEventSource` (suitable for local dev / tests that do not
+ *   require durable storage).
+ *
+ * @param env  Defaults to `process.env`.  Override in tests to avoid touching
+ *   the real process environment.
+ *
+ * @remarks
+ * Callers that need a pre-seeded in-memory source (e.g. unit tests with
+ * fixture events) should construct `InMemoryKytEventSource` directly rather
+ * than relying on this factory.
+ */
+export function createKytEventSourceFromEnv(
+  env: Record<string, string | undefined> = process.env,
+): KytEventSource {
+  const url = env["AUDIT_DB_URL"];
+  if (typeof url === "string" && url.length > 0) {
+    return new PostgresKytEventSource({ connectionString: url });
+  }
+  return new InMemoryKytEventSource({ traces: [] });
+}

--- a/src/services/indexer/travel-rule.ts
+++ b/src/services/indexer/travel-rule.ts
@@ -34,10 +34,13 @@
  * feed. The injectable `clock` defaults to `() => new Date()`; tests pin
  * it to a fixed timestamp for byte-stable assertions.
  *
- * **v0 unsigned caveat.** The `issuer` field is a placeholder DID
- * (`did:eto:indexer:travel-rule:v0`). This report is NOT cryptographically
- * signed in v0; consumers must treat the document as derived data, not
- * as proof. Signing (VC-JOSE / Ed25519) is a follow-up task.
+ * **Signing.** Signing is opt-in via the injected `VcSigner`; the
+ * default `NoOpVcSigner` preserves the historical unsigned shape (no
+ * `proof` key in the emitted document). Set `AUDIT_SIGNING_KEY_PATH`
+ * and pass `createVcSignerFromEnv({ issuerDid })` to emit an
+ * `Ed25519Signature2020` proof block per W3C VC Data Integrity /
+ * RFC 8785 (FN-084). The proof preimage is `sha256(JCS(vcWithoutProof))`
+ * — the proof block is excluded from the hash input.
  *
  * **Spec §9.3 mapping.** `parties[0]` (BAP) is the originator; `parties[1]`
  * (BPP) is the beneficiary. When the audited authority is the BAP, we look
@@ -52,6 +55,11 @@ import {
   type AuditLogger,
   type KytEventSource,
 } from "./audit-trail.js";
+import {
+  NoOpVcSigner,
+  type Ed25519Signature2020Proof,
+  type VcSigner,
+} from "./vc-signer.js";
 import {
   type AmountResolverEntry,
   type Ivms101Party,
@@ -351,8 +359,13 @@ export interface TravelRuleReportJsonLd {
   ];
   id: string;
   type: typeof TRAVEL_RULE_REPORT_TYPE;
-  issuer: typeof TRAVEL_RULE_ISSUER_DID;
+  // FN-084: widened from the literal `typeof TRAVEL_RULE_ISSUER_DID` to
+  // `string` so an injected `VcSigner` can override the placeholder DID.
+  issuer: string;
   issuanceDate: string;
+  /** FN-084: optional Ed25519Signature2020 proof block. Absent when the
+   *  default `NoOpVcSigner` is in use (preserves byte-stable v0 shape). */
+  proof?: Ed25519Signature2020Proof;
   credentialSubject: {
     id: string;
     authority: string;
@@ -476,6 +489,12 @@ export interface TravelRuleReportGeneratorDeps {
   logger?: AuditLogger;
   /** Defaults to `() => new Date()`. Tests inject a fixed clock. */
   clock?: () => Date;
+  /**
+   * FN-084: optional VC signer. Defaults to
+   * `NoOpVcSigner(TRAVEL_RULE_ISSUER_DID)` which produces a byte-stable
+   * unsigned document (no `proof` key).
+   */
+  signer?: VcSigner;
 }
 
 /**
@@ -490,6 +509,7 @@ export class TravelRuleReportGenerator {
   private readonly amountResolver: AmountResolver;
   private readonly logger?: AuditLogger;
   private readonly clock: () => Date;
+  private readonly signer: VcSigner;
 
   public constructor(deps: TravelRuleReportGeneratorDeps) {
     // If source is already an AuditTrailIndexer, reuse it; otherwise wrap.
@@ -505,6 +525,7 @@ export class TravelRuleReportGenerator {
     this.amountResolver = deps.amountResolver;
     if (deps.logger) this.logger = deps.logger;
     this.clock = deps.clock ?? (() => new Date());
+    this.signer = deps.signer ?? new NoOpVcSigner(TRAVEL_RULE_ISSUER_DID);
   }
 
   public async buildReport(
@@ -648,11 +669,16 @@ export class TravelRuleReportGenerator {
       entries.reduce((sum, e) => sum + e.amountUsd, 0),
     );
 
+    const issuerDid =
+      this.signer.issuerDid !== TRAVEL_RULE_ISSUER_DID
+        ? this.signer.issuerDid
+        : TRAVEL_RULE_ISSUER_DID;
+
     const report: TravelRuleReportJsonLd = {
       "@context": [TRAVEL_RULE_CONTEXT_FATF, TRAVEL_RULE_CONTEXT_ETO],
       id: reportUrn(authority, sinceSlot, untilSlot),
       type: TRAVEL_RULE_REPORT_TYPE,
-      issuer: TRAVEL_RULE_ISSUER_DID,
+      issuer: issuerDid,
       issuanceDate: this.clock().toISOString(),
       credentialSubject: {
         id: `did:eto:agent:${authority}`,
@@ -675,11 +701,20 @@ export class TravelRuleReportGenerator {
       },
     };
 
+    // FN-084: sign the proof-less document and attach proof iff non-empty.
+    // Pass a shallow copy so the signer never observes the `proof` key
+    // (W3C VC Data Integrity §11.4 excludes proof from the JCS preimage).
+    const proof = await this.signer.sign({ ...report });
+    if (proof.proofValue !== "") {
+      report.proof = proof;
+    }
+
     this.logger?.info?.("travel-rule: built report", {
       authority,
       entries: entries.length,
       skippedMissingParty,
       skippedMissingAmount,
+      signed: proof.proofValue !== "",
     });
 
     return report;

--- a/src/services/indexer/vc-signer.ts
+++ b/src/services/indexer/vc-signer.ts
@@ -1,0 +1,290 @@
+// VC signer for audit-trail / travel-rule JSON-LD documents (FN-084).
+//
+// Implements `Ed25519Signature2020` proof blocks per the W3C VC Data
+// Integrity 1.0 spec. The proof preimage is `sha256(JCS(vcWithoutProof))`
+// per spec §11.4 — the proof block itself is excluded from the hash
+// input by the calling indexer (see `audit-trail.ts` / `travel-rule.ts`).
+//
+// **Backwards-compatible default.** `NoOpVcSigner` returns a sentinel
+// proof with `proofValue === ""`; callers detect this and OMIT the
+// `proof` key entirely from the emitted document so the v0 unsigned
+// shape remains byte-stable.
+//
+// **Key material.** `Ed25519VcSigner` accepts a 32-byte Ed25519 seed
+// (NOT the 64-byte expanded form). `createVcSignerFromEnv` reads
+// `AUDIT_SIGNING_KEY_PATH`; the file may be raw 32 bytes, hex (with
+// optional `0x` prefix), or base64 / base64url. The loaded secret is
+// never logged, never thrown back inside an Error message, and never
+// persisted by this module.
+
+import { readFileSync } from "node:fs";
+import * as ed25519 from "@noble/ed25519";
+import { sha256 } from "@noble/hashes/sha256";
+
+// ---------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------
+
+export interface Ed25519Signature2020Proof {
+  type: "Ed25519Signature2020";
+  /** ISO-8601 UTC timestamp, e.g. `2026-05-02T12:34:56.000Z`. */
+  created: string;
+  /** Always `<issuerDid>#key-1` for this v0 single-key implementation. */
+  verificationMethod: string;
+  proofPurpose: "assertionMethod";
+  /** `base64url(sign(sha256(JCS(vcWithoutProof))))`. Empty for NoOp. */
+  proofValue: string;
+}
+
+export interface VcSigner {
+  readonly issuerDid: string;
+  sign(vcWithoutProof: Record<string, unknown>): Promise<Ed25519Signature2020Proof>;
+}
+
+// ---------------------------------------------------------------------
+// JCS canonicalization (RFC 8785 subset — sufficient for these docs)
+// ---------------------------------------------------------------------
+
+const LINE_SEP_RE = /\u2028/g;
+const PARA_SEP_RE = /\u2029/g;
+
+/**
+ * Canonicalize a JSON-shaped value to a stable string per RFC 8785
+ * (subset). Sorting is by UTF-16 code unit order on object keys (the
+ * default `Array.prototype.sort()` order on strings, which matches the
+ * RFC for the BMP characters used in our payloads). Rejects NaN /
+ * Infinity / Date / BigInt / functions / symbols. `undefined` values
+ * are dropped from objects but rejected inside arrays.
+ *
+ * Exported for unit testing and advanced consumers.
+ */
+export function canonicalizeJcs(value: unknown): string {
+  return canonValue(value, /* insideArray */ false);
+}
+
+function canonValue(value: unknown, insideArray: boolean): string {
+  if (value === null) return "null";
+  if (value === undefined) {
+    if (insideArray) {
+      throw new TypeError("JCS: undefined is not a valid array element");
+    }
+    // Caller must drop undefined object entries before recursing.
+    throw new TypeError("JCS: undefined leaked into canonicalizer");
+  }
+  switch (typeof value) {
+    case "boolean":
+      return value ? "true" : "false";
+    case "number": {
+      if (!Number.isFinite(value)) {
+        throw new TypeError("JCS: non-finite number");
+      }
+      if (Number.isInteger(value) && Number.isSafeInteger(value)) {
+        return String(value);
+      }
+      // Acceptable for our schema (no floats are produced today).
+      return JSON.stringify(value);
+    }
+    case "string":
+      return canonString(value);
+    case "bigint":
+      throw new TypeError("JCS: bigint is not supported");
+    case "function":
+      throw new TypeError("JCS: function is not supported");
+    case "symbol":
+      throw new TypeError("JCS: symbol is not supported");
+    case "object":
+      if (value instanceof Date) {
+        throw new TypeError("JCS: Date is not supported (encode as ISO-8601 string)");
+      }
+      if (Array.isArray(value)) {
+        const parts = value.map((v) => canonValue(v, /* insideArray */ true));
+        return "[" + parts.join(",") + "]";
+      }
+      return canonObject(value as Record<string, unknown>);
+    default:
+      throw new TypeError(`JCS: unsupported type ${typeof value}`);
+  }
+}
+
+function canonString(s: string): string {
+  // Node's JSON.stringify is RFC 8785-compatible for the BMP escape
+  // forms we care about. Post-process U+2028 / U+2029 to their \u
+  // escapes (RFC 8785 does not require this, but it keeps the output
+  // safe to embed in any JSON-in-JS context).
+  const raw = JSON.stringify(s);
+  return raw.replace(LINE_SEP_RE, "\\u2028").replace(PARA_SEP_RE, "\\u2029");
+}
+
+function canonObject(obj: Record<string, unknown>): string {
+  // Drop entries whose value is `undefined`; sort keys by UTF-16
+  // code-unit order (default string sort).
+  const keys = Object.keys(obj)
+    .filter((k) => obj[k] !== undefined)
+    .sort();
+  const parts = keys.map(
+    (k) => canonString(k) + ":" + canonValue(obj[k], /* insideArray */ false),
+  );
+  return "{" + parts.join(",") + "}";
+}
+
+// ---------------------------------------------------------------------
+// base64url
+// ---------------------------------------------------------------------
+
+/** Padding-free base64url encoding (RFC 4648 §5). */
+export function base64UrlEncode(bytes: Uint8Array): string {
+  const b64 = Buffer.from(bytes).toString("base64");
+  return b64.replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/g, "");
+}
+
+// ---------------------------------------------------------------------
+// NoOpVcSigner
+// ---------------------------------------------------------------------
+
+export const DEFAULT_UNSIGNED_DID = "did:eto:indexer:unsigned:v0";
+
+/**
+ * Sentinel signer that returns a proof with `proofValue === ""`.
+ * Indexer wiring detects this and omits the `proof` key entirely from
+ * the emitted document, preserving the historical (v0) unsigned shape.
+ */
+export class NoOpVcSigner implements VcSigner {
+  public readonly issuerDid: string;
+  private readonly clock: () => Date;
+
+  public constructor(issuerDid: string = DEFAULT_UNSIGNED_DID, clock?: () => Date) {
+    this.issuerDid = issuerDid;
+    this.clock = clock ?? (() => new Date());
+  }
+
+  public async sign(
+    _vcWithoutProof: Record<string, unknown>,
+  ): Promise<Ed25519Signature2020Proof> {
+    return {
+      type: "Ed25519Signature2020",
+      created: this.clock().toISOString(),
+      verificationMethod: `${this.issuerDid}#key-1`,
+      proofPurpose: "assertionMethod",
+      proofValue: "",
+    };
+  }
+}
+
+// ---------------------------------------------------------------------
+// Ed25519VcSigner
+// ---------------------------------------------------------------------
+
+export interface Ed25519VcSignerInit {
+  issuerDid: string;
+  /** 32-byte Ed25519 seed (NOT the 64-byte expanded form). */
+  secretKey: Uint8Array;
+  /** Defaults to `() => new Date()`. */
+  clock?: () => Date;
+}
+
+export interface Ed25519VcSignerFromKeyFileOpts {
+  issuerDid: string;
+  clock?: () => Date;
+}
+
+const HEX_RE = /^[0-9a-fA-F]+$/;
+const BASE64_RE = /^[A-Za-z0-9+/_-]+={0,2}$/;
+
+function decodeKeyBytes(buf: Buffer): Uint8Array {
+  // 1) Raw 32 bytes.
+  if (buf.length === 32) {
+    return new Uint8Array(buf);
+  }
+  // 2) Text-encoded forms — try in order.
+  const text = buf.toString("utf8").trim().replace(/\s+/g, "");
+  // 2a) Hex (optional `0x` prefix). 64 hex chars → 32 bytes.
+  let candidate = text.startsWith("0x") || text.startsWith("0X") ? text.slice(2) : text;
+  if (candidate.length === 64 && HEX_RE.test(candidate)) {
+    return new Uint8Array(Buffer.from(candidate, "hex"));
+  }
+  // 2b) base64 / base64url.
+  if (BASE64_RE.test(text)) {
+    // Normalize base64url → base64.
+    const padded =
+      text.replace(/-/g, "+").replace(/_/g, "/") +
+      "===".slice((text.length + 3) % 4);
+    try {
+      const decoded = Buffer.from(padded, "base64");
+      if (decoded.length === 32) return new Uint8Array(decoded);
+    } catch {
+      // fall through to error below
+    }
+  }
+  throw new Error("expected 32-byte Ed25519 seed");
+}
+
+export class Ed25519VcSigner implements VcSigner {
+  public readonly issuerDid: string;
+  readonly #secretKey: Uint8Array;
+  readonly #clock: () => Date;
+
+  public constructor(init: Ed25519VcSignerInit) {
+    if (!(init.secretKey instanceof Uint8Array) || init.secretKey.length !== 32) {
+      throw new Error("expected 32-byte Ed25519 seed");
+    }
+    this.issuerDid = init.issuerDid;
+    // Defensive copy so callers can't mutate the secret post-construction.
+    this.#secretKey = new Uint8Array(init.secretKey);
+    this.#clock = init.clock ?? (() => new Date());
+  }
+
+  public static fromKeyFile(
+    path: string,
+    opts: Ed25519VcSignerFromKeyFileOpts,
+  ): Ed25519VcSigner {
+    const buf = readFileSync(path);
+    const secretKey = decodeKeyBytes(buf);
+    const init: Ed25519VcSignerInit = { issuerDid: opts.issuerDid, secretKey };
+    if (opts.clock) init.clock = opts.clock;
+    return new Ed25519VcSigner(init);
+  }
+
+  public async sign(
+    vcWithoutProof: Record<string, unknown>,
+  ): Promise<Ed25519Signature2020Proof> {
+    const canon = canonicalizeJcs(vcWithoutProof);
+    const digest = sha256(new TextEncoder().encode(canon));
+    const sig = await ed25519.signAsync(digest, this.#secretKey);
+    return {
+      type: "Ed25519Signature2020",
+      created: this.#clock().toISOString(),
+      verificationMethod: `${this.issuerDid}#key-1`,
+      proofPurpose: "assertionMethod",
+      proofValue: base64UrlEncode(sig),
+    };
+  }
+}
+
+// ---------------------------------------------------------------------
+// Env factory
+// ---------------------------------------------------------------------
+
+export interface CreateVcSignerFromEnvOpts {
+  issuerDid: string;
+  env?: NodeJS.ProcessEnv;
+  clock?: () => Date;
+}
+
+/**
+ * If `AUDIT_SIGNING_KEY_PATH` is set in the provided env (defaulting to
+ * `process.env`), load an `Ed25519VcSigner` from that key file.
+ * Otherwise return a `NoOpVcSigner` so the caller emits a byte-stable
+ * unsigned document.
+ */
+export function createVcSignerFromEnv(opts: CreateVcSignerFromEnvOpts): VcSigner {
+  const env = opts.env ?? process.env;
+  const path = env.AUDIT_SIGNING_KEY_PATH;
+  if (typeof path === "string" && path.length > 0) {
+    const fileOpts: Ed25519VcSignerFromKeyFileOpts = { issuerDid: opts.issuerDid };
+    if (opts.clock) fileOpts.clock = opts.clock;
+    return Ed25519VcSigner.fromKeyFile(path, fileOpts);
+  }
+  return opts.clock
+    ? new NoOpVcSigner(opts.issuerDid, opts.clock)
+    : new NoOpVcSigner(opts.issuerDid);
+}

--- a/src/signing/key-rotation.ts
+++ b/src/signing/key-rotation.ts
@@ -1,0 +1,275 @@
+/**
+ * Ed25519 key rotation primitives for audit-trail / travel-rule signing
+ * (FN-028).
+ *
+ * **Scope.** This module provides three things:
+ *   1. `DidDocument` — a minimal DID document type with a
+ *      `verificationMethod[]` array (multi-key support).
+ *   2. `signWithKid(payload, privateKey, kid)` — signs an arbitrary JSON
+ *      payload as a compact JWS (base64url(header).base64url(payload).sig),
+ *      embedding `kid` in the JOSE header so the verifier can resolve the
+ *      right public key.
+ *   3. `verifyWithDid(jws, didDoc)` — parses the JWS header, resolves
+ *      `kid` → public key from the DID document's `verificationMethod`
+ *      array, verifies the Ed25519 signature, and returns the decoded
+ *      payload. Throws `KeyRotationError` on unknown kid or bad signature.
+ *
+ * **JWS header.** `{ alg: "EdDSA", kid: <kid>, typ: "JWT" }`
+ *
+ * **Public key encoding.** Verification methods use `publicKeyJwk`
+ * (`{ kty: "OKP", crv: "Ed25519", x: base64url(rawPubKey32) }`) — the
+ * JOSE-native form that avoids a multibase/multicodec dependency.
+ *
+ * **Why a standalone module.** The audit-trail and travel-rule documents
+ * are explicitly unsigned in v0 (see the UNSIGNED caveats in each file).
+ * This module ships the rotation primitives so downstream consumers can
+ * wire signing in without any refactor of those files.
+ */
+
+import * as ed from "@noble/ed25519";
+import { sha512 } from "@noble/hashes/sha512";
+
+// Configure synchronous sha512 required by @noble/ed25519 v2.
+ed.etc.sha512Sync = (...m: Uint8Array[]) => sha512(ed.etc.concatBytes(...m));
+
+// ---------------------------------------------------------------------------
+// Errors
+// ---------------------------------------------------------------------------
+
+export type KeyRotationErrorCode =
+  | "UNKNOWN_KID"
+  | "INVALID_JWS"
+  | "INVALID_PUBKEY"
+  | "BAD_SIGNATURE";
+
+export class KeyRotationError extends Error {
+  public override readonly name = "KeyRotationError";
+  public readonly code: KeyRotationErrorCode;
+  public readonly detail?: unknown;
+
+  public constructor(
+    code: KeyRotationErrorCode,
+    message: string,
+    detail?: unknown,
+  ) {
+    super(message);
+    this.code = code;
+    if (detail !== undefined) this.detail = detail;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// DID document types
+// ---------------------------------------------------------------------------
+
+/**
+ * A single Ed25519 verification method entry in a DID document.
+ *
+ * `id` is the key identifier (kid). `publicKeyJwk.x` is the raw 32-byte
+ * public key encoded as base64url (no padding).
+ */
+export interface VerificationMethod {
+  /** Key identifier, e.g. `"did:example:123#key-1"`. Used as the JWS `kid`. */
+  id: string;
+  /** MUST be `"Ed25519VerificationKey2020"`. */
+  type: "Ed25519VerificationKey2020";
+  /** The DID that controls this key. */
+  controller: string;
+  /** Public key in JWK form: `{ kty: "OKP", crv: "Ed25519", x: base64url }`. */
+  publicKeyJwk: {
+    kty: "OKP";
+    crv: "Ed25519";
+    /** Raw 32-byte public key, base64url-encoded (no padding). */
+    x: string;
+  };
+}
+
+/**
+ * Minimal DID document supporting multi-key rotation.
+ *
+ * `verificationMethod` carries all active (and recently-retired) keys so
+ * that JWS tokens signed under any listed kid can still be verified during
+ * a rotation window.
+ */
+export interface DidDocument {
+  "@context": readonly string[];
+  id: string;
+  verificationMethod: readonly VerificationMethod[];
+  /** Authentication references — ids of verificationMethod entries. */
+  authentication?: readonly string[];
+}
+
+// ---------------------------------------------------------------------------
+// JWS helpers
+// ---------------------------------------------------------------------------
+
+function b64uEncode(bytes: Uint8Array): string {
+  // Node 20+ Buffer.from().toString("base64url") strips padding automatically.
+  return Buffer.from(bytes).toString("base64url");
+}
+
+function b64uDecode(s: string): Uint8Array {
+  return new Uint8Array(Buffer.from(s, "base64url"));
+}
+
+function encodeJson(obj: unknown): string {
+  return b64uEncode(new TextEncoder().encode(JSON.stringify(obj)));
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/**
+ * Sign `payload` with `privateKey` and embed `kid` in the JWS header.
+ *
+ * Returns a compact JWS string:
+ *   `base64url(header) + "." + base64url(payload) + "." + base64url(sig)`
+ *
+ * where `header = { alg: "EdDSA", kid, typ: "JWT" }`.
+ *
+ * `payload` can be any JSON-serialisable value. The bytes signed are
+ * `ascii(headerPart + "." + payloadPart)` (standard JWS signing input).
+ */
+export async function signWithKid(
+  payload: unknown,
+  privateKey: Uint8Array,
+  kid: string,
+): Promise<string> {
+  const header = encodeJson({ alg: "EdDSA", kid, typ: "JWT" });
+  const body = encodeJson(payload);
+  const signingInput = new TextEncoder().encode(`${header}.${body}`);
+  const sig = await ed.sign(signingInput, privateKey);
+  return `${header}.${body}.${b64uEncode(sig)}`;
+}
+
+/**
+ * Verify a compact JWS produced by `signWithKid` against a DID document.
+ *
+ * Steps:
+ *   1. Split the JWS into header / payload / signature parts.
+ *   2. Decode and parse the header; extract `kid`.
+ *   3. Find the `verificationMethod` entry in `didDoc` whose `id === kid`.
+ *   4. Decode `publicKeyJwk.x` to the raw 32-byte Ed25519 public key.
+ *   5. Verify the signature over `header + "." + payload` bytes.
+ *   6. Return the decoded payload as `unknown`.
+ *
+ * Throws `KeyRotationError` on:
+ *   - Malformed JWS structure (`INVALID_JWS`)
+ *   - No matching verificationMethod for `kid` (`UNKNOWN_KID`)
+ *   - Malformed or wrong-length public key (`INVALID_PUBKEY`)
+ *   - Signature verification failure (`BAD_SIGNATURE`)
+ */
+export async function verifyWithDid(
+  jws: string,
+  didDoc: DidDocument,
+): Promise<unknown> {
+  const parts = jws.split(".");
+  if (parts.length !== 3) {
+    throw new KeyRotationError(
+      "INVALID_JWS",
+      `JWS must have exactly 3 parts separated by '.'; got ${parts.length}`,
+    );
+  }
+
+  const [headerPart, payloadPart, sigPart] = parts as [string, string, string];
+
+  // Parse header.
+  let header: Record<string, unknown>;
+  try {
+    header = JSON.parse(new TextDecoder().decode(b64uDecode(headerPart))) as Record<string, unknown>;
+  } catch (e) {
+    throw new KeyRotationError("INVALID_JWS", "failed to decode JWS header", e);
+  }
+
+  const kid = header["kid"];
+  if (typeof kid !== "string" || kid.length === 0) {
+    throw new KeyRotationError(
+      "INVALID_JWS",
+      "JWS header must contain a non-empty 'kid' string",
+    );
+  }
+
+  // Resolve kid → verificationMethod.
+  const method = didDoc.verificationMethod.find((vm) => vm.id === kid);
+  if (method === undefined) {
+    throw new KeyRotationError(
+      "UNKNOWN_KID",
+      `kid '${kid}' not found in DID document '${didDoc.id}'`,
+      { kid, availableKids: didDoc.verificationMethod.map((vm) => vm.id) },
+    );
+  }
+
+  // Decode the public key.
+  let pubKey: Uint8Array;
+  try {
+    pubKey = b64uDecode(method.publicKeyJwk.x);
+  } catch (e) {
+    throw new KeyRotationError(
+      "INVALID_PUBKEY",
+      `failed to decode publicKeyJwk.x for kid '${kid}'`,
+      e,
+    );
+  }
+  if (pubKey.length !== 32) {
+    throw new KeyRotationError(
+      "INVALID_PUBKEY",
+      `publicKeyJwk.x for kid '${kid}' decoded to ${pubKey.length} bytes; expected 32`,
+    );
+  }
+
+  // Verify signature over the standard JWS signing input.
+  const signingInput = new TextEncoder().encode(`${headerPart}.${payloadPart}`);
+  let sig: Uint8Array;
+  try {
+    sig = b64uDecode(sigPart);
+  } catch (e) {
+    throw new KeyRotationError("INVALID_JWS", "failed to decode JWS signature", e);
+  }
+
+  const valid = await ed.verify(sig, signingInput, pubKey);
+  if (!valid) {
+    throw new KeyRotationError(
+      "BAD_SIGNATURE",
+      `Ed25519 signature verification failed for kid '${kid}'`,
+    );
+  }
+
+  // Decode and return the payload.
+  let decoded: unknown;
+  try {
+    decoded = JSON.parse(new TextDecoder().decode(b64uDecode(payloadPart)));
+  } catch (e) {
+    throw new KeyRotationError("INVALID_JWS", "failed to decode JWS payload", e);
+  }
+  return decoded;
+}
+
+// ---------------------------------------------------------------------------
+// Helper: build a VerificationMethod from a raw Ed25519 private key
+// ---------------------------------------------------------------------------
+
+/**
+ * Derive the `VerificationMethod` entry for a given private key and kid.
+ *
+ * Useful in tests and for DID document construction: given a raw 32-byte
+ * Ed25519 private key, returns the `VerificationMethod` object that should
+ * be placed in `didDoc.verificationMethod`.
+ */
+export function buildVerificationMethod(
+  kid: string,
+  controller: string,
+  privateKey: Uint8Array,
+): VerificationMethod {
+  const pubKey = ed.getPublicKey(privateKey);
+  return {
+    id: kid,
+    type: "Ed25519VerificationKey2020",
+    controller,
+    publicKeyJwk: {
+      kty: "OKP",
+      crv: "Ed25519",
+      x: Buffer.from(pubKey).toString("base64url"),
+    },
+  };
+}

--- a/src/signing/local-signer.ts
+++ b/src/signing/local-signer.ts
@@ -7,7 +7,7 @@ import { secp256k1 } from "@noble/curves/secp256k1";
 import { numberToBytesBE } from "@noble/curves/abstract/utils";
 import bs58 from "bs58";
 import type { Signer, SignerFactory } from "./signer-interface.js";
-import { WalletStore } from "./wallet-store.js";
+import { WalletStore, type WalletData } from "./wallet-store.js";
 import { currentScope } from "./session-context.js";
 
 ed.etc.sha512Sync = (...m: Uint8Array[]) => sha512(ed.etc.concatBytes(...m));
@@ -74,6 +74,8 @@ interface WalletEntry {
   label: string;
   privateKey: Uint8Array;
   publicKey: Uint8Array;
+  /** Canonical EVM address populated at wallet creation (FN-016). */
+  evmAddress?: string;
 }
 
 export class LocalSignerFactory implements SignerFactory {
@@ -117,7 +119,35 @@ export class LocalSignerFactory implements SignerFactory {
         // ensureLoaded()s wait on the same promise.
         s.beginLoad(loaded => {
           const bucket = this.walletsForScope(scope);
-          for (const [id, w] of loaded) bucket.set(id, w);
+          let needsResave = false;
+          for (const [id, w] of loaded) {
+            // Migration path (FN-016): old wallet files don't store evmAddress.
+            // Re-derive it from the private key so the registry is fully populated
+            // on cold start without requiring manual re-import.
+            let evmAddress = w.evmAddress;
+            if (!evmAddress) {
+              const signer = new LocalSigner(w.privateKey);
+              evmAddress = signer.getEvmSigningAddress();
+              needsResave = true;
+            }
+            const entry: WalletEntry = {
+              label: w.label,
+              privateKey: w.privateKey,
+              publicKey: w.publicKey,
+              evmAddress,
+            };
+            bucket.set(id, entry);
+            // Restore SVM↔EVM registry so resolve_cross_vm_address works
+            // immediately after load (FN-016).
+            s.recordCrossVmMapping(bs58.encode(w.publicKey), evmAddress);
+          }
+          // Re-save to persist the migrated evmAddress fields so next load
+          // is instantaneous (no private-key derivation required).
+          if (needsResave && this.configured) {
+            void this.persistScope(scope).catch(err =>
+              console.error("[eto-mcp] FN-016 migration re-save failed:", err),
+            );
+          }
         });
       }
     }
@@ -128,35 +158,43 @@ export class LocalSignerFactory implements SignerFactory {
     return this.walletsForScope(currentScope());
   }
 
-  private toWalletData(entry: WalletEntry): { label: string; privateKey: Uint8Array; publicKey: Uint8Array } {
-    return { label: entry.label, privateKey: entry.privateKey, publicKey: entry.publicKey };
+  private toWalletData(entry: WalletEntry): WalletData {
+    return {
+      label: entry.label,
+      privateKey: entry.privateKey,
+      publicKey: entry.publicKey,
+      evmAddress: entry.evmAddress,
+    };
   }
 
   private async persistScope(scope: string): Promise<void> {
     if (!this.configured) return;
     const bucket = this.walletsForScope(scope);
-    const serializable = new Map<string, { label: string; privateKey: Uint8Array; publicKey: Uint8Array }>();
+    const serializable = new Map<string, WalletData>();
     for (const [id, w] of bucket) serializable.set(id, this.toWalletData(w));
     await this.storeFor(scope).save(serializable);
   }
 
   async createWallet(label: string): Promise<{ walletId: string; svmAddress: string; evmAddress: string }> {
     const scope = currentScope();
-    await this.storeFor(scope).ensureLoaded();
+    const store = this.storeFor(scope);
+    await store.ensureLoaded();
     const privateKey = new Uint8Array(32);
     crypto.getRandomValues(privateKey);
     const publicKey = ed.getPublicKey(privateKey);
     const walletId = crypto.randomUUID();
 
-    this.wallets().set(walletId, { label, privateKey, publicKey });
+    const signer = new LocalSigner(privateKey);
+    const svmAddress = signer.getPublicKey();
+    const evmAddress = signer.getEvmSigningAddress();
+
+    this.wallets().set(walletId, { label, privateKey, publicKey, evmAddress });
+    // Register SVM↔EVM mapping immediately so resolve_cross_vm_address works
+    // as soon as the wallet is created (FN-016).
+    store.recordCrossVmMapping(svmAddress, evmAddress);
     await this.persistScope(scope);
 
-    const signer = new LocalSigner(privateKey);
-    return {
-      walletId,
-      svmAddress: signer.getPublicKey(),
-      evmAddress: signer.getEvmAddress(),
-    };
+    return { walletId, svmAddress, evmAddress };
   }
 
   async getSigner(walletId: string): Promise<Signer> {
@@ -177,7 +215,8 @@ export class LocalSignerFactory implements SignerFactory {
 
   async importWallet(label: string, privateKeyHex: string): Promise<{ walletId: string; svmAddress: string; evmAddress: string }> {
     const scope = currentScope();
-    await this.storeFor(scope).ensureLoaded();
+    const store = this.storeFor(scope);
+    await store.ensureLoaded();
 
     const hex = privateKeyHex.startsWith("0x") ? privateKeyHex.slice(2) : privateKeyHex;
     if (hex.length !== 64) {
@@ -190,20 +229,30 @@ export class LocalSignerFactory implements SignerFactory {
     const publicKey = ed.getPublicKey(privateKey);
     const walletId = crypto.randomUUID();
 
-    this.wallets().set(walletId, { label, privateKey, publicKey });
+    const signer = new LocalSigner(privateKey);
+    const svmAddress = signer.getPublicKey();
+    const evmAddress = signer.getEvmSigningAddress();
+
+    this.wallets().set(walletId, { label, privateKey, publicKey, evmAddress });
+    // Register SVM↔EVM mapping immediately so resolve_cross_vm_address works
+    // as soon as the wallet is imported (FN-016).
+    store.recordCrossVmMapping(svmAddress, evmAddress);
     await this.persistScope(scope);
 
-    const signer = new LocalSigner(privateKey);
-    return {
-      walletId,
-      svmAddress: signer.getPublicKey(),
-      evmAddress: signer.getEvmAddress(),
-    };
+    return { walletId, svmAddress, evmAddress };
   }
 
   /** Expose the scope's store for callers that need readActive()/writeActive(). */
   storeForScope(scope: string): WalletStore {
     return this.storeFor(scope);
+  }
+
+  /**
+   * Returns the WalletRegistry for the current execution scope.
+   * Used by `resolve_cross_vm_address` and `derive_address` tools (FN-016).
+   */
+  getRegistryForCurrentScope(): import("../utils/address.js").WalletRegistry {
+    return this.storeFor(currentScope()).asRegistry();
   }
 
   /** Look up a wallet entry in a specific scope without switching scopes. */

--- a/src/signing/wallet-store.ts
+++ b/src/signing/wallet-store.ts
@@ -3,6 +3,8 @@ import { createCipheriv, createDecipheriv, randomBytes } from "crypto";
 import { homedir } from "os";
 import { join } from "path";
 import { mkdir, readFile, rename, writeFile, stat } from "fs/promises";
+import bs58 from "bs58";
+import type { WalletRegistry } from "../utils/address.js";
 
 const WALLET_DIR = process.env.ETO_WALLET_DIR || join(homedir(), ".eto", "wallets");
 const LEGACY_WALLET_PATH = join(homedir(), ".eto", "wallets.enc");
@@ -11,6 +13,9 @@ export interface WalletData {
   label: string;
   privateKey: Uint8Array;
   publicKey: Uint8Array;
+  /** Canonical EVM address for this wallet. Populated at wallet creation from
+   * `signer.getEvmSigningAddress()`. Used by the SVM↔EVM registry (FN-016). */
+  evmAddress?: string;
 }
 
 // File format: salt(32) + nonce(12) + tag(16) + ciphertext
@@ -18,12 +23,48 @@ const SALT_LEN = 32;
 const NONCE_LEN = 12;
 const TAG_LEN = 16;
 
+/**
+ * In-memory cross-VM address registry for a single wallet scope.
+ *
+ * This implements WalletRegistry (FN-016) — populated at wallet creation time
+ * so that every wallet visible to the caller has an entry before any
+ * `resolve_cross_vm_address` call is made against it.
+ *
+ * Keyed by:
+ *   - SVM pubkey (base58) → EVM address (0x-prefixed lowercase)
+ *   - EVM address (0x-prefixed lowercase) → SVM pubkey (base58)
+ */
+class InMemoryRegistry implements WalletRegistry {
+  private readonly svmToEvm = new Map<string, string>();
+  private readonly evmToSvm = new Map<string, string>();
+
+  record(svmAddress: string, evmAddress: string): void {
+    const normalizedEvm = evmAddress.toLowerCase();
+    this.svmToEvm.set(svmAddress, normalizedEvm);
+    this.evmToSvm.set(normalizedEvm, svmAddress);
+  }
+
+  lookupBySvm(svmAddress: string): string | undefined {
+    return this.svmToEvm.get(svmAddress);
+  }
+
+  lookupByEvm(evmAddress: string): string | undefined {
+    return this.evmToSvm.get(evmAddress.toLowerCase());
+  }
+
+  clear(): void {
+    this.svmToEvm.clear();
+    this.evmToSvm.clear();
+  }
+}
+
 export class WalletStore {
   private key: Uint8Array | null = null;
   private _passphrase: string | null = null;
   private _cachedKey: { salt: Uint8Array; key: Uint8Array; N: number } | null = null;
   private loadPromise: Promise<void> | null = null;
   private readonly scope: string;
+  private readonly registry = new InMemoryRegistry();
 
   constructor(scope: string = "__default__") {
     this.scope = scope;
@@ -110,12 +151,13 @@ export class WalletStore {
     if (!this._passphrase) return;
 
     // Serialize wallet map to JSON-safe structure
-    const plain: Record<string, { label: string; privateKey: string; publicKey: string }> = {};
+    const plain: Record<string, { label: string; privateKey: string; publicKey: string; evmAddress?: string }> = {};
     for (const [id, w] of wallets) {
       plain[id] = {
         label: w.label,
         privateKey: Buffer.from(w.privateKey).toString("hex"),
         publicKey: Buffer.from(w.publicKey).toString("hex"),
+        ...(w.evmAddress ? { evmAddress: w.evmAddress } : {}),
       };
     }
     const plaintext = Buffer.from(JSON.stringify(plain), "utf8");
@@ -183,15 +225,23 @@ export class WalletStore {
         const plaintext = Buffer.concat([decipher.update(ciphertext), decipher.final()]);
         const plain = JSON.parse(plaintext.toString("utf8")) as Record<
           string,
-          { label: string; privateKey: string; publicKey: string }
+          { label: string; privateKey: string; publicKey: string; evmAddress?: string }
         >;
         const wallets = new Map<string, WalletData>();
         for (const [id, w] of Object.entries(plain)) {
-          wallets.set(id, {
+          const entry: WalletData = {
             label: w.label,
             privateKey: Uint8Array.from(Buffer.from(w.privateKey, "hex")),
             publicKey: Uint8Array.from(Buffer.from(w.publicKey, "hex")),
-          });
+            evmAddress: w.evmAddress,
+          };
+          wallets.set(id, entry);
+          // Restore SVM↔EVM registry entries so resolve_cross_vm_address works
+          // immediately after load (FN-016).
+          if (w.evmAddress) {
+            const svmAddr = bs58.encode(entry.publicKey);
+            this.registry.record(svmAddr, w.evmAddress);
+          }
         }
         if (N === WalletStore.SCRYPT_N_LEGACY) {
           console.error(
@@ -238,5 +288,48 @@ export class WalletStore {
       console.error("[eto-mcp] Migrated legacy wallets but could not rename legacy file:", e);
     }
     console.error("[eto-mcp] Migrated legacy wallets.enc into scoped store (__stdio__).");
+  }
+
+  // -------------------------------------------------------------------------
+  // SVM↔EVM Cross-VM Registry (FN-016)
+  // -------------------------------------------------------------------------
+
+  /**
+   * Record a SVM↔EVM address mapping in the in-memory registry.
+   *
+   * Called immediately after a wallet keypair is materialised (in
+   * `LocalSignerFactory.createWallet` / `importWallet`) so every wallet the
+   * caller can reach has an entry before any `resolve_cross_vm_address` call.
+   *
+   * @param svmAddress  Base58-encoded SVM (Ed25519) public key.
+   * @param evmAddress  0x-prefixed EVM (secp256k1) address from
+   *   `signer.getEvmSigningAddress()`.  Stored lowercase.
+   */
+  recordCrossVmMapping(svmAddress: string, evmAddress: string): void {
+    this.registry.record(svmAddress, evmAddress);
+  }
+
+  /**
+   * Look up the EVM address for a given SVM pubkey.
+   * Returns `undefined` if no mapping exists (foreign / unregistered wallet).
+   */
+  lookupBySvm(svmAddress: string): string | undefined {
+    return this.registry.lookupBySvm(svmAddress);
+  }
+
+  /**
+   * Look up the SVM pubkey for a given EVM address.
+   * Returns `undefined` if no mapping exists (foreign / unregistered wallet).
+   */
+  lookupByEvm(evmAddress: string): string | undefined {
+    return this.registry.lookupByEvm(evmAddress);
+  }
+
+  /**
+   * Expose the WalletRegistry interface for use with `resolveAddressesAsync`.
+   * Returns this store's in-memory registry view.
+   */
+  asRegistry(): WalletRegistry {
+    return this.registry;
   }
 }

--- a/src/tools/cross-vm.ts
+++ b/src/tools/cross-vm.ts
@@ -2,10 +2,13 @@ import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
 import { rpc } from "../read/rpc-client.js";
 import {
-  resolveAddresses,
+  resolveAddressesAsync,
+  evmAddressToPubkey,
   isValidEvmAddress,
   isValidSvmAddress,
 } from "../utils/address.js";
+import bs58 from "bs58";
+import { localSignerFactory } from "../signing/local-signer.js";
 import { buildCrossVmCallTx } from "../wasm/index.js";
 import { getSignerFactory } from "../signing/index.js";
 import { getActiveWalletId } from "./wallet.js";
@@ -69,10 +72,14 @@ export function registerCrossVmTools(server: McpServer): void {
         const sourceVmNum = vmMap[source_vm] ?? 0;
         const targetVmNum = vmMap[target_vm] ?? 1;
 
-        // If target is EVM and address is 0x-prefixed, derive the SVM pubkey via SHA256("evm:" || addr)
+        // If target is EVM and address is 0x-prefixed, encode the EVM address as an
+        // SVM-compatible pubkey for the CrossVmDispatcher instruction. This uses
+        // `evmAddressToPubkey` (FN-017 will update the body; for now the SHA-256
+        // preimage is retained as a stable internal representation for the
+        // cross-VM dispatcher key derivation — distinct from the wallet registry).
         let resolvedTargetContract = target_contract;
         if (target_vm === "evm" && target_contract.startsWith("0x") && isValidEvmAddress(target_contract)) {
-          resolvedTargetContract = resolveAddresses(target_contract).svm;
+          resolvedTargetContract = bs58.encode(evmAddressToPubkey(target_contract));
         }
 
         let calldata: Uint8Array;
@@ -147,7 +154,10 @@ export function registerCrossVmTools(server: McpServer): void {
           };
         }
 
-        const { svm, evm } = resolveAddresses(trimmed);
+        // Use the registry-backed async resolver (FN-016).
+        // Falls back to an informative error if the address is not registered.
+        const registry = localSignerFactory.getRegistryForCurrentScope();
+        const { svm, evm } = await resolveAddressesAsync(trimmed, registry);
 
         const inputType = isValidEvmAddress(trimmed) ? "EVM" : "SVM";
 
@@ -158,30 +168,13 @@ export function registerCrossVmTools(server: McpServer): void {
           `SVM Address:   ${svm}`,
           `EVM Address:   ${evm}`,
           ``,
-        ];
-
-        if (inputType === "SVM") {
-          lines.push(
-            "Mapping (SVM → EVM):",
-            "  The EVM address is derived by taking the last 20 bytes of the 32-byte SVM pubkey.",
-            "  pubkey[12..32] → 0x-prefixed hex string.",
-            "  This is a deterministic, one-to-many mapping — multiple SVM keys can share",
-            "  the same EVM suffix. For the reverse mapping, use the EVM→SVM derivation."
-          );
-        } else {
-          lines.push(
-            "Mapping (EVM → SVM):",
-            "  The SVM pubkey is derived via SHA256('evm:' || address_bytes).",
-            "  This creates a unique, deterministic 32-byte pubkey for each EVM address.",
-            "  The 'evm:' prefix prevents collision with native SVM pubkeys."
-          );
-        }
-
-        lines.push(
+          "Mapping method: registry-backed bijection (FN-016).",
+          "  EVM address = signer.getEvmSigningAddress() stored at wallet creation.",
+          "  This is the address recovered by ecrecover on any signed EVM transaction.",
           "",
           "Note: Both addresses refer to the same ETO account. Funds sent to either",
-          "address are accessible from both EVM and SVM programs."
-        );
+          "address are accessible from both EVM and SVM programs.",
+        ];
 
         return { content: [{ type: "text", text: lines.join("\n") }] };
       } catch (err: any) {

--- a/src/tools/query.ts
+++ b/src/tools/query.ts
@@ -119,7 +119,10 @@ export function registerQueryTools(server: McpServer): void {
     { hash: z.string().describe("Transaction hash (base58 SVM or 0x EVM)") },
     async ({ hash }) => {
       try {
-        const tx = await rpc.etoGetTransaction(hash);
+        // FN-027: align with submitter.pollConfirmation — both now use getTransaction
+        // (Solana-compatible method). The eto_getTransaction unified shape is only
+        // used by the MCP tool's prior code; after this fix, response shape matches.
+        const tx = await rpc.getTransaction(hash);
 
         if (!tx) {
           return {

--- a/src/tools/transfer.ts
+++ b/src/tools/transfer.ts
@@ -130,6 +130,7 @@ export function registerTransferTools(server: McpServer): void {
           to: z.string().describe("Recipient address (base58 or 0x)"),
           amount: z.string().describe("Amount in SOL"),
           memo: z.string().optional(),
+          idempotency_key: z.string().optional().describe("Optional caller-supplied idempotency key for this transfer. Defaults to batch-{i}-{from}-{to}-{lamports}."),
         })
       ).max(20).describe("List of transfers to execute (max 20)"),
       from_wallet: z.string().optional().describe("Wallet ID to send from; defaults to active wallet"),
@@ -159,7 +160,7 @@ export function registerTransferTools(server: McpServer): void {
         let lastBlockhash: string | null = null;
 
         for (let i = 0; i < transfers.length; i++) {
-          const { to, amount, memo } = transfers[i];
+          const { to, amount, memo, idempotency_key } = transfers[i];
 
           try {
             const registry = localSignerFactory.getRegistryForCurrentScope();
@@ -192,10 +193,11 @@ export function registerTransferTools(server: McpServer): void {
             const signedBase64 = Buffer.from(signedBytes).toString("base64");
 
             const memoSuffix = memo ? `-m:${memo}` : "";
+            const effectiveKey = idempotency_key ?? `batch-${i}-${fromSvm}-${toSvm}-${lamports}`;
             const result = await submitter.submitAndConfirm({
               signedTxBase64: signedBase64,
               vm: "svm",
-              idempotencyKey: `batch-${i}-${fromSvm}-${toSvm}-${lamports}-${blockhash}${memoSuffix}`,
+              idempotencyKey: `${effectiveKey}-${blockhash}${memoSuffix}`,
             });
 
             if (result.status === "confirmed" || result.status === "finalized") {

--- a/src/tools/transfer.ts
+++ b/src/tools/transfer.ts
@@ -6,7 +6,8 @@ import { buildTransferTx } from "../wasm/index.js";
 import { blockhashCache } from "../write/blockhash-cache.js";
 import { submitter } from "../write/submitter.js";
 import { solToLamports, lamportsToSol } from "../utils/units.js";
-import { resolveAddresses } from "../utils/address.js";
+import { resolveAddressesAsync } from "../utils/address.js";
+import { localSignerFactory } from "../signing/local-signer.js";
 import bs58 from "bs58";
 
 export function registerTransferTools(server: McpServer): void {
@@ -38,8 +39,9 @@ export function registerTransferTools(server: McpServer): void {
         const signer = await factory.getSigner(walletId);
         const fromSvm = signer.getPublicKey();
 
-        // Resolve recipient to SVM address
-        const toAddresses = resolveAddresses(to);
+        // Resolve recipient to SVM address (registry-backed, FN-016)
+        const registry = localSignerFactory.getRegistryForCurrentScope();
+        const toAddresses = await resolveAddressesAsync(to, registry);
         const toSvm = toAddresses.svm;
 
         // Convert amount to lamports
@@ -160,7 +162,8 @@ export function registerTransferTools(server: McpServer): void {
           const { to, amount, memo } = transfers[i];
 
           try {
-            const toAddresses = resolveAddresses(to);
+            const registry = localSignerFactory.getRegistryForCurrentScope();
+            const toAddresses = await resolveAddressesAsync(to, registry);
             const toSvm = toAddresses.svm;
             const lamports = solToLamports(amount);
 

--- a/src/tools/wallet.ts
+++ b/src/tools/wallet.ts
@@ -3,7 +3,7 @@ import { z } from "zod";
 import { getSignerFactory } from "../signing/index.js";
 import { localSignerFactory } from "../signing/local-signer.js";
 import { rpc } from "../read/rpc-client.js";
-import { resolveAddresses } from "../utils/address.js";
+import { resolveAddressesAsync } from "../utils/address.js";
 import { lamportsToSol } from "../utils/units.js";
 
 // Active wallet is scoped per caller (thirdweb sub / __stdio__ / __dev__) via
@@ -252,15 +252,19 @@ export function registerWalletTools(server: McpServer): void {
         const factory = getSignerFactory();
         const signer = await factory.getSigner(wallet_id);
         const svmAddress = signer.getPublicKey();
-        const addresses = resolveAddresses(svmAddress);
+        // EVM address comes directly from the signer (HKDF-SHA256 → secp256k1 →
+        // keccak256) — this is the same address used by ecrecover on signed EVM
+        // transactions (FN-016). No registry lookup needed since we hold the
+        // signer and its getEvmAddress() is the canonical source.
+        const evmAddress = signer.getEvmAddress();
 
         const lines: string[] = [`Wallet ID: ${wallet_id}`];
 
         if (!vm || vm === "svm") {
-          lines.push(`SVM Address (base58): ${addresses.svm}`);
+          lines.push(`SVM Address (base58): ${svmAddress}`);
         }
         if (!vm || vm === "evm") {
-          lines.push(`EVM Address (0x):     ${addresses.evm}`);
+          lines.push(`EVM Address (0x):     ${evmAddress}`);
         }
 
         return { content: [{ type: "text" as const, text: lines.join("\n") }] };

--- a/src/utils/address.ts
+++ b/src/utils/address.ts
@@ -24,13 +24,57 @@ export function detectAddressType(addr: string): "svm" | "evm" | "unknown" {
   return "unknown";
 }
 
-/** SVM pubkey (32 bytes) → EVM address (last 20 bytes) */
-export function pubkeyToEvmAddress(pubkey: Uint8Array): string {
-  const addr = pubkey.slice(12, 32);
-  return "0x" + Buffer.from(addr).toString("hex");
+/**
+ * Registry interface for SVM↔EVM address lookups.
+ *
+ * Implemented by WalletStore and any test double. The registry is populated at
+ * wallet-creation time (see LocalSignerFactory.createWallet / importWallet) and
+ * is the single source of truth for the SVM→EVM bijection (FN-015 Option B).
+ */
+export interface WalletRegistry {
+  /** Returns the canonical EVM address for a given SVM pubkey, or undefined if unmapped. */
+  lookupBySvm(svmAddress: string): string | undefined;
+  /** Returns the canonical SVM pubkey for a given EVM address, or undefined if unmapped. */
+  lookupByEvm(evmAddress: string): string | undefined;
 }
 
-/** EVM address (20 bytes) → SVM pubkey via SHA256("evm:" || addr) */
+/**
+ * Forward derivation stub: SVM pubkey (32 bytes) → EVM address.
+ *
+ * **Algorithm:** Registry-backed bijection (FN-015 recommendation, Option B).
+ * The EVM address for a LocalSigner wallet equals `signer.getEvmSigningAddress()`,
+ * which is derived via HKDF-SHA256(privateKey) → secp256k1 → keccak256. This
+ * derivation requires the Ed25519 *private* key and cannot be recomputed from
+ * the 32-byte public key alone.
+ *
+ * Therefore this function always throws — call `resolveAddressesAsync` with a
+ * `WalletRegistry` instead, or call `signer.getEvmAddress()` directly when the
+ * signer is available.
+ *
+ * @throws Always — SVM→EVM requires a registry lookup (FN-016).
+ *         Use `resolveAddressesAsync(svmAddr, registry)` for mapped wallets.
+ * @see resolveAddressesAsync
+ * @see WalletRegistry
+ * @deprecated — retained for type-compatibility only; body is replaced in FN-016.
+ *   The inverse (`EVM→SVM`) is implemented in FN-017.
+ */
+export function pubkeyToEvmAddress(_pubkey: Uint8Array): string {
+  throw new Error(
+    "SVM→EVM address derivation requires a registry lookup (FN-016). " +
+    "Use resolveAddressesAsync(addr, registry) for wallet-backed addresses, " +
+    "or call signer.getEvmAddress() when the signer is available.",
+  );
+}
+
+/**
+ * EVM address (20 bytes) → SVM pubkey stub.
+ *
+ * Body is intentionally left for FN-017 to implement. The current SHA-256
+ * preimage is retained to keep the function compilable; FN-017 will replace it
+ * with a registry-backed inverse lookup.
+ *
+ * @deprecated — body is a placeholder; the correct inverse is implemented in FN-017.
+ */
 export function evmAddressToPubkey(evmAddr: string): Uint8Array {
   const addrBytes = hexToBytes(evmAddr.replace("0x", ""));
   const preimage = new Uint8Array(4 + 20);
@@ -39,14 +83,85 @@ export function evmAddressToPubkey(evmAddr: string): Uint8Array {
   return sha256(preimage);
 }
 
-/** Convert base58 SVM address to both SVM and EVM formats */
-export function resolveAddresses(addr: string): { svm: string; evm: string } {
-  if (isValidEvmAddress(addr)) {
-    const pubkey = evmAddressToPubkey(addr);
-    return { svm: bs58.encode(pubkey), evm: addr.toLowerCase() };
+/**
+ * Registry-backed resolver: converts an SVM or EVM address to both formats.
+ *
+ * **Algorithm:** FN-015 Option B (registry-backed bijection).
+ *
+ * - SVM input: looks up the registry for the canonical EVM address populated at
+ *   wallet-creation time via `signer.getEvmSigningAddress()`.
+ * - EVM input: looks up the registry for the canonical SVM pubkey.
+ * - If no registry entry exists for the address, throws with an explicit
+ *   "unmapped" error — the function never fabricates an address.
+ *
+ * @param addr  SVM base58 pubkey or 0x-prefixed EVM address.
+ * @param registry  WalletRegistry providing the SVM↔EVM mapping.
+ * @returns  Both `svm` (base58) and `evm` (0x-prefixed lowercase) addresses.
+ * @throws  If the address has no registry entry.
+ */
+export async function resolveAddressesAsync(
+  addr: string,
+  registry: WalletRegistry,
+): Promise<{ svm: string; evm: string }> {
+  const trimmed = addr.trim();
+
+  if (isValidEvmAddress(trimmed)) {
+    const normalized = trimmed.toLowerCase();
+    const svm = registry.lookupByEvm(normalized);
+    if (!svm) {
+      throw new Error(
+        `EVM address ${trimmed} is not registered in any known wallet. ` +
+        "Create or import a wallet to establish the SVM↔EVM mapping.",
+      );
+    }
+    return { svm, evm: normalized };
   }
-  const pubkey = bs58.decode(addr);
-  return { svm: addr, evm: pubkeyToEvmAddress(pubkey) };
+
+  if (isValidSvmAddress(trimmed)) {
+    const evm = registry.lookupBySvm(trimmed);
+    if (!evm) {
+      throw new Error(
+        `SVM address ${trimmed} is not registered in any known wallet. ` +
+        "Create or import a wallet to establish the SVM↔EVM mapping.",
+      );
+    }
+    return { svm: trimmed, evm };
+  }
+
+  throw new Error(
+    `Invalid address: "${trimmed}". Expected a base58 SVM pubkey (32 bytes) or a 0x-prefixed EVM address (20 bytes).`,
+  );
+}
+
+/**
+ * Synchronous address resolver — **retained for backward-compatibility only**.
+ *
+ * This function can no longer compute SVM→EVM or EVM→SVM mappings without a
+ * registry (FN-015 Option B).  Call sites that only need address validation /
+ * pass-through (i.e. they use only the same-type output field) still compile
+ * correctly.  Any call site that needs a cross-VM conversion MUST switch to
+ * `resolveAddressesAsync`.
+ *
+ * Behavior:
+ * - SVM input: `{ svm: addr, evm: "<unmapped — use resolveAddressesAsync>" }`
+ * - EVM input: `{ svm: "<unmapped — use resolveAddressesAsync>", evm: addr.toLowerCase() }`
+ *
+ * @deprecated  For cross-VM resolution use `resolveAddressesAsync` with a
+ *   `WalletRegistry` (FN-016).  This function is kept so existing call sites
+ *   that only consume the same-type field continue to compile.
+ */
+export function resolveAddresses(addr: string): { svm: string; evm: string } {
+  const trimmed = addr.trim();
+  if (isValidEvmAddress(trimmed)) {
+    return {
+      svm: "<unmapped — use resolveAddressesAsync>",
+      evm: trimmed.toLowerCase(),
+    };
+  }
+  return {
+    svm: trimmed,
+    evm: "<unmapped — use resolveAddressesAsync>",
+  };
 }
 
 export function pubkeyToBase58(pubkey: Uint8Array): string {

--- a/src/wasm/index.ts
+++ b/src/wasm/index.ts
@@ -4,6 +4,7 @@ import { sha256 } from "@noble/hashes/sha256";
 import { sha512 } from "@noble/hashes/sha2";
 import { keccak_256 } from "@noble/hashes/sha3";
 import bs58 from "bs58";
+import * as addressUtils from "../utils/address.js";
 
 // Configure ed25519 to use synchronous SHA-512
 etc.sha512Sync = (...m: Uint8Array[]) => sha512(etc.concatBytes(...m));
@@ -204,21 +205,29 @@ export function deriveKeypair(_mnemonic: string, _path: string): never {
 // Address Conversion
 // ---------------------------------------------------------------------------
 
+/**
+ * SVM pubkey (base58) → EVM address.
+ *
+ * Delegates to `src/utils/address.ts:pubkeyToEvmAddress` to eliminate
+ * algorithm duplication (FN-016). The forward derivation is registry-backed
+ * and always throws when called without a registry context — use
+ * `resolveAddressesAsync` from `src/utils/address.ts` instead.
+ *
+ * @throws Always — see `pubkeyToEvmAddress` in `src/utils/address.ts`.
+ */
 export function pubkeyToEvmAddress(pubkeyB58: string): string {
+  // Decode pubkey bytes only to pass to the canonical implementation.
   const bytes = pubkeyBytes(pubkeyB58);
-  const last20 = bytes.slice(12); // last 20 bytes
-  return "0x" + Buffer.from(last20).toString("hex");
+  return addressUtils.pubkeyToEvmAddress(bytes);
 }
 
+/**
+ * EVM address → SVM pubkey (base58).
+ *
+ * Delegates to `src/utils/address.ts:evmAddressToPubkey` (FN-016 / FN-017).
+ */
 export function evmAddressToPubkey(evmAddr: string): string {
-  const addr = evmAddr.startsWith("0x") ? evmAddr.slice(2) : evmAddr;
-  const prefix = new TextEncoder().encode("evm:");
-  const addrBytes = new TextEncoder().encode(addr);
-  const combined = new Uint8Array(prefix.length + addrBytes.length);
-  combined.set(prefix);
-  combined.set(addrBytes, prefix.length);
-  const hash = sha256(combined);
-  return bs58.encode(hash);
+  return bs58.encode(addressUtils.evmAddressToPubkey(evmAddr));
 }
 
 export function findPda(

--- a/src/write/submitter.ts
+++ b/src/write/submitter.ts
@@ -1,6 +1,7 @@
 import { config } from "../config.js";
 import { rpc } from "../read/rpc-client.js";
 import { blockhashCache } from "./blockhash-cache.js";
+import { log } from "../utils/logger.js";
 import type { TransactionResult } from "../models/index.js";
 
 export interface SubmitParams {
@@ -129,10 +130,17 @@ export class TransactionSubmitter {
     _vm: string,
   ): Promise<TransactionResult> {
     const deadline = Date.now() + Math.max(remainingMs, 5000);
+    // FN-197: count consecutive non-"not found" RPC failures. A single
+    // transient blip (e.g. brief network glitch) should not abort the
+    // polling loop, but a sustained failure window must surface to the
+    // caller so they don’t spin silently until timeout. Reset on any
+    // successful round-trip (whether tx is null or a receipt).
+    let consecutiveErrors = 0;
 
     while (Date.now() < deadline) {
       try {
         const tx: any = await rpc.getTransaction(signature);
+        consecutiveErrors = 0;
         if (tx) {
           // The receipt arrives whether the tx succeeded or failed; check
           // success/error before reporting "confirmed". Otherwise every failed
@@ -171,19 +179,32 @@ export class TransactionSubmitter {
         }
       } catch (e: any) {
         // FN-197 / FN-099: only swallow "transaction not found yet" — that
-        // is the expected polling case. Network errors, JSON-RPC malformed
-        // responses, and 5xx errors are real failures that the caller
-        // needs to see, otherwise the loop spins silently until timeout.
+        // is the expected polling case. Real RPC/network failures are
+        // tolerated up to `config.tx.maxPollErrors` consecutive occurrences
+        // before bubbling, which gives roughly
+        // `maxPollErrors * confirmationPollMs` of tolerance for transient
+        // node hiccups. Anything beyond that surfaces to the caller so
+        // the loop never spins silently until timeout.
         const msg = String(e?.message ?? e ?? "");
         const notFound =
           /not\s*found|unknown\s*transaction|invalid\s*signature/i.test(msg) ||
           /JSON-RPC\s*error\s*-32004/.test(msg) || // common "tx not found" code
           /JSON-RPC\s*error\s*-32602/.test(msg); // invalid params (sig not seen yet)
-        if (!notFound) {
-          // Bubble real errors out — caller needs to know the node is sick.
-          throw e;
+        if (notFound) {
+          // Expected polling case — reset the counter and keep polling.
+          consecutiveErrors = 0;
+        } else {
+          consecutiveErrors++;
+          if (consecutiveErrors >= config.tx.maxPollErrors) {
+            // Threshold reached: the node looks sick. Bubble to _submit’s
+            // outer retry/non-retryable classifier.
+            throw e;
+          }
+          log("warn", "rpc", "pollConfirmation transient error", {
+            attempt: consecutiveErrors,
+            msg,
+          });
         }
-        // Otherwise: keep polling.
       }
       await new Promise<void>((r) => setTimeout(r, config.tx.confirmationPollMs));
     }

--- a/test/bank-mock.test.ts
+++ b/test/bank-mock.test.ts
@@ -124,6 +124,7 @@ describe("issueBankFiatRampTest — happy path", () => {
     const res = await issueBankFiatRampTest(deps, {
       checkingAccountId: ACCT,
       agentCardPubkey: CARD_A,
+      callerPubkey: CARD_A,
     });
 
     expect(res.status).toBe("issued");
@@ -165,12 +166,14 @@ describe("issueBankFiatRampTest — idempotency", () => {
     const first = await issueBankFiatRampTest(deps, {
       checkingAccountId: ACCT,
       agentCardPubkey: CARD_A,
+      callerPubkey: CARD_A,
     });
     expect(first.status).toBe("issued");
 
     const second = await issueBankFiatRampTest(deps, {
       checkingAccountId: ACCT,
       agentCardPubkey: CARD_A,
+      callerPubkey: CARD_A,
     });
     expect(second.status).toBe("idempotent");
     if (second.status !== "idempotent") throw new Error("unreachable");
@@ -191,12 +194,14 @@ describe("issueBankFiatRampTest — binding conflict", () => {
     await issueBankFiatRampTest(deps, {
       checkingAccountId: ACCT,
       agentCardPubkey: CARD_A,
+      callerPubkey: CARD_A,
     });
 
     await expect(
       issueBankFiatRampTest(deps, {
         checkingAccountId: ACCT,
         agentCardPubkey: CARD_B,
+        callerPubkey: CARD_B,
       }),
     ).rejects.toMatchObject({
       name: "BankMockIssueError",
@@ -238,6 +243,7 @@ describe("issueBankFiatRampTest — binding conflict", () => {
       issueBankFiatRampTest(deps, {
         checkingAccountId: ACCT,
         agentCardPubkey: CARD_A,
+        callerPubkey: CARD_A,
       }),
     ).rejects.toMatchObject({
       name: "BankMockIssueError",
@@ -252,6 +258,7 @@ describe("issueBankFiatRampTest — invalid input", () => {
       issueBankFiatRampTest(depsWith(), {
         checkingAccountId: "",
         agentCardPubkey: CARD_A,
+        callerPubkey: CARD_A,
       }),
     ).rejects.toMatchObject({
       name: "BankMockIssueError",
@@ -260,16 +267,133 @@ describe("issueBankFiatRampTest — invalid input", () => {
   });
 
   it("rejects empty agentCardPubkey", async () => {
+    // callerPubkey cannot equal empty agentCardPubkey → unauthorized_caller fires first.
+    // This test verifies that an empty agentCardPubkey is always rejected.
     await expect(
       issueBankFiatRampTest(depsWith(), {
         checkingAccountId: ACCT,
         agentCardPubkey: "",
+        callerPubkey: CARD_A,
       }),
     ).rejects.toMatchObject({
       name: "BankMockIssueError",
-      kind: "invalid_request",
+      kind: "unauthorized_caller",
     });
   });
+});
+
+describe("issueBankFiatRampTest — caller binding (FN-070)", () => {
+  it("rejects when callerPubkey != agentCardPubkey (impersonation attempt)", async () => {
+    // Attacker tries to mint a credential whose subject is CARD_A while the
+    // gateway-verified caller principal is CARD_B. This is the core FN-070
+    // attack: prior to the fix, any caller could name an arbitrary subject
+    // pubkey in the request body and have it bound on-chain.
+    const chain = new StubChain();
+    const store = new InMemoryBankMockStore();
+    const deps = depsWith({ chain, store });
+
+    await expect(
+      issueBankFiatRampTest(deps, {
+        checkingAccountId: ACCT,
+        agentCardPubkey: CARD_A,
+        callerPubkey: CARD_B,
+      }),
+    ).rejects.toMatchObject({
+      name: "BankMockIssueError",
+      kind: "unauthorized_caller",
+    });
+
+    // Hard guarantee: zero side effects — no chain tx, no store row.
+    expect(chain.calls).toHaveLength(0);
+    expect(await store.get(ACCT)).toBeUndefined();
+  });
+
+  it("rejects when callerPubkey is missing", async () => {
+    const chain = new StubChain();
+    const store = new InMemoryBankMockStore();
+    const deps = depsWith({ chain, store });
+
+    await expect(
+      issueBankFiatRampTest(deps, {
+        checkingAccountId: ACCT,
+        agentCardPubkey: CARD_A,
+        // @ts-expect-error — exercising runtime guard for a missing field
+        callerPubkey: undefined,
+      }),
+    ).rejects.toMatchObject({
+      name: "BankMockIssueError",
+      kind: "unauthorized_caller",
+    });
+    expect(chain.calls).toHaveLength(0);
+  });
+
+  it("rejects when callerPubkey is an empty string", async () => {
+    const chain = new StubChain();
+    const deps = depsWith({ chain });
+    await expect(
+      issueBankFiatRampTest(deps, {
+        checkingAccountId: ACCT,
+        agentCardPubkey: CARD_A,
+        callerPubkey: "",
+      }),
+    ).rejects.toMatchObject({
+      name: "BankMockIssueError",
+      kind: "unauthorized_caller",
+    });
+    expect(chain.calls).toHaveLength(0);
+  });
+
+  it("accepts case-insensitive hex match between caller and subject", async () => {
+    // Caller pubkey may arrive in a different hex case (some signers emit
+    // upper-case). Constant-time comparison still succeeds after lowering.
+    const deps = depsWith();
+    const res = await issueBankFiatRampTest(deps, {
+      checkingAccountId: ACCT,
+      agentCardPubkey: CARD_A.toLowerCase(),
+      callerPubkey: CARD_A.toUpperCase(),
+    });
+    expect(res.status).toBe("issued");
+  });
+
+  it(
+    "race-attack acceptance criterion: an attacker armed with a valid " +
+      "signature over their own card can still poison a victim acct id, " +
+      "but only with a card they actually control",
+    async () => {
+      // Per FN-070 acceptance criterion #4: caller-auth alone does NOT
+      // close the checkingAccountId-provenance race; that's a separate
+      // task. What it MUST guarantee is that the attacker can only bind
+      // cards they control — they cannot mint a credential whose subject
+      // is the legitimate holder's AgentCard.
+      const chain = new StubChain();
+      const store = new InMemoryBankMockStore();
+      const deps = depsWith({ chain, store });
+
+      // Attacker successfully binds the victim acct id to *their own* card.
+      const attacker = await issueBankFiatRampTest(deps, {
+        checkingAccountId: ACCT,
+        agentCardPubkey: CARD_B,
+        callerPubkey: CARD_B,
+      });
+      expect(attacker.status).toBe("issued");
+
+      // The attacker CANNOT, however, bind the acct id to the victim's
+      // card — even racing the legitimate holder, because the gateway
+      // verifier would never produce callerPubkey=CARD_A for an attacker.
+      // We model that here by simulating the attacker submitting with
+      // CARD_A as the named subject but their own (CARD_B) verified caller.
+      await expect(
+        issueBankFiatRampTest(deps, {
+          checkingAccountId: "any-other-acct",
+          agentCardPubkey: CARD_A,
+          callerPubkey: CARD_B,
+        }),
+      ).rejects.toMatchObject({
+        name: "BankMockIssueError",
+        kind: "unauthorized_caller",
+      });
+    },
+  );
 });
 
 describe("issueBankFiatRampTest — chain failure", () => {
@@ -283,6 +407,7 @@ describe("issueBankFiatRampTest — chain failure", () => {
       issueBankFiatRampTest(deps, {
         checkingAccountId: ACCT,
         agentCardPubkey: CARD_A,
+        callerPubkey: CARD_A,
       }),
     ).rejects.toMatchObject({
       name: "BankMockIssueError",
@@ -295,6 +420,7 @@ describe("issueBankFiatRampTest — chain failure", () => {
     const retry = await issueBankFiatRampTest(deps, {
       checkingAccountId: ACCT,
       agentCardPubkey: CARD_A,
+      callerPubkey: CARD_A,
     });
     expect(retry.status).toBe("issued");
   });
@@ -315,6 +441,7 @@ describe("revokeBankFiatRampTest", () => {
     const issued = await issueBankFiatRampTest(deps, {
       checkingAccountId: ACCT,
       agentCardPubkey: CARD_A,
+      callerPubkey: CARD_A,
     });
     if (issued.status !== "issued") throw new Error("unreachable");
 
@@ -338,6 +465,7 @@ describe("revokeBankFiatRampTest", () => {
     await issueBankFiatRampTest(deps, {
       checkingAccountId: ACCT,
       agentCardPubkey: CARD_A,
+      callerPubkey: CARD_A,
     });
     const first = await revokeBankFiatRampTest(deps, {
       checkingAccountId: ACCT,
@@ -380,6 +508,7 @@ describe("revokeBankFiatRampTest", () => {
     await issueBankFiatRampTest(deps, {
       checkingAccountId: ACCT,
       agentCardPubkey: CARD_A,
+      callerPubkey: CARD_A,
     });
 
     revoker.failNext = true;

--- a/test/kyc-test.test.ts
+++ b/test/kyc-test.test.ts
@@ -4,6 +4,7 @@ import {
   HmacKycTestFormTokenSigner,
   KYC_TEST_MIN_DWELL_SECONDS,
   KYC_TEST_SCHEMA_ID_HEX,
+  KycTestAgentCardSignatureVerifier,
   KycTestDedupeRow,
   KycTestDedupeStore,
   KycTestFormSubmission,
@@ -20,6 +21,18 @@ import {
   normalizeName,
   renderKycTestFormHtml,
 } from "../src/issuers/kyc-test.js";
+
+// FN-057 — wallet-binding signature is now required. Tests in this
+// file pre-date that change and exercise issuance logic that doesn't
+// depend on signature semantics, so we use an always-true stub and a
+// constant signature placeholder. The dedicated boundary suite in
+// `tests/issuers/kyc-test.test.ts` exercises the real Ed25519 path.
+const stubSigVerifier: KycTestAgentCardSignatureVerifier = {
+  async verify() {
+    return true;
+  },
+};
+const STUB_SIGNATURE = Buffer.alloc(64).toString("base64");
 
 const CARD_A = "AgentCardAaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
 const CARD_B = "AgentCardBbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb";
@@ -117,6 +130,7 @@ interface DepsOverrides {
   chain?: KycTestIssueCredentialClient;
   pinner?: KycTestVcPinner;
   clock?: KycTestSlotClock;
+  signatureVerifier?: KycTestAgentCardSignatureVerifier;
   issuerAuthorityPubkey?: string;
   minDwellSeconds?: number;
   nowUnix: number;
@@ -129,6 +143,7 @@ function depsWith(overrides: DepsOverrides): KycTestIssuerDeps {
     chain: overrides.chain ?? new StubChain(),
     pinner: overrides.pinner ?? new StubPinner(),
     clock: overrides.clock ?? new FixedClock(123n),
+    signatureVerifier: overrides.signatureVerifier ?? stubSigVerifier,
     issuerAuthorityPubkey: overrides.issuerAuthorityPubkey ?? ISSUER,
     nowUnix: () => overrides.nowUnix,
     ...(overrides.minDwellSeconds !== undefined
@@ -258,6 +273,7 @@ describe("issueKycTest happy path", () => {
     const res = await issueKycTest(deps, {
       submission,
       agentCardPubkey: CARD_A,
+      agentCardSignature: STUB_SIGNATURE,
     });
 
     expect(res.status).toBe("issued");
@@ -296,10 +312,12 @@ describe("issueKycTest happy path", () => {
     const first = await issueKycTest(deps, {
       submission,
       agentCardPubkey: CARD_A,
+      agentCardSignature: STUB_SIGNATURE,
     });
     const second = await issueKycTest(deps, {
       submission,
       agentCardPubkey: CARD_A,
+      agentCardSignature: STUB_SIGNATURE,
     });
 
     expect(first.status).toBe("issued");
@@ -325,6 +343,7 @@ describe("issueKycTest dwell enforcement", () => {
       issueKycTest(deps, {
         submission: makeSubmission({ signer, flowStartedAtUnix }),
         agentCardPubkey: CARD_A,
+        agentCardSignature: STUB_SIGNATURE,
       }),
     ).rejects.toMatchObject({
       kind: "dwell_too_short",
@@ -341,6 +360,7 @@ describe("issueKycTest dwell enforcement", () => {
       issueKycTest(deps, {
         submission: makeSubmission({ signer, flowStartedAtUnix }),
         agentCardPubkey: CARD_A,
+        agentCardSignature: STUB_SIGNATURE,
       }),
     ).rejects.toBeInstanceOf(KycTestIssueError);
   });
@@ -355,6 +375,7 @@ describe("issueKycTest dwell enforcement", () => {
     const res = await issueKycTest(deps, {
       submission: makeSubmission({ signer, flowStartedAtUnix }),
       agentCardPubkey: CARD_A,
+      agentCardSignature: STUB_SIGNATURE,
     });
     expect(res.status).toBe("issued");
   });
@@ -373,7 +394,7 @@ describe("issueKycTest token + form validation", () => {
       tagOverride: "00".repeat(32),
     });
     await expect(
-      issueKycTest(deps, { submission, agentCardPubkey: CARD_A }),
+      issueKycTest(deps, { submission, agentCardPubkey: CARD_A, agentCardSignature: STUB_SIGNATURE }),
     ).rejects.toMatchObject({ kind: "invalid_token" });
   });
 
@@ -394,6 +415,7 @@ describe("issueKycTest token + form validation", () => {
           formTokenHmacHex: tag,
         },
         agentCardPubkey: CARD_A,
+        agentCardSignature: STUB_SIGNATURE,
       }),
     ).rejects.toMatchObject({ kind: "invalid_token" });
   });
@@ -411,7 +433,7 @@ describe("issueKycTest token + form validation", () => {
       flowStartedAtUnix,
     });
     await expect(
-      issueKycTest(deps, { submission, agentCardPubkey: CARD_A }),
+      issueKycTest(deps, { submission, agentCardPubkey: CARD_A, agentCardSignature: STUB_SIGNATURE }),
     ).rejects.toMatchObject({ kind: "invalid_form" });
   });
 
@@ -430,7 +452,7 @@ describe("issueKycTest token + form validation", () => {
       flowStartedAtUnix,
     });
     await expect(
-      issueKycTest(deps, { submission, agentCardPubkey: CARD_A }),
+      issueKycTest(deps, { submission, agentCardPubkey: CARD_A, agentCardSignature: STUB_SIGNATURE }),
     ).rejects.toMatchObject({ kind: "invalid_form" });
   });
 
@@ -439,7 +461,7 @@ describe("issueKycTest token + form validation", () => {
     const deps = depsWith({ tokenSigner: signer, nowUnix });
     const submission = makeSubmission({ signer, flowStartedAtUnix });
     await expect(
-      issueKycTest(deps, { submission, agentCardPubkey: "" }),
+      issueKycTest(deps, { submission, agentCardPubkey: "", agentCardSignature: STUB_SIGNATURE }),
     ).rejects.toMatchObject({ kind: "invalid_form" });
   });
 });
@@ -462,12 +484,14 @@ describe("issueKycTest dedupe semantics", () => {
     await issueKycTest(deps, {
       submission: makeSubmission({ signer, flowStartedAtUnix }),
       agentCardPubkey: CARD_A,
+      agentCardSignature: STUB_SIGNATURE,
     });
 
     await expect(
       issueKycTest(deps, {
         submission: makeSubmission({ signer, flowStartedAtUnix }),
         agentCardPubkey: CARD_B,
+        agentCardSignature: STUB_SIGNATURE,
       }),
     ).rejects.toMatchObject({ kind: "replay_conflict" });
 
@@ -490,6 +514,7 @@ describe("issueKycTest dedupe semantics", () => {
       issueKycTest(deps, {
         submission: makeSubmission({ signer, flowStartedAtUnix }),
         agentCardPubkey: CARD_A,
+        agentCardSignature: STUB_SIGNATURE,
       }),
     ).rejects.toMatchObject({ kind: "chain_failed" });
     expect(dedupe.rows.size).toBe(0);
@@ -498,6 +523,7 @@ describe("issueKycTest dedupe semantics", () => {
     const res = await issueKycTest(deps, {
       submission: makeSubmission({ signer, flowStartedAtUnix }),
       agentCardPubkey: CARD_A,
+      agentCardSignature: STUB_SIGNATURE,
     });
     expect(res.status).toBe("issued");
   });

--- a/test/skill-cert.test.ts
+++ b/test/skill-cert.test.ts
@@ -1,26 +1,56 @@
+import {
+  generateKeyPairSync,
+  sign as cryptoSign,
+} from "node:crypto";
 import { describe, expect, it, vi } from "vitest";
 
 import {
   buildSkillCertClaim,
   canonicalJson,
   defaultClaimHasher,
+  ed25519SkillCertSignatureVerifier,
   InMemorySkillBindingStore,
   schemaIdForSkill,
   sha256Hex,
   SKILL_CERT_SCHEMA_PREFIX,
   SKILL_CERT_SCHEMA_SUFFIX,
+  skillCertSignaturePreimage,
   SkillCertIssuer,
   SkillCertIssuerError,
   StaticSkillWhitelist,
 } from "../src/issuers/skill-cert.js";
 import type {
+  AgentCardSignatureVerifier,
   ChainClient,
   IpfsPinner,
   IssueCredentialArgs,
   IssueCredentialResult,
+  SkillCertIssueRequest,
   SkillCertIssuerConfig,
   SkillCertIssuerDeps,
 } from "../src/issuers/skill-cert.js";
+
+/** Stub that accepts any signature — used by tests focused on other paths. */
+const acceptAllSignatureVerifier: AgentCardSignatureVerifier = {
+  async verify() {
+    return true;
+  },
+};
+
+/** Helper: tack a stub signature/nonce onto a (skill, subject) request. */
+function req(
+  skill: string,
+  subjectAgentCard: string,
+  overrides: Partial<SkillCertIssueRequest> = {},
+): SkillCertIssueRequest {
+  return {
+    skill,
+    subjectAgentCard,
+    agentCardSignature: "AA",
+    issuanceNonce: "nonce-1",
+    ...overrides,
+  } as SkillCertIssueRequest;
+}
 
 const SUBJECT_A = "AgentCardPubkeyAAAAAAAAAAAAAAAAAAAAAAAAAAAA";
 const SUBJECT_B = "AgentCardPubkeyBBBBBBBBBBBBBBBBBBBBBBBBBBBB";
@@ -69,6 +99,7 @@ function makeIssuer(opts: {
   chain?: FakeChain;
   ipfs?: FakePinner;
   now?: () => number;
+  signatureVerifier?: AgentCardSignatureVerifier;
 } = {}): { issuer: SkillCertIssuer; deps: MakeIssuerDeps } {
   const whitelist =
     opts.whitelist ??
@@ -83,6 +114,7 @@ function makeIssuer(opts: {
     bindingStore,
     chain,
     ipfs,
+    signatureVerifier: opts.signatureVerifier ?? acceptAllSignatureVerifier,
     now,
   };
   return {
@@ -214,10 +246,7 @@ describe("buildSkillCertClaim", () => {
 describe("SkillCertIssuer.issue — happy path (AC: whitelist + per-(subject,skill))", () => {
   it("issues a credential for a whitelisted (skill, subject) pair", async () => {
     const { issuer, deps } = makeIssuer();
-    const res = await issuer.issue({
-      skill: SKILL,
-      subjectAgentCard: SUBJECT_A,
-    });
+    const res = await issuer.issue(req(SKILL, SUBJECT_A));
     expect(res.idempotent).toBe(false);
     expect(res.schema).toBe(schemaIdForSkill(SKILL));
     expect(res.claimUri.startsWith("ipfs://")).toBe(true);
@@ -237,10 +266,7 @@ describe("SkillCertIssuer.issue — happy path (AC: whitelist + per-(subject,ski
 
   it("claim_hash matches sha256(JCS(envelope))", async () => {
     const { issuer, deps } = makeIssuer({ now: () => 1_700_000_000_000 });
-    const res = await issuer.issue({
-      skill: SKILL,
-      subjectAgentCard: SUBJECT_A,
-    });
+    const res = await issuer.issue(req(SKILL, SUBJECT_A));
     const expectedClaim = buildSkillCertClaim({
       issuerDid: ISSUER_DID,
       skill: SKILL,
@@ -256,7 +282,7 @@ describe("SkillCertIssuer.issue — AC1: whitelist enforcement", () => {
   it("rejects (skill, subject) not on the whitelist", async () => {
     const { issuer, deps } = makeIssuer();
     await expect(
-      issuer.issue({ skill: SKILL, subjectAgentCard: SUBJECT_C }),
+      issuer.issue(req(SKILL, SUBJECT_C )),
     ).rejects.toMatchObject({
       name: "SkillCertIssuerError",
       code: "NOT_WHITELISTED",
@@ -270,7 +296,7 @@ describe("SkillCertIssuer.issue — AC1: whitelist enforcement", () => {
   it("rejects unknown skill (no whitelist entries)", async () => {
     const { issuer } = makeIssuer();
     await expect(
-      issuer.issue({ skill: "rust-audit", subjectAgentCard: SUBJECT_A }),
+      issuer.issue(req("rust-audit", SUBJECT_A )),
     ).rejects.toMatchObject({ code: "NOT_WHITELISTED" });
   });
 
@@ -289,13 +315,14 @@ describe("SkillCertIssuer.issue — AC1: whitelist enforcement", () => {
         bindingStore: new InMemorySkillBindingStore(),
         chain: new FakeChain(),
         ipfs: new FakePinner(),
+        signatureVerifier: acceptAllSignatureVerifier,
       },
     );
     await expect(
-      issuer.issue({ skill: SKILL, subjectAgentCard: SUBJECT_A }),
+      issuer.issue(req(SKILL, SUBJECT_A )),
     ).resolves.toMatchObject({ idempotent: false });
     await expect(
-      issuer.issue({ skill: SKILL, subjectAgentCard: SUBJECT_B }),
+      issuer.issue(req(SKILL, SUBJECT_B )),
     ).rejects.toMatchObject({ code: "NOT_WHITELISTED" });
     expect(asyncWhitelist.isAllowed).toHaveBeenCalled();
   });
@@ -304,14 +331,8 @@ describe("SkillCertIssuer.issue — AC1: whitelist enforcement", () => {
 describe("SkillCertIssuer.issue — AC2: one credential per (subject, skill)", () => {
   it("returns the cached binding on the second call (idempotent)", async () => {
     const { issuer, deps } = makeIssuer();
-    const first = await issuer.issue({
-      skill: SKILL,
-      subjectAgentCard: SUBJECT_A,
-    });
-    const second = await issuer.issue({
-      skill: SKILL,
-      subjectAgentCard: SUBJECT_A,
-    });
+    const first = await issuer.issue(req(SKILL, SUBJECT_A));
+    const second = await issuer.issue(req(SKILL, SUBJECT_A));
     expect(first.idempotent).toBe(false);
     expect(second.idempotent).toBe(true);
     expect(second.credentialPda).toBe(first.credentialPda);
@@ -325,14 +346,8 @@ describe("SkillCertIssuer.issue — AC2: one credential per (subject, skill)", (
 
   it("issues separate credentials for different subjects on the same skill", async () => {
     const { issuer, deps } = makeIssuer();
-    const a = await issuer.issue({
-      skill: SKILL,
-      subjectAgentCard: SUBJECT_A,
-    });
-    const b = await issuer.issue({
-      skill: SKILL,
-      subjectAgentCard: SUBJECT_B,
-    });
+    const a = await issuer.issue(req(SKILL, SUBJECT_A));
+    const b = await issuer.issue(req(SKILL, SUBJECT_B));
     expect(a.credentialPda).not.toBe(b.credentialPda);
     expect(deps.chain.calls).toHaveLength(2);
   });
@@ -343,14 +358,8 @@ describe("SkillCertIssuer.issue — AC2: one credential per (subject, skill)", (
       "rust-audit": [SUBJECT_A],
     });
     const { issuer, deps } = makeIssuer({ whitelist: wl });
-    const s1 = await issuer.issue({
-      skill: "solidity-audit",
-      subjectAgentCard: SUBJECT_A,
-    });
-    const s2 = await issuer.issue({
-      skill: "rust-audit",
-      subjectAgentCard: SUBJECT_A,
-    });
+    const s1 = await issuer.issue(req("solidity-audit", SUBJECT_A));
+    const s2 = await issuer.issue(req("rust-audit", SUBJECT_A));
     expect(s1.schema).not.toBe(s2.schema);
     expect(s1.credentialPda).not.toBe(s2.credentialPda);
     expect(deps.chain.calls).toHaveLength(2);
@@ -359,19 +368,13 @@ describe("SkillCertIssuer.issue — AC2: one credential per (subject, skill)", (
   it("idempotent re-hit serves even if subject is later removed from whitelist", async () => {
     const wl = new StaticSkillWhitelist({ [SKILL]: [SUBJECT_A] });
     const { issuer, deps } = makeIssuer({ whitelist: wl });
-    const first = await issuer.issue({
-      skill: SKILL,
-      subjectAgentCard: SUBJECT_A,
-    });
+    const first = await issuer.issue(req(SKILL, SUBJECT_A));
     // The deps object inside the issuer is the original one — but we're
     // testing the contract: a previously-bound subject should still get
     // the cached row because the bridge consults the binding store
     // BEFORE the whitelist (cached row wins).
     void deps;
-    const second = await issuer.issue({
-      skill: SKILL,
-      subjectAgentCard: SUBJECT_A,
-    });
+    const second = await issuer.issue(req(SKILL, SUBJECT_A));
     expect(second.idempotent).toBe(true);
     expect(second.credentialPda).toBe(first.credentialPda);
   });
@@ -382,7 +385,7 @@ describe("SkillCertIssuer.issue — request validation", () => {
     const { issuer } = makeIssuer();
     for (const bad of ["", "Solidity-Audit", "x_y", "x y", "x--y", "-x", "x-"]) {
       await expect(
-        issuer.issue({ skill: bad, subjectAgentCard: SUBJECT_A }),
+        issuer.issue(req(bad, SUBJECT_A )),
       ).rejects.toMatchObject({ code: "INVALID_SKILL", status: 400 });
     }
   });
@@ -390,7 +393,7 @@ describe("SkillCertIssuer.issue — request validation", () => {
   it("rejects empty subjectAgentCard", async () => {
     const { issuer } = makeIssuer();
     await expect(
-      issuer.issue({ skill: SKILL, subjectAgentCard: "" }),
+      issuer.issue(req(SKILL, "" )),
     ).rejects.toMatchObject({ code: "INVALID_SUBJECT", status: 400 });
   });
 });
@@ -401,7 +404,7 @@ describe("SkillCertIssuer.issue — failure modes", () => {
     chain.failures = 1;
     const { issuer, deps } = makeIssuer({ chain });
     await expect(
-      issuer.issue({ skill: SKILL, subjectAgentCard: SUBJECT_A }),
+      issuer.issue(req(SKILL, SUBJECT_A )),
     ).rejects.toMatchObject({ code: "CHAIN_TX_FAILED", status: 502 });
     expect(await deps.bindingStore.get(SKILL, SUBJECT_A)).toBeUndefined();
   });
@@ -412,7 +415,7 @@ describe("SkillCertIssuer.issue — failure modes", () => {
     };
     const { issuer } = makeIssuer({ ipfs: ipfs as unknown as FakePinner });
     await expect(
-      issuer.issue({ skill: SKILL, subjectAgentCard: SUBJECT_A }),
+      issuer.issue(req(SKILL, SUBJECT_A )),
     ).rejects.toMatchObject({ code: "CHAIN_TX_FAILED", status: 500 });
   });
 
@@ -444,10 +447,7 @@ describe("SkillCertIssuer.issue — failure modes", () => {
     racingStore.get = async () => (getCalls++ === 0 ? undefined : canonical);
 
     const { issuer, deps } = makeIssuer({ store: racingStore });
-    const res = await issuer.issue({
-      skill: SKILL,
-      subjectAgentCard: SUBJECT_A,
-    });
+    const res = await issuer.issue(req(SKILL, SUBJECT_A));
     expect(res.idempotent).toBe(true);
     expect(res.credentialPda).toBe("PDA-canonical");
     expect(res.txSignature).toBe("tx-canonical");
@@ -464,8 +464,204 @@ describe("SkillCertIssuer.issue — failure modes", () => {
     };
     const { issuer } = makeIssuer({ store: racingStore });
     await expect(
-      issuer.issue({ skill: SKILL, subjectAgentCard: SUBJECT_A }),
+      issuer.issue(req(SKILL, SUBJECT_A )),
     ).rejects.toMatchObject({ code: "CHAIN_TX_FAILED", status: 500 });
+  });
+});
+
+describe("SkillCertIssuer.issue — caller-binding signature (FN-058)", () => {
+  // Generate a stable Ed25519 keypair for tests; the wallet pubkey is
+  // the raw 32-byte public key encoded as base58 — the AgentCard wire
+  // format used elsewhere in this codebase. We rebuild the base58
+  // string locally so tests do not pull in extra deps.
+  const BASE58_ALPHABET =
+    "123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz";
+  function base58Encode(bytes: Uint8Array): string {
+    let zeros = 0;
+    while (zeros < bytes.length && bytes[zeros] === 0) zeros += 1;
+    const digits: number[] = [];
+    for (let i = zeros; i < bytes.length; i += 1) {
+      let carry = bytes[i]!;
+      for (let j = 0; j < digits.length; j += 1) {
+        carry += digits[j]! << 8;
+        digits[j] = carry % 58;
+        carry = (carry / 58) | 0;
+      }
+      while (carry > 0) {
+        digits.push(carry % 58);
+        carry = (carry / 58) | 0;
+      }
+    }
+    let out = "";
+    for (let i = 0; i < zeros; i += 1) out += "1";
+    for (let i = digits.length - 1; i >= 0; i -= 1) out += BASE58_ALPHABET[digits[i]!];
+    return out;
+  }
+
+  function makeKeypair(): {
+    pubBase58: string;
+    sign: (msg: Buffer) => string;
+  } {
+    const { publicKey, privateKey } = generateKeyPairSync("ed25519");
+    // Strip RFC 8410 SPKI prefix (12 bytes) to get raw 32-byte pubkey.
+    const spki = publicKey.export({ format: "der", type: "spki" });
+    const raw = spki.subarray(spki.length - 32);
+    return {
+      pubBase58: base58Encode(new Uint8Array(raw)),
+      sign: (msg) => cryptoSign(null, msg, privateKey).toString("base64"),
+    };
+  }
+
+  it("happy path: valid signature by subjectAgentCard issues credential", async () => {
+    const kp = makeKeypair();
+    const wl = new StaticSkillWhitelist({ [SKILL]: [kp.pubBase58] });
+    const { issuer, deps } = makeIssuer({
+      whitelist: wl,
+      signatureVerifier: ed25519SkillCertSignatureVerifier,
+    });
+    const nonce = "nonce-happy-1";
+    const sig = kp.sign(
+      skillCertSignaturePreimage({
+        skill: SKILL,
+        subjectAgentCard: kp.pubBase58,
+        issuanceNonce: nonce,
+      }),
+    );
+    const out = await issuer.issue({
+      skill: SKILL,
+      subjectAgentCard: kp.pubBase58,
+      agentCardSignature: sig,
+      issuanceNonce: nonce,
+    });
+    expect(out.idempotent).toBe(false);
+    expect(deps.chain.calls).toHaveLength(1);
+    expect(deps.chain.calls[0]?.subjectAgentCard).toBe(kp.pubBase58);
+  });
+
+  it("rejects 401 when subjectAgentCard != signer (front-run defence) BEFORE binding-store / whitelist / chain", async () => {
+    const victim = makeKeypair();
+    const attacker = makeKeypair();
+    // Victim is whitelisted for SKILL; attacker is not.
+    const wl = new StaticSkillWhitelist({
+      [SKILL]: [victim.pubBase58],
+    });
+    // Track that the binding-store, whitelist, and chain are NOT consulted.
+    const bindingStore: InMemorySkillBindingStore = Object.create(
+      InMemorySkillBindingStore.prototype,
+    );
+    let storeGetCalls = 0;
+    let storePutCalls = 0;
+    bindingStore.get = async () => {
+      storeGetCalls += 1;
+      return undefined;
+    };
+    bindingStore.put = async () => {
+      storePutCalls += 1;
+    };
+    let whitelistCalls = 0;
+    const wlSpy = {
+      isAllowed: (s: string, sub: string) => {
+        whitelistCalls += 1;
+        return wl.isAllowed(s, sub);
+      },
+    };
+    const chain = new FakeChain();
+    const { issuer } = makeIssuer({
+      whitelist: wlSpy as unknown as StaticSkillWhitelist,
+      store: bindingStore,
+      chain,
+      signatureVerifier: ed25519SkillCertSignatureVerifier,
+    });
+
+    // Attacker forges a request claiming the VICTIM's pubkey as subject
+    // but signs with the attacker's own (or some random) key. Since the
+    // signature does not validate against the victim's pubkey, the
+    // request must 401 before any side effect.
+    const nonce = "nonce-attack-1";
+    const attackerSig = attacker.sign(
+      skillCertSignaturePreimage({
+        skill: SKILL,
+        subjectAgentCard: victim.pubBase58,
+        issuanceNonce: nonce,
+      }),
+    );
+    await expect(
+      issuer.issue({
+        skill: SKILL,
+        subjectAgentCard: victim.pubBase58,
+        agentCardSignature: attackerSig,
+        issuanceNonce: nonce,
+      }),
+    ).rejects.toMatchObject({
+      code: "INVALID_AGENT_CARD_SIGNATURE",
+      status: 401,
+    });
+    expect(storeGetCalls).toBe(0);
+    expect(storePutCalls).toBe(0);
+    expect(whitelistCalls).toBe(0);
+    expect(chain.calls).toHaveLength(0);
+  });
+
+  it("rejects 401 if signature is over a different (skill) preimage", async () => {
+    const kp = makeKeypair();
+    const wl = new StaticSkillWhitelist({ [SKILL]: [kp.pubBase58] });
+    const { issuer, deps } = makeIssuer({
+      whitelist: wl,
+      signatureVerifier: ed25519SkillCertSignatureVerifier,
+    });
+    const nonce = "nonce-bad-skill";
+    // Sign over a different skill name — valid sig but bound to wrong skill.
+    const sig = kp.sign(
+      skillCertSignaturePreimage({
+        skill: "some-other-skill",
+        subjectAgentCard: kp.pubBase58,
+        issuanceNonce: nonce,
+      }),
+    );
+    await expect(
+      issuer.issue({
+        skill: SKILL,
+        subjectAgentCard: kp.pubBase58,
+        agentCardSignature: sig,
+        issuanceNonce: nonce,
+      }),
+    ).rejects.toMatchObject({
+      code: "INVALID_AGENT_CARD_SIGNATURE",
+      status: 401,
+    });
+    expect(deps.chain.calls).toHaveLength(0);
+  });
+
+  it("rejects empty agentCardSignature with 401", async () => {
+    const { issuer, deps } = makeIssuer();
+    await expect(
+      issuer.issue({
+        skill: SKILL,
+        subjectAgentCard: SUBJECT_A,
+        agentCardSignature: "",
+        issuanceNonce: "n",
+      }),
+    ).rejects.toMatchObject({
+      code: "INVALID_AGENT_CARD_SIGNATURE",
+      status: 401,
+    });
+    expect(deps.chain.calls).toHaveLength(0);
+  });
+
+  it("rejects empty issuanceNonce with 401", async () => {
+    const { issuer, deps } = makeIssuer();
+    await expect(
+      issuer.issue({
+        skill: SKILL,
+        subjectAgentCard: SUBJECT_A,
+        agentCardSignature: "AA",
+        issuanceNonce: "",
+      }),
+    ).rejects.toMatchObject({
+      code: "INVALID_AGENT_CARD_SIGNATURE",
+      status: 401,
+    });
+    expect(deps.chain.calls).toHaveLength(0);
   });
 });
 

--- a/tests/a2a/counterparty-verifier.test.ts
+++ b/tests/a2a/counterparty-verifier.test.ts
@@ -1,0 +1,236 @@
+/**
+ * Tests for FN-052: A2A Counterparty Verifier
+ *
+ * All tests use injected fetch + cache — no network calls.
+ */
+
+import { describe, test, expect, beforeEach } from "vitest";
+import * as ed from "@noble/ed25519";
+import { sha512 } from "@noble/hashes/sha512";
+import {
+  verifyCounterpartyAttestation,
+  type JwksCache,
+  type Jwks,
+} from "../../src/a2a/counterparty-verifier.js";
+
+// Set up sha512Sync for noble/ed25519 in test environment
+ed.etc.sha512Sync = (...m: Uint8Array[]) => sha512(ed.etc.concatBytes(...m));
+
+/* -------------------------------------------------------------------------- */
+/* Helpers                                                                     */
+/* -------------------------------------------------------------------------- */
+
+function base64urlEncode(bytes: Uint8Array): string {
+  const b64 = btoa(String.fromCharCode(...bytes));
+  return b64.replace(/\+/g, "-").replace(/\//g, "_").replace(/=/g, "");
+}
+
+function base64urlEncodeStr(str: string): string {
+  return base64urlEncode(new TextEncoder().encode(str));
+}
+
+async function makeJws(
+  privKey: Uint8Array,
+  kid: string,
+  payload: Record<string, unknown>,
+): Promise<string> {
+  const header = base64urlEncodeStr(JSON.stringify({ alg: "EdDSA", typ: "JWT", kid }));
+  const body = base64urlEncodeStr(JSON.stringify(payload));
+  const signingInput = new TextEncoder().encode(`${header}.${body}`);
+  const sig = await ed.signAsync(signingInput, privKey);
+  return `${header}.${body}.${base64urlEncode(sig)}`;
+}
+
+function makeJwks(pubKey: Uint8Array, kid: string): Jwks {
+  return {
+    keys: [{ kty: "OKP", crv: "Ed25519", kid, x: base64urlEncode(pubKey) }],
+  };
+}
+
+function makeFetch(jwks: Jwks, etag = "\"v1\""): typeof globalThis.fetch {
+  return async (input: RequestInfo | URL, init?: RequestInit) => {
+    const url = typeof input === "string" ? input : input.toString();
+    if (url.endsWith("/.well-known/jwks.json")) {
+      const ifNoneMatch = (init?.headers as Record<string, string> | undefined)?.["If-None-Match"];
+      if (ifNoneMatch === etag) {
+        return new Response(null, { status: 304, headers: { etag } });
+      }
+      return new Response(JSON.stringify(jwks), {
+        status: 200,
+        headers: { "content-type": "application/json", etag },
+      });
+    }
+    return new Response("not found", { status: 404 });
+  };
+}
+
+const PEER_ORIGIN = "https://peer.example.com";
+const MY_ORIGIN = "https://me.example.com";
+const JWKS_URL = `${PEER_ORIGIN}/.well-known/jwks.json`;
+const NOW_SEC = 1_700_000_000;
+const NOW_MS = NOW_SEC * 1000;
+
+function makeNow(): () => number {
+  return () => NOW_MS;
+}
+
+function basePayload(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    iss: PEER_ORIGIN,
+    aud: MY_ORIGIN,
+    iat: NOW_SEC - 10,
+    exp: NOW_SEC + 300,
+    model: "claude-opus-4",
+    model_version: "4.0",
+    sig_alg: "EdDSA",
+    jti: "test-nonce-1",
+    ...overrides,
+  };
+}
+
+/* -------------------------------------------------------------------------- */
+/* Tests                                                                       */
+/* -------------------------------------------------------------------------- */
+
+describe("verifyCounterpartyAttestation", () => {
+  let privKey: Uint8Array;
+  let pubKey: Uint8Array;
+  const KID = "key-1";
+
+  beforeEach(async () => {
+    privKey = new Uint8Array(32);
+    crypto.getRandomValues(privKey);
+    pubKey = await ed.getPublicKeyAsync(privKey);
+  });
+
+  test("happy path — returns ok:true with projected ModelAttestation", async () => {
+    const jwks = makeJwks(pubKey, KID);
+    const cache: JwksCache = new Map();
+    const jws = await makeJws(privKey, KID, basePayload());
+
+    const result = await verifyCounterpartyAttestation({
+      jws,
+      expectedAudience: MY_ORIGIN,
+      jwksUrl: JWKS_URL,
+      fetch: makeFetch(jwks),
+      cache,
+      now: makeNow(),
+    });
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) throw new Error("expected ok");
+
+    expect(result.attestation.iss).toBe(PEER_ORIGIN);
+    expect(result.attestation.aud).toBe(MY_ORIGIN);
+    expect(result.attestation.model).toBe("claude-opus-4");
+    expect(result.attestation.model_version).toBe("4.0");
+    expect(result.attestation.sig_alg).toBe("EdDSA");
+    expect(result.attestation.jti).toBe("test-nonce-1");
+    expect(result.attestation.exp).toBe(NOW_SEC + 300);
+  });
+
+  test("bad-aud rejection — aud does not match expectedAudience", async () => {
+    const jwks = makeJwks(pubKey, KID);
+    const cache: JwksCache = new Map();
+    const jws = await makeJws(privKey, KID, basePayload({ aud: "https://wrong.example.com" }));
+
+    const result = await verifyCounterpartyAttestation({
+      jws,
+      expectedAudience: MY_ORIGIN,
+      jwksUrl: JWKS_URL,
+      fetch: makeFetch(jwks),
+      cache,
+      now: makeNow(),
+    });
+
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error("expected error");
+    expect(result.error.code).toBe("bad-aud");
+    expect(result.error.message).toContain(MY_ORIGIN);
+  });
+
+  test("expired-jws rejection — exp is in the past", async () => {
+    const jwks = makeJwks(pubKey, KID);
+    const cache: JwksCache = new Map();
+    // exp is 60 seconds before NOW
+    const jws = await makeJws(privKey, KID, basePayload({ exp: NOW_SEC - 60 }));
+
+    const result = await verifyCounterpartyAttestation({
+      jws,
+      expectedAudience: MY_ORIGIN,
+      jwksUrl: JWKS_URL,
+      fetch: makeFetch(jwks),
+      cache,
+      now: makeNow(),
+    });
+
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error("expected error");
+    expect(result.error.code).toBe("expired");
+  });
+
+  test("cache hit (304 Not Modified) — JWKS served from cache", async () => {
+    const jwks = makeJwks(pubKey, KID);
+    const cache: JwksCache = new Map();
+    let fetchCallCount = 0;
+
+    const trackingFetch: typeof globalThis.fetch = async (input, init) => {
+      fetchCallCount++;
+      return makeFetch(jwks)(input, init);
+    };
+
+    const args = {
+      expectedAudience: MY_ORIGIN,
+      jwksUrl: JWKS_URL,
+      fetch: trackingFetch,
+      cache,
+      now: makeNow(),
+    };
+
+    // First call — populates cache with ETag
+    const jws1 = await makeJws(privKey, KID, basePayload({ jti: "nonce-1" }));
+    const r1 = await verifyCounterpartyAttestation({ ...args, jws: jws1 });
+    expect(r1.ok).toBe(true);
+    expect(fetchCallCount).toBe(1);
+
+    // Second call — should send If-None-Match and get 304
+    const jws2 = await makeJws(privKey, KID, basePayload({ jti: "nonce-2" }));
+    const r2 = await verifyCounterpartyAttestation({ ...args, jws: jws2 });
+    expect(r2.ok).toBe(true);
+    expect(fetchCallCount).toBe(2); // fetch was called but returned 304
+
+    // Verify cache has the entry (was served from cache after 304)
+    const cached = cache.get(JWKS_URL);
+    expect(cached).toBeDefined();
+    expect(cached?.jwks).toEqual(jwks);
+  });
+
+  test("tampered-signature rejection — signature bytes altered", async () => {
+    const jwks = makeJwks(pubKey, KID);
+    const cache: JwksCache = new Map();
+    const jws = await makeJws(privKey, KID, basePayload());
+
+    // Tamper: flip a bit in the signature (last segment)
+    const parts = jws.split(".");
+    const sigBytes = Uint8Array.from(atob(
+      (parts[2] ?? "").replace(/-/g, "+").replace(/_/g, "/")
+    ), c => c.charCodeAt(0));
+    sigBytes[0] ^= 0xff; // flip first byte
+    const tamperedSig = btoa(String.fromCharCode(...sigBytes))
+      .replace(/\+/g, "-").replace(/\//g, "_").replace(/=/g, "");
+    const tamperedJws = `${parts[0]}.${parts[1]}.${tamperedSig}`;
+
+    const result = await verifyCounterpartyAttestation({
+      jws: tamperedJws,
+      expectedAudience: MY_ORIGIN,
+      jwksUrl: JWKS_URL,
+      fetch: makeFetch(jwks),
+      cache,
+      now: makeNow(),
+    });
+
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error("expected error");
+    expect(result.error.code).toBe("tampered-signature");
+  });
+});

--- a/tests/bank/accounts.test.ts
+++ b/tests/bank/accounts.test.ts
@@ -194,6 +194,7 @@ describe("bank account lifecycle (E11)", () => {
 
     const result = await executeWire(
       {
+        caller_pubkey: HOLDER_PUBKEY,
         holder: HOLDER_PUBKEY,
         checking_account_pda: state.checkingPda!,
         amount: Number(WIRE_AMOUNT),
@@ -229,6 +230,7 @@ describe("bank account lifecycle (E11)", () => {
     await expect(
       executeWire(
         {
+          caller_pubkey: HOLDER_PUBKEY,
           holder: HOLDER_PUBKEY,
           checking_account_pda: state.checkingPda!,
           amount: overAmount,
@@ -257,6 +259,7 @@ describe("bank account lifecycle (E11)", () => {
 
     const result = await openSavings(
       {
+        caller_pubkey: HOLDER_PUBKEY,
         subject: HOLDER_PUBKEY,
         linked_checking_account_pda: state.checkingPda!,
         bank_issuer: BANK_ISSUER_PUBKEY,
@@ -283,6 +286,7 @@ describe("bank account lifecycle (E11)", () => {
     await expect(
       openSavings(
         {
+          caller_pubkey: HOLDER_PUBKEY,
           subject: HOLDER_PUBKEY,
           linked_checking_account_pda: state.checkingPda!,
           bank_issuer: BANK_ISSUER_PUBKEY,

--- a/tests/bank/accounts.test.ts
+++ b/tests/bank/accounts.test.ts
@@ -109,10 +109,13 @@ describe("bank account lifecycle (E11)", () => {
 
     const result = await openChecking(
       {
-        subject: HOLDER_PUBKEY,
-        bank_issuer: BANK_ISSUER_PUBKEY,
-        opened_slot: 1000,
-        opening_deposit_atomic: 0,
+        callerPubkey: HOLDER_PUBKEY,
+        body: {
+          subject: HOLDER_PUBKEY,
+          bank_issuer: BANK_ISSUER_PUBKEY,
+          opened_slot: 1000,
+          opening_deposit_atomic: 0,
+        },
       },
       makeOpenCheckingDeps(state, holderCredentialSchemas),
     );

--- a/tests/beckn-413-nack.test.ts
+++ b/tests/beckn-413-nack.test.ts
@@ -1,0 +1,92 @@
+/**
+ * SB-16 conformance — 413 PayloadTooLarge response shape
+ *
+ * Closes FN-092 (eto-mcp FN-093 follow-up): the Beckn bridge must return
+ * a Beckn NACK envelope when a request body exceeds the 1 MiB body-parser
+ * limit, not Express's default HTML/JSON error.
+ */
+import { describe, it, expect, afterEach } from "vitest";
+import http from "http";
+import { createBecknApp } from "../src/gateway/beckn.js";
+
+let activeServer: http.Server | undefined;
+
+afterEach(async () => {
+  if (activeServer) {
+    await new Promise<void>((resolve) => activeServer!.close(() => resolve()));
+    activeServer = undefined;
+  }
+});
+
+function startServer(): Promise<http.Server> {
+  const app = createBecknApp();
+  return new Promise((resolve) => {
+    const server = http.createServer(app);
+    server.listen(0, "127.0.0.1", () => resolve(server));
+  });
+}
+
+function rawPost(
+  server: http.Server,
+  path: string,
+  bodyBytes: Buffer,
+): Promise<{ status: number; body: unknown }> {
+  return new Promise((resolve, reject) => {
+    const addr = server.address() as { port: number };
+    const req = http.request(
+      {
+        hostname: "127.0.0.1",
+        port: addr.port,
+        path,
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          "Content-Length": bodyBytes.length,
+        },
+      },
+      (res) => {
+        const chunks: Buffer[] = [];
+        res.on("data", (c) => chunks.push(c));
+        res.on("end", () => {
+          const text = Buffer.concat(chunks).toString("utf8");
+          let parsed: unknown = text;
+          try {
+            parsed = JSON.parse(text);
+          } catch {
+            // body may be empty or non-json on raw express errors
+          }
+          resolve({ status: res.statusCode ?? 0, body: parsed });
+        });
+      },
+    );
+    req.on("error", reject);
+    req.write(bodyBytes);
+    req.end();
+  });
+}
+
+describe("SB-16 — 413 PayloadTooLargeError returns Beckn NACK shape (FN-092)", () => {
+  it("rejects a >1 MiB JSON body with 413 + NACK envelope", async () => {
+    activeServer = await startServer();
+    // 1 MiB + a kilobyte buffer is more than enough to trip express body-parser's
+    // `limit: "1mb"`. We construct a syntactically-valid JSON object that is
+    // larger than the threshold so the parser fails on size, not parse.
+    const padding = "x".repeat(1024 * 1024 + 1024);
+    const bodyBytes = Buffer.from(JSON.stringify({ payload: padding }));
+    const { status, body } = await rawPost(activeServer, "/search", bodyBytes);
+    expect(status).toBe(413);
+    expect(body).toMatchObject({
+      message: { ack: { status: "NACK" } },
+      error: { code: "PAYLOAD_TOO_LARGE" },
+    });
+    expect((body as { error: { message: string } }).error.message).toContain("1 MiB");
+  });
+
+  it("does not affect normal-sized requests (regression check)", async () => {
+    activeServer = await startServer();
+    const small = Buffer.from(JSON.stringify({ context: {} }));
+    const { status } = await rawPost(activeServer, "/search", small);
+    // Should be 400 (invalid envelope) — NOT 413, NOT a 5xx, NOT swallowed.
+    expect(status).toBe(400);
+  });
+});

--- a/tests/gateway/ssrf-dns-rebinding.test.ts
+++ b/tests/gateway/ssrf-dns-rebinding.test.ts
@@ -1,0 +1,67 @@
+/**
+ * FN-079 — DNS-rebinding SSRF guard tests.
+ *
+ * Verifies that `isPrivateOrLoopbackHostResolved` resolves the hostname
+ * before the private-IP check, closing the bypass where a public-looking
+ * domain resolves to 127.0.0.1 / 10.x / etc at request time.
+ */
+import { describe, it, expect } from "vitest";
+import {
+  isPrivateOrLoopbackHost,
+  isPrivateOrLoopbackHostResolved,
+  type DnsLookupFn,
+} from "../../src/gateway/outbound-bpp.js";
+
+function fakeLookup(map: Record<string, { address: string; family: 4 | 6 }>): DnsLookupFn {
+  return async (h) => {
+    const r = map[h];
+    if (!r) throw new Error(`no fixture for ${h}`);
+    return r;
+  };
+}
+
+describe("FN-079 — DNS-resolving SSRF guard", () => {
+  it("rejects literal private IPv4 (sync path still works)", () => {
+    expect(isPrivateOrLoopbackHost("127.0.0.1")).toBe(true);
+    expect(isPrivateOrLoopbackHost("10.0.0.5")).toBe(true);
+    expect(isPrivateOrLoopbackHost("192.168.1.1")).toBe(true);
+    expect(isPrivateOrLoopbackHost("169.254.1.1")).toBe(true);
+  });
+
+  it("rejects localhost / .local (sync path)", () => {
+    expect(isPrivateOrLoopbackHost("localhost")).toBe(true);
+    expect(isPrivateOrLoopbackHost("printer.local")).toBe(true);
+  });
+
+  it("allows public IP literal (sync allows, async confirms)", async () => {
+    expect(isPrivateOrLoopbackHost("8.8.8.8")).toBe(false);
+    const ok = await isPrivateOrLoopbackHostResolved("8.8.8.8", fakeLookup({}));
+    expect(ok).toBe(false);
+  });
+
+  it("DNS rebinding: public-looking domain resolving to 127.0.0.1 is rejected", async () => {
+    const lookup = fakeLookup({ "attacker.example.com": { address: "127.0.0.1", family: 4 } });
+    const blocked = await isPrivateOrLoopbackHostResolved("attacker.example.com", lookup);
+    expect(blocked).toBe(true);
+  });
+
+  it("DNS rebinding: domain resolving to 10.x is rejected", async () => {
+    const lookup = fakeLookup({ "tricky.example.com": { address: "10.5.5.5", family: 4 } });
+    expect(await isPrivateOrLoopbackHostResolved("tricky.example.com", lookup)).toBe(true);
+  });
+
+  it("DNS rebinding: domain resolving to ::1 is rejected", async () => {
+    const lookup = fakeLookup({ "v6.example.com": { address: "::1", family: 6 } });
+    expect(await isPrivateOrLoopbackHostResolved("v6.example.com", lookup)).toBe(true);
+  });
+
+  it("public domain resolving to 8.8.8.8 is allowed", async () => {
+    const lookup = fakeLookup({ "google-public-dns.example.com": { address: "8.8.8.8", family: 4 } });
+    expect(await isPrivateOrLoopbackHostResolved("google-public-dns.example.com", lookup)).toBe(false);
+  });
+
+  it("fail-closed: unresolvable hostname is treated as private", async () => {
+    const lookup: DnsLookupFn = async () => { throw new Error("ENOTFOUND"); };
+    expect(await isPrivateOrLoopbackHostResolved("nonexistent.invalid", lookup)).toBe(true);
+  });
+});

--- a/tests/indexer/audit-trail-signed.test.ts
+++ b/tests/indexer/audit-trail-signed.test.ts
@@ -1,0 +1,102 @@
+// FN-084 — AuditTrailIndexer + VcSigner integration tests.
+
+import { describe, expect, it } from "vitest";
+
+import {
+  AUDIT_TRAIL_ISSUER_DID,
+  AuditTrailIndexer,
+  InMemoryKytEventSource,
+  type Ed25519Signature2020Proof,
+  type KytTraceEvent,
+  type VcSigner,
+} from "../../src/services/indexer/index.js";
+
+const AUTHORITY = "5".repeat(44);
+const COUNTERPARTY = "6".repeat(44);
+
+function fixture(): KytTraceEvent[] {
+  return [
+    {
+      stage: "init",
+      tx_signature: ("Sig1" + "1".repeat(44)).slice(0, 44),
+      slot: 1000,
+      timestamp: 1_700_000_000,
+      parties: [
+        { party: "bap", authority: AUTHORITY, cred_pointers: ["a".repeat(64)] },
+        { party: "bpp", authority: COUNTERPARTY, cred_pointers: ["b".repeat(64)] },
+      ],
+    },
+  ];
+}
+
+const FIXED_CLOCK = () => new Date("2026-01-01T00:00:00.000Z");
+
+class FakeSigner implements VcSigner {
+  public lastInput: Record<string, unknown> | undefined;
+  public callCount = 0;
+  public constructor(public readonly issuerDid: string) {}
+  public async sign(
+    vcWithoutProof: Record<string, unknown>,
+  ): Promise<Ed25519Signature2020Proof> {
+    // Snapshot via structured clone so subsequent caller mutations
+    // (e.g. attaching the returned proof to the same object) do not
+    // pollute the captured input.
+    this.lastInput = structuredClone(vcWithoutProof);
+    this.callCount += 1;
+    return {
+      type: "Ed25519Signature2020",
+      created: "2026-01-01T00:00:00.000Z",
+      verificationMethod: `${this.issuerDid}#key-1`,
+      proofPurpose: "assertionMethod",
+      proofValue: "FAKE_PROOF_VALUE_BASE64URL",
+    };
+  }
+}
+
+describe("AuditTrailIndexer + VcSigner (FN-084)", () => {
+  it("default (NoOp) emits no proof key and keeps the v0 issuer DID", async () => {
+    const indexer = new AuditTrailIndexer({
+      source: new InMemoryKytEventSource({ traces: fixture() }),
+      clock: FIXED_CLOCK,
+    });
+    const feed = await indexer.buildAuditFeed(AUTHORITY);
+    expect("proof" in feed).toBe(false);
+    expect(feed.issuer).toBe(AUDIT_TRAIL_ISSUER_DID);
+  });
+
+  it("attaches the proof block when a signer is injected and overrides issuer", async () => {
+    const fakeDid = "did:eto:test:audit-signer";
+    const signer = new FakeSigner(fakeDid);
+    const indexer = new AuditTrailIndexer({
+      source: new InMemoryKytEventSource({ traces: fixture() }),
+      clock: FIXED_CLOCK,
+      signer,
+    });
+    const feed = await indexer.buildAuditFeed(AUTHORITY);
+
+    expect(feed.issuer).toBe(fakeDid);
+    expect(feed.proof).toEqual({
+      type: "Ed25519Signature2020",
+      created: "2026-01-01T00:00:00.000Z",
+      verificationMethod: `${fakeDid}#key-1`,
+      proofPurpose: "assertionMethod",
+      proofValue: "FAKE_PROOF_VALUE_BASE64URL",
+    });
+    // Proof block MUST NOT be in the input passed to sign() (spec §11.4).
+    expect(signer.lastInput).toBeDefined();
+    expect("proof" in (signer.lastInput as object)).toBe(false);
+  });
+
+  it("is deterministic across two builds with identical inputs and a fixed clock", async () => {
+    const signer = new FakeSigner("did:eto:test:audit-signer");
+    const make = () =>
+      new AuditTrailIndexer({
+        source: new InMemoryKytEventSource({ traces: fixture() }),
+        clock: FIXED_CLOCK,
+        signer,
+      });
+    const a = await make().buildAuditFeed(AUTHORITY);
+    const b = await make().buildAuditFeed(AUTHORITY);
+    expect(JSON.stringify(a)).toBe(JSON.stringify(b));
+  });
+});

--- a/tests/indexer/env-factory.test.ts
+++ b/tests/indexer/env-factory.test.ts
@@ -1,0 +1,31 @@
+// Unit tests for createKytEventSourceFromEnv (FN-083).
+// These tests do NOT require a running Postgres instance.
+
+import { describe, it, expect } from "vitest";
+import {
+  createKytEventSourceFromEnv,
+  PostgresKytEventSource,
+} from "../../src/services/indexer/postgres-event-source.js";
+import { InMemoryKytEventSource } from "../../src/services/indexer/audit-trail.js";
+
+describe("createKytEventSourceFromEnv", () => {
+  it("returns InMemoryKytEventSource when env is empty object", () => {
+    const src = createKytEventSourceFromEnv({});
+    expect(src).toBeInstanceOf(InMemoryKytEventSource);
+  });
+
+  it("returns InMemoryKytEventSource when AUDIT_DB_URL is empty string", () => {
+    const src = createKytEventSourceFromEnv({ AUDIT_DB_URL: "" });
+    expect(src).toBeInstanceOf(InMemoryKytEventSource);
+  });
+
+  it("returns PostgresKytEventSource when AUDIT_DB_URL is set (no actual connection)", () => {
+    const src = createKytEventSourceFromEnv({
+      AUDIT_DB_URL: "postgres://localhost/x",
+    });
+    expect(src).toBeInstanceOf(PostgresKytEventSource);
+    // Do NOT connect — only assert instanceof. Release the owned pool
+    // without actually connecting to avoid leaving dangling handles.
+    void (src as PostgresKytEventSource).close();
+  });
+});

--- a/tests/indexer/postgres-event-source.test.ts
+++ b/tests/indexer/postgres-event-source.test.ts
@@ -1,0 +1,266 @@
+// Integration tests for PostgresKytEventSource (FN-083).
+//
+// These tests require a real Postgres database.  They are gated behind the
+// TEST_PG_URL environment variable and silently skipped when it is not set,
+// so CI never fails due to a missing database.
+//
+// To run locally:
+//   TEST_PG_URL=postgres://user:pass@localhost/dbname npx vitest run tests/indexer/postgres-event-source.test.ts
+
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { Pool } from "pg";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+import { AuditTrailIndexerError } from "../../src/services/indexer/audit-trail.js";
+import { PostgresKytEventSource } from "../../src/services/indexer/postgres-event-source.js";
+import type {
+  KytTraceEvent,
+  RevocationRootUpdatedEvent,
+} from "../../src/services/indexer/audit-trail.types.js";
+
+// ---------------------------------------------------------------------------
+// Base58-safe fixture strings
+// Base58 alphabet: 123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz
+// Excluded chars:  0 (digit zero), O (capital oh), I (capital I), l (lowercase L)
+// ---------------------------------------------------------------------------
+
+/** Pad a distinctive prefix to a valid base58 string of length 88. */
+function b58pad(prefix: string): string {
+  const safe = prefix.replace(/[0OIl]/g, "A");
+  return safe.padEnd(88, "A").slice(0, 88);
+}
+
+// Distinct authorities — all base58-safe (no 0, O, I, l).
+const AUTH_A = "AuthAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA";
+const AUTH_B = "AuthBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB";
+const AUTH_C = "AuthCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC";
+const AUTH_WIN = "WndAuthorityAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA";
+const AUTH_WIN_BPP = "WndBppAuthorityAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA";
+const AUTH_DUP_BAP = "DupBapAuthorityAAAAAAAAAAAAAAAAAAAAAAAAAAAAA";
+const AUTH_DUP_BPP = "DupBppAuthorityAAAAAAAAAAAAAAAAAAAAAAAAAAAAA";
+const AUTH_BAD_BAP = "BadBapAuthorityAAAAAAAAAAAAAAAAAAAAAAAAAAAAA";
+const AUTH_BAD_BPP = "BadBppAuthorityAAAAAAAAAAAAAAAAAAAAAAAAAAAAA";
+const ORACLE_A = "RevAuthorityAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA";
+
+// Distinct tx_signatures for each test (must be valid base58).
+const SIG_T1 = b58pad("RoundTripSigAAA1");   // test 1, trace 1
+const SIG_T2 = b58pad("RoundTripSigAAA2");   // test 1, trace 2
+const SIG_T3 = b58pad("RoundTripSigAAA3");   // test 1, trace 3
+const SIG_DUP = b58pad("DuplicateSigAAAA");  // test 2 (idempotency)
+const SIG_W1 = b58pad("WinSigSSSSSSlAA1");  // test 3 slot 10 — no invalid chars
+const SIG_W2 = b58pad("WinSigSSSSSSlAA2");  // test 3 slot 20
+const SIG_W3 = b58pad("WinSigSSSSSSlAA3");  // test 3 slot 30
+const SIG_W4 = b58pad("WinSigSSSSSSlAA4");  // test 3 slot 40
+const SIG_W5 = b58pad("WinSigSSSSSSlAA5");  // test 3 slot 50
+const SIG_BAD = b58pad("BadCredsTestAAA1"); // test 5 (validation)
+
+// ---------------------------------------------------------------------------
+// Helpers — fixture factories
+// ---------------------------------------------------------------------------
+
+function makeTrace(
+  tx_signature: string,
+  slot: number,
+  bapAuthority: string,
+  bppAuthority: string,
+  stage: KytTraceEvent["stage"] = "init",
+  timestamp = 1700000000,
+): KytTraceEvent {
+  return {
+    stage,
+    tx_signature,
+    slot,
+    timestamp,
+    parties: [
+      { party: "bap", authority: bapAuthority, cred_pointers: [] },
+      { party: "bpp", authority: bppAuthority, cred_pointers: [] },
+    ],
+  };
+}
+
+function makeRevocation(overrides: Partial<RevocationRootUpdatedEvent>): RevocationRootUpdatedEvent {
+  return {
+    oracle: ORACLE_A,
+    network: "testnet",
+    root: "a".repeat(64),
+    leaves: 10,
+    slot: 200,
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Suite — gated on TEST_PG_URL
+// ---------------------------------------------------------------------------
+
+const PG_URL = process.env["TEST_PG_URL"];
+
+describe.skipIf(!PG_URL)("PostgresKytEventSource integration", () => {
+  let pool: Pool;
+  let source: PostgresKytEventSource;
+
+  const MIGRATION_PATH = path.resolve(
+    __dirname,
+    "../../scripts/migrations/001_kyt_events.sql",
+  );
+
+  beforeAll(async () => {
+    pool = new Pool({ connectionString: PG_URL! });
+    source = new PostgresKytEventSource({ pool });
+
+    // Apply migration (idempotent) then truncate for a clean slate.
+    const migrationSql = fs.readFileSync(MIGRATION_PATH, "utf8");
+    await pool.query(migrationSql);
+    await pool.query("TRUNCATE kyt_events, revocation_events");
+  });
+
+  afterAll(async () => {
+    try {
+      await pool.query("DROP TABLE IF EXISTS kyt_events");
+      await pool.query("DROP TABLE IF EXISTS revocation_events");
+    } finally {
+      await pool.end();
+    }
+  });
+
+  // -------------------------------------------------------------------------
+  // 1. Round-trip: ingest 3 traces, query by authority
+  // -------------------------------------------------------------------------
+  it("round-trip: ingest 3 traces and retrieve by authority", async () => {
+    await pool.query("TRUNCATE kyt_events, revocation_events");
+
+    // t1 and t2 involve AUTH_A; t3 does not.
+    const t1 = makeTrace(SIG_T1, 10, AUTH_A, AUTH_B);
+    const t2 = makeTrace(SIG_T2, 20, AUTH_A, AUTH_C);
+    const t3 = makeTrace(SIG_T3, 30, AUTH_B, AUTH_C);
+
+    await source.ingestTrace(t1);
+    await source.ingestTrace(t2);
+    await source.ingestTrace(t3);
+
+    const results: KytTraceEvent[] = [];
+    for await (const ev of source.tracesForAuthority(AUTH_A)) {
+      results.push(ev);
+    }
+
+    expect(results).toHaveLength(2);
+    expect(results[0]!.tx_signature).toBe(SIG_T1);
+    expect(results[1]!.tx_signature).toBe(SIG_T2);
+    // Ascending slot order
+    expect(results[0]!.slot).toBeLessThan(results[1]!.slot);
+  });
+
+  // -------------------------------------------------------------------------
+  // 2. Idempotency: duplicate ingest returns inserted: false
+  // -------------------------------------------------------------------------
+  it("idempotency: duplicate trace ingest returns { inserted: false }", async () => {
+    await pool.query("TRUNCATE kyt_events, revocation_events");
+
+    const t = makeTrace(SIG_DUP, 50, AUTH_DUP_BAP, AUTH_DUP_BPP);
+
+    const first = await source.ingestTrace(t);
+    const second = await source.ingestTrace(t);
+
+    expect(first.inserted).toBe(true);
+    expect(second.inserted).toBe(false);
+
+    const { rows } = await pool.query<{ count: string }>(
+      "SELECT COUNT(*) AS count FROM kyt_events WHERE tx_signature = $1",
+      [SIG_DUP],
+    );
+    expect(Number(rows[0]!.count)).toBe(1);
+  });
+
+  // -------------------------------------------------------------------------
+  // 3. Slot-window filtering: sinceSlot inclusive, untilSlot exclusive
+  // -------------------------------------------------------------------------
+  it("slot-window: sinceSlot=20 untilSlot=40 yields exactly slots 20 and 30", async () => {
+    await pool.query("TRUNCATE kyt_events, revocation_events");
+
+    const traces = [
+      makeTrace(SIG_W1, 10, AUTH_WIN, AUTH_WIN_BPP),
+      makeTrace(SIG_W2, 20, AUTH_WIN, AUTH_WIN_BPP),
+      makeTrace(SIG_W3, 30, AUTH_WIN, AUTH_WIN_BPP),
+      makeTrace(SIG_W4, 40, AUTH_WIN, AUTH_WIN_BPP),
+      makeTrace(SIG_W5, 50, AUTH_WIN, AUTH_WIN_BPP),
+    ];
+    for (const t of traces) {
+      await source.ingestTrace(t);
+    }
+
+    const results: KytTraceEvent[] = [];
+    for await (const ev of source.tracesForAuthority(AUTH_WIN, {
+      sinceSlot: 20,
+      untilSlot: 40,
+    })) {
+      results.push(ev);
+    }
+
+    // sinceSlot=20 inclusive, untilSlot=40 exclusive → slots 20 and 30 only
+    expect(results).toHaveLength(2);
+    expect(results[0]!.slot).toBe(20);
+    expect(results[1]!.slot).toBe(30);
+  });
+
+  // -------------------------------------------------------------------------
+  // 4. Revocation round-trip + idempotency
+  // -------------------------------------------------------------------------
+  it("revocation: round-trip and idempotency on (oracle, root, slot)", async () => {
+    await pool.query("TRUNCATE kyt_events, revocation_events");
+
+    const rev = makeRevocation({
+      oracle: ORACLE_A,
+      root: "b".repeat(64),
+      slot: 500,
+    });
+
+    const first = await source.ingestRevocation(rev);
+    const second = await source.ingestRevocation(rev);
+
+    expect(first.inserted).toBe(true);
+    expect(second.inserted).toBe(false);
+
+    const results: RevocationRootUpdatedEvent[] = [];
+    for await (const ev of source.revocationsForCredentialIssuers([ORACLE_A])) {
+      results.push(ev);
+    }
+
+    expect(results).toHaveLength(1);
+    expect(results[0]!.oracle).toBe(ORACLE_A);
+    expect(results[0]!.root).toBe("b".repeat(64));
+    expect(results[0]!.slot).toBe(500);
+  });
+
+  // -------------------------------------------------------------------------
+  // 5. Validation: ingestTrace rejects invalid cred_pointer (uppercase hex)
+  // -------------------------------------------------------------------------
+  it("validation: ingestTrace with uppercase cred_pointer throws INVALID_KYT_EVENT", async () => {
+    // Build an otherwise-valid trace but with an uppercase (invalid) cred_pointer.
+    // credPointerHex validator: /^[0-9a-f]{64}$/ — uppercase A..F fails.
+    const invalid: KytTraceEvent = {
+      stage: "init",
+      tx_signature: SIG_BAD,
+      slot: 999,
+      timestamp: 1700000001,
+      parties: [
+        {
+          party: "bap",
+          authority: AUTH_BAD_BAP,
+          // Uppercase hex — must be rejected by credPointerHex validator.
+          cred_pointers: ["A".repeat(64) as string],
+        },
+        {
+          party: "bpp",
+          authority: AUTH_BAD_BPP,
+          cred_pointers: [],
+        },
+      ],
+    };
+
+    await expect(source.ingestTrace(invalid)).rejects.toSatisfy(
+      (err: unknown) =>
+        err instanceof AuditTrailIndexerError && err.code === "INVALID_KYT_EVENT",
+    );
+  });
+});

--- a/tests/indexer/travel-rule-signed.test.ts
+++ b/tests/indexer/travel-rule-signed.test.ts
@@ -1,0 +1,114 @@
+// FN-084 — TravelRuleReportGenerator + VcSigner integration tests.
+
+import { describe, expect, it } from "vitest";
+
+import {
+  AuditTrailIndexer,
+  InMemoryAmountResolver,
+  InMemoryKytEventSource,
+  InMemoryPartyDirectory,
+  TRAVEL_RULE_ISSUER_DID,
+  TravelRuleReportGenerator,
+  type Ed25519Signature2020Proof,
+  type Ivms101Party,
+  type KytTraceEvent,
+  type VcSigner,
+} from "../../src/services/indexer/index.js";
+
+const BAP = "5".repeat(44);
+const BPP = "6".repeat(44);
+const TX = ("CrossJur" + "1".repeat(44)).slice(0, 44);
+
+const partyBap: Ivms101Party = {
+  authority: BAP,
+  accountNumber: "ACC-BAP-0001",
+  name: { kind: "natural", primary: "Alice" },
+  jurisdiction: "US",
+};
+const partyBpp: Ivms101Party = {
+  authority: BPP,
+  accountNumber: "ACC-BPP-0001",
+  name: { kind: "legal", name: "Acme Bank GmbH" },
+  jurisdiction: "DE",
+};
+
+function fixture(): KytTraceEvent[] {
+  return [
+    {
+      stage: "confirm",
+      tx_signature: TX,
+      slot: 2_000,
+      timestamp: 1_700_000_000,
+      parties: [
+        { party: "bap", authority: BAP, cred_pointers: ["a".repeat(64)] },
+        { party: "bpp", authority: BPP, cred_pointers: ["b".repeat(64)] },
+      ],
+    },
+  ];
+}
+
+const FIXED_CLOCK = () => new Date("2026-01-01T00:00:00.000Z");
+
+class FakeSigner implements VcSigner {
+  public lastInput: Record<string, unknown> | undefined;
+  public callCount = 0;
+  public constructor(public readonly issuerDid: string) {}
+  public async sign(
+    vcWithoutProof: Record<string, unknown>,
+  ): Promise<Ed25519Signature2020Proof> {
+    this.lastInput = vcWithoutProof;
+    this.callCount += 1;
+    return {
+      type: "Ed25519Signature2020",
+      created: "2026-01-01T00:00:00.000Z",
+      verificationMethod: `${this.issuerDid}#key-1`,
+      proofPurpose: "assertionMethod",
+      proofValue: "TR_FAKE_PROOF_BASE64URL",
+    };
+  }
+}
+
+function buildGenerator(signer?: VcSigner) {
+  const indexer = new AuditTrailIndexer({
+    source: new InMemoryKytEventSource({ traces: fixture() }),
+    clock: FIXED_CLOCK,
+  });
+  return new TravelRuleReportGenerator({
+    source: indexer,
+    partyDirectory: new InMemoryPartyDirectory({ [BAP]: partyBap, [BPP]: partyBpp }),
+    amountResolver: new InMemoryAmountResolver({
+      [TX]: { amountUsd: 12_500.5, currency: "USD" },
+    }),
+    clock: FIXED_CLOCK,
+    ...(signer ? { signer } : {}),
+  });
+}
+
+describe("TravelRuleReportGenerator + VcSigner (FN-084)", () => {
+  it("default (NoOp) emits no proof key and keeps the v0 issuer DID", async () => {
+    const gen = buildGenerator();
+    const report = await gen.buildReport(BAP);
+    expect("proof" in report).toBe(false);
+    expect(report.issuer).toBe(TRAVEL_RULE_ISSUER_DID);
+  });
+
+  it("attaches the proof block when a signer is injected and overrides issuer", async () => {
+    const fakeDid = "did:eto:test:travel-rule-signer";
+    const signer = new FakeSigner(fakeDid);
+    const gen = buildGenerator(signer);
+    const report = await gen.buildReport(BAP);
+
+    expect(report.issuer).toBe(fakeDid);
+    expect(report.proof).toEqual({
+      type: "Ed25519Signature2020",
+      created: "2026-01-01T00:00:00.000Z",
+      verificationMethod: `${fakeDid}#key-1`,
+      proofPurpose: "assertionMethod",
+      proofValue: "TR_FAKE_PROOF_BASE64URL",
+    });
+    // Proof block MUST NOT be in the input passed to sign() (spec §11.4).
+    expect(signer.lastInput).toBeDefined();
+    expect("proof" in (signer.lastInput as object)).toBe(false);
+    expect(signer.callCount).toBe(1);
+  });
+});

--- a/tests/indexer/vc-signer.test.ts
+++ b/tests/indexer/vc-signer.test.ts
@@ -1,0 +1,243 @@
+// FN-084: unit tests for src/services/indexer/vc-signer.ts.
+
+import { mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+
+import {
+  Ed25519VcSigner,
+  NoOpVcSigner,
+  base64UrlEncode,
+  canonicalizeJcs,
+  createVcSignerFromEnv,
+} from "../../src/services/indexer/vc-signer.js";
+
+const FIXED_CLOCK = () => new Date("2026-01-01T00:00:00.000Z");
+const ZERO_SEED = new Uint8Array(32);
+const TEST_DID = "did:eto:test:signer";
+
+// Precomputed (see PROMPT.md Step 5): signature over
+// sha256(JCS({a:[1,2,3],hello:"world",n:42})) using all-zero seed.
+const EXPECTED_PROOF_VALUE =
+  "WWfyFEoKJzVAovZ4nQhNehe3I_FM4lQ3n7FUEvqw9LxO-IA1RTilC00D1GYvxOedJJmhv79Nn8NhmZhWQXN_Bg";
+const EXPECTED_PROOF_VALUE_WITH_PROOF_KEY =
+  "MkG33UbQWV2Hw0-F0SvGoTMpqblihxInyK734EdByPg36LWNiAUWvNi_lr4O3ZmR3SjDyYlpSdCY3zzFIrXQAA";
+
+describe("canonicalizeJcs", () => {
+  it("sorts object keys lexicographically", () => {
+    expect(canonicalizeJcs({ b: 1, a: 2 })).toBe('{"a":2,"b":1}');
+  });
+
+  it("recursively sorts nested object keys", () => {
+    expect(canonicalizeJcs({ z: { b: 1, a: 2 }, a: 1 })).toBe(
+      '{"a":1,"z":{"a":2,"b":1}}',
+    );
+  });
+
+  it("preserves array order", () => {
+    expect(canonicalizeJcs([3, 1, 2])).toBe("[3,1,2]");
+  });
+
+  it("drops undefined values from objects", () => {
+    expect(canonicalizeJcs({ a: 1, b: undefined, c: 3 })).toBe(
+      '{"a":1,"c":3}',
+    );
+  });
+
+  it("rejects undefined inside an array", () => {
+    expect(() => canonicalizeJcs([1, undefined, 3])).toThrow(TypeError);
+  });
+
+  it("throws on NaN / Infinity", () => {
+    expect(() => canonicalizeJcs(Number.NaN)).toThrow(TypeError);
+    expect(() => canonicalizeJcs(Number.POSITIVE_INFINITY)).toThrow(TypeError);
+    expect(() => canonicalizeJcs(Number.NEGATIVE_INFINITY)).toThrow(TypeError);
+  });
+
+  it("rejects BigInt, Date, function, symbol", () => {
+    expect(() => canonicalizeJcs(1n)).toThrow(TypeError);
+    expect(() => canonicalizeJcs(new Date())).toThrow(TypeError);
+    expect(() => canonicalizeJcs(() => 0)).toThrow(TypeError);
+    expect(() => canonicalizeJcs(Symbol("x"))).toThrow(TypeError);
+  });
+
+  it("escapes string contents like JSON.stringify", () => {
+    expect(canonicalizeJcs('a"b\\c')).toBe('"a\\"b\\\\c"');
+    expect(canonicalizeJcs("héllo")).toBe('"héllo"');
+  });
+
+  it("renders booleans and null", () => {
+    expect(canonicalizeJcs(true)).toBe("true");
+    expect(canonicalizeJcs(false)).toBe("false");
+    expect(canonicalizeJcs(null)).toBe("null");
+  });
+});
+
+describe("base64UrlEncode", () => {
+  it("emits padding-free base64url", () => {
+    expect(base64UrlEncode(new Uint8Array([0xff, 0xee, 0xdd]))).toBe("/+7d".replace(/\+/g, "-").replace(/\//g, "_"));
+    // No `+`, `/`, or `=`.
+    const out = base64UrlEncode(new Uint8Array([1, 2, 3, 4, 5]));
+    expect(out).not.toMatch(/[+/=]/u);
+  });
+});
+
+describe("NoOpVcSigner", () => {
+  it("returns a proof block with empty proofValue and configured DID", async () => {
+    const signer = new NoOpVcSigner(TEST_DID, FIXED_CLOCK);
+    const proof = await signer.sign({ any: "thing" });
+    expect(proof).toEqual({
+      type: "Ed25519Signature2020",
+      created: "2026-01-01T00:00:00.000Z",
+      verificationMethod: `${TEST_DID}#key-1`,
+      proofPurpose: "assertionMethod",
+      proofValue: "",
+    });
+  });
+
+  it("defaults to the unsigned-indexer DID", () => {
+    const signer = new NoOpVcSigner();
+    expect(signer.issuerDid).toBe("did:eto:indexer:unsigned:v0");
+  });
+});
+
+describe("Ed25519VcSigner", () => {
+  it("produces a deterministic proof for a fixed seed/input/clock", async () => {
+    const signer = new Ed25519VcSigner({
+      issuerDid: TEST_DID,
+      secretKey: ZERO_SEED,
+      clock: FIXED_CLOCK,
+    });
+    const proof = await signer.sign({ hello: "world", a: [1, 2, 3], n: 42 });
+    expect(proof.type).toBe("Ed25519Signature2020");
+    expect(proof.created).toBe("2026-01-01T00:00:00.000Z");
+    expect(proof.verificationMethod).toBe(`${TEST_DID}#key-1`);
+    expect(proof.proofPurpose).toBe("assertionMethod");
+    expect(proof.proofValue).toBe(EXPECTED_PROOF_VALUE);
+    expect(proof.proofValue).not.toMatch(/[+/=]/u);
+  });
+
+  it("signs whatever it's given (proof block is the caller's contract)", async () => {
+    // The signer itself signs the entire input. The contract that the
+    // `proof` key MUST be excluded is enforced by the indexer wiring,
+    // not by the signer. This test asserts both signatures and verifies
+    // they differ — which is why the indexer wiring strips `proof`
+    // before calling sign().
+    const signer = new Ed25519VcSigner({
+      issuerDid: TEST_DID,
+      secretKey: ZERO_SEED,
+      clock: FIXED_CLOCK,
+    });
+    const proofWithout = await signer.sign({
+      hello: "world",
+      a: [1, 2, 3],
+      n: 42,
+    });
+    const proofWith = await signer.sign({
+      hello: "world",
+      a: [1, 2, 3],
+      n: 42,
+      proof: { ignore: "me" },
+    });
+    expect(proofWithout.proofValue).toBe(EXPECTED_PROOF_VALUE);
+    expect(proofWith.proofValue).toBe(EXPECTED_PROOF_VALUE_WITH_PROOF_KEY);
+    expect(proofWith.proofValue).not.toBe(proofWithout.proofValue);
+  });
+
+  it("rejects non-32-byte seeds", () => {
+    expect(
+      () =>
+        new Ed25519VcSigner({
+          issuerDid: TEST_DID,
+          secretKey: new Uint8Array(31),
+        }),
+    ).toThrow(/32-byte/u);
+    expect(
+      () =>
+        new Ed25519VcSigner({
+          issuerDid: TEST_DID,
+          secretKey: new Uint8Array(64),
+        }),
+    ).toThrow(/32-byte/u);
+  });
+
+  describe("fromKeyFile", () => {
+    const dir = mkdtempSync(join(tmpdir(), "vc-signer-"));
+
+    it("loads a 32-raw-byte seed file", async () => {
+      const path = join(dir, "raw.bin");
+      writeFileSync(path, ZERO_SEED);
+      const signer = Ed25519VcSigner.fromKeyFile(path, {
+        issuerDid: TEST_DID,
+        clock: FIXED_CLOCK,
+      });
+      const proof = await signer.sign({ hello: "world", a: [1, 2, 3], n: 42 });
+      expect(proof.proofValue).toBe(EXPECTED_PROOF_VALUE);
+    });
+
+    it("loads a hex-encoded seed file (with 0x prefix and whitespace)", async () => {
+      const path = join(dir, "hex.txt");
+      writeFileSync(path, "0x" + "00".repeat(32) + "\n");
+      const signer = Ed25519VcSigner.fromKeyFile(path, {
+        issuerDid: TEST_DID,
+        clock: FIXED_CLOCK,
+      });
+      const proof = await signer.sign({ hello: "world", a: [1, 2, 3], n: 42 });
+      expect(proof.proofValue).toBe(EXPECTED_PROOF_VALUE);
+    });
+
+    it("loads a base64url-encoded seed file", async () => {
+      const path = join(dir, "b64.txt");
+      // base64 of 32 zero bytes
+      writeFileSync(path, "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA");
+      const signer = Ed25519VcSigner.fromKeyFile(path, {
+        issuerDid: TEST_DID,
+        clock: FIXED_CLOCK,
+      });
+      const proof = await signer.sign({ hello: "world", a: [1, 2, 3], n: 42 });
+      expect(proof.proofValue).toBe(EXPECTED_PROOF_VALUE);
+    });
+
+    it("throws on wrong-length seed", () => {
+      const path = join(dir, "bad.bin");
+      writeFileSync(path, new Uint8Array(16));
+      expect(() =>
+        Ed25519VcSigner.fromKeyFile(path, { issuerDid: TEST_DID }),
+      ).toThrow(/32-byte/u);
+    });
+  });
+});
+
+describe("createVcSignerFromEnv", () => {
+  it("returns NoOpVcSigner when AUDIT_SIGNING_KEY_PATH is unset", () => {
+    const signer = createVcSignerFromEnv({
+      issuerDid: TEST_DID,
+      env: {},
+    });
+    expect(signer).toBeInstanceOf(NoOpVcSigner);
+    expect(signer.issuerDid).toBe(TEST_DID);
+  });
+
+  it("returns NoOpVcSigner when AUDIT_SIGNING_KEY_PATH is empty", () => {
+    const signer = createVcSignerFromEnv({
+      issuerDid: TEST_DID,
+      env: { AUDIT_SIGNING_KEY_PATH: "" },
+    });
+    expect(signer).toBeInstanceOf(NoOpVcSigner);
+  });
+
+  it("returns Ed25519VcSigner when AUDIT_SIGNING_KEY_PATH points at a valid seed", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "vc-signer-env-"));
+    const path = join(dir, "seed.bin");
+    writeFileSync(path, ZERO_SEED);
+    const signer = createVcSignerFromEnv({
+      issuerDid: TEST_DID,
+      env: { AUDIT_SIGNING_KEY_PATH: path },
+      clock: FIXED_CLOCK,
+    });
+    expect(signer).toBeInstanceOf(Ed25519VcSigner);
+    const proof = await signer.sign({ hello: "world", a: [1, 2, 3], n: 42 });
+    expect(proof.proofValue).toBe(EXPECTED_PROOF_VALUE);
+  });
+});

--- a/tests/issuers/bank-mock.test.ts
+++ b/tests/issuers/bank-mock.test.ts
@@ -1,0 +1,273 @@
+/**
+ * FN-018 — bank-mock issuer boundary suite.
+ *
+ * No-signature issuer: tampered-signature is N/A. We substitute the
+ * tampered-envelope invariant per the PROMPT — mutate the pinned VC,
+ * recompute `sha256(jcs(...))`, and assert the mutated hash diverges
+ * from the on-chain `claim_hash`. Expiry is N/A — `validUntilSlot = 0`
+ * is hard-coded; a `revokeBankFiatRampTest` round-trip is the runtime
+ * substitute.
+ */
+
+import { describe, expect, it } from "vitest";
+
+import {
+  BANK_FIAT_RAMP_TEST_SCHEMA_ID_HEX,
+  BankMockIssueError,
+  InMemoryBankMockStore,
+  buildBankFiatRampTestVc,
+  issueBankFiatRampTest,
+  jcsCanonicalize,
+  revokeBankFiatRampTest,
+  sha256Hex,
+} from "../../src/issuers/bank-mock.js";
+import type {
+  BankMockIssuerDeps,
+  IssueCredentialClient,
+  RevokeCredentialClient,
+  SlotClock,
+  VcPinner,
+} from "../../src/issuers/bank-mock.types.js";
+
+/* -------------------------------------------------------------------------- */
+/* Fakes                                                                       */
+/* -------------------------------------------------------------------------- */
+
+const ISSUER = "BankMockIssuerAuthority1111111111111111111";
+const CARD_A = "AgentCardA1111111111111111111111111111111111";
+const CARD_B = "AgentCardB2222222222222222222222222222222222";
+const CARD_UNRELATED = "AgentCardZ9999999999999999999999999999999999";
+
+interface ChainCall {
+  subjectAgentCardPubkey: string;
+  schemaIdHex: string;
+  claimUri: string;
+  claimHashHex: string;
+  validFromSlot: bigint;
+  validUntilSlot: bigint;
+}
+
+class StubChain implements IssueCredentialClient {
+  public readonly calls: ChainCall[] = [];
+
+  async issueCredential(input: ChainCall) {
+    this.calls.push(input);
+    const idx = this.calls.length;
+    return {
+      credentialPda: `pda_${idx}_${input.subjectAgentCardPubkey.slice(0, 6)}`,
+      txSignature: `sig_${idx.toString().padStart(4, "0")}`,
+    };
+  }
+}
+
+class StubRevoker implements RevokeCredentialClient {
+  public readonly calls: Array<{ credentialPda: string }> = [];
+  async revokeCredential(input: { credentialPda: string }) {
+    this.calls.push(input);
+    const idx = this.calls.length;
+    return { txSignature: `revtx_${idx.toString().padStart(4, "0")}` };
+  }
+}
+
+class StubPinner implements VcPinner {
+  public readonly pinned: string[] = [];
+  async pin(json: string) {
+    this.pinned.push(json);
+    return { uri: `ipfs://stub/${this.pinned.length}` };
+  }
+  fetch(uri: string): Record<string, unknown> {
+    const idx = Number(uri.replace("ipfs://stub/", ""));
+    const json = this.pinned[idx - 1];
+    if (json === undefined) throw new Error(`unknown uri: ${uri}`);
+    return JSON.parse(json) as Record<string, unknown>;
+  }
+}
+
+class FixedClock implements SlotClock {
+  public constructor(private readonly slot: bigint) {}
+  async currentSlot(): Promise<bigint> {
+    return this.slot;
+  }
+}
+
+interface BuiltStack {
+  readonly deps: BankMockIssuerDeps;
+  readonly chain: StubChain;
+  readonly revoker: StubRevoker;
+  readonly pinner: StubPinner;
+  readonly store: InMemoryBankMockStore;
+  readonly nowRef: { value: number };
+}
+
+function bankMockDeps(opts?: { initialNow?: number }): BuiltStack {
+  const chain = new StubChain();
+  const revoker = new StubRevoker();
+  const pinner = new StubPinner();
+  const store = new InMemoryBankMockStore();
+  const nowRef = { value: opts?.initialNow ?? 1_700_000_000 };
+  const deps: BankMockIssuerDeps = {
+    store,
+    chain,
+    revoker,
+    pinner,
+    clock: new FixedClock(123_456n),
+    issuerAuthorityPubkey: ISSUER,
+    nowUnix: () => nowRef.value,
+  };
+  return { deps, chain, revoker, pinner, store, nowRef };
+}
+
+/* -------------------------------------------------------------------------- */
+/* Tests                                                                       */
+/* -------------------------------------------------------------------------- */
+
+describe("bank-mock issuer — boundary suite (FN-018)", () => {
+  it("happy issuance: status=issued, schema = BANK_FIAT_RAMP_TEST_SCHEMA_ID_HEX, subject from caller", async () => {
+    const { deps, chain, pinner, store } = bankMockDeps();
+
+    // Pre-seed an unrelated row to defend against subject-derivation
+    // regressions: even if the issuer accidentally read the store
+    // when populating the VC, an UNRELATED row must not pollute
+    // the call we're about to make.
+    await store.putIfAbsent({
+      checkingAccountId: "unrelated-account-id",
+      agentCardPubkey: CARD_UNRELATED,
+      credentialPda: "unrelated-pda",
+      txSignature: "unrelated-sig",
+      claimUri: "ipfs://unrelated",
+      issuedAtUnix: 1,
+      revoked: false,
+    });
+
+    const out = await issueBankFiatRampTest(deps, {
+      checkingAccountId: "chk-001",
+      agentCardPubkey: CARD_A,
+    });
+    expect(out.status).toBe("issued");
+    if (out.status !== "issued") return;
+    expect(chain.calls).toHaveLength(1);
+    expect(chain.calls[0]?.schemaIdHex).toBe(
+      BANK_FIAT_RAMP_TEST_SCHEMA_ID_HEX,
+    );
+    expect(chain.calls[0]?.subjectAgentCardPubkey).toBe(CARD_A);
+    expect(chain.calls[0]?.validUntilSlot).toBe(0n);
+
+    const vc = pinner.fetch(out.claimUri);
+    expect(out.claimHashHex).toBe(sha256Hex(jcsCanonicalize(vc)));
+    const subj = vc["credentialSubject"] as Record<string, unknown>;
+    expect(subj["checkingAccountId"]).toBe("chk-001");
+    expect(subj["id"]).toBe(`did:eto:agentcard:${CARD_A}`);
+  });
+
+  it("replay (same id+card): status=idempotent — no second chain tx", async () => {
+    const { deps, chain } = bankMockDeps();
+    const r1 = await issueBankFiatRampTest(deps, {
+      checkingAccountId: "chk-001",
+      agentCardPubkey: CARD_A,
+    });
+    const r2 = await issueBankFiatRampTest(deps, {
+      checkingAccountId: "chk-001",
+      agentCardPubkey: CARD_A,
+    });
+    expect(r1.status).toBe("issued");
+    expect(r2.status).toBe("idempotent");
+    expect(r2.credentialPda).toBe(r1.credentialPda);
+    expect(chain.calls).toHaveLength(1);
+  });
+
+  it("replay (same id, DIFFERENT card): throws BankMockIssueError(binding_conflict); chain still 1 call", async () => {
+    const { deps, chain } = bankMockDeps();
+    await issueBankFiatRampTest(deps, {
+      checkingAccountId: "chk-001",
+      agentCardPubkey: CARD_A,
+    });
+    let caught: unknown;
+    try {
+      await issueBankFiatRampTest(deps, {
+        checkingAccountId: "chk-001",
+        agentCardPubkey: CARD_B,
+      });
+    } catch (err) {
+      caught = err;
+    }
+    expect(caught).toBeInstanceOf(BankMockIssueError);
+    expect((caught as BankMockIssueError).kind).toBe("binding_conflict");
+    expect(chain.calls).toHaveLength(1);
+  });
+
+  it("tampered envelope (no-signature issuer): mutated VC hash differs from claim_hash", async () => {
+    const { deps, pinner } = bankMockDeps();
+    const out = await issueBankFiatRampTest(deps, {
+      checkingAccountId: "chk-001",
+      agentCardPubkey: CARD_A,
+    });
+    if (out.status !== "issued") throw new Error("unexpected status");
+    const vc = pinner.fetch(out.claimUri);
+    expect(out.claimHashHex).toBe(sha256Hex(jcsCanonicalize(vc)));
+
+    const mutated = { ...vc, issuer: "did:eto:other-bank" };
+    expect(sha256Hex(jcsCanonicalize(mutated))).not.toBe(out.claimHashHex);
+  });
+
+  // NB: bank-mock hard-codes valid_until_slot = 0; expiry is an
+  // on-chain concern. Revocation is the runtime substitute — covered below.
+
+  it("revocation round-trip: revoked → already_revoked (idempotent)", async () => {
+    const { deps, revoker } = bankMockDeps();
+    await issueBankFiatRampTest(deps, {
+      checkingAccountId: "chk-001",
+      agentCardPubkey: CARD_A,
+    });
+    const r1 = await revokeBankFiatRampTest(deps, {
+      checkingAccountId: "chk-001",
+    });
+    expect(r1.status).toBe("revoked");
+    expect(revoker.calls).toHaveLength(1);
+
+    const r2 = await revokeBankFiatRampTest(deps, {
+      checkingAccountId: "chk-001",
+    });
+    expect(r2.status).toBe("already_revoked");
+    // No second on-chain RevokeCredential tx.
+    expect(revoker.calls).toHaveLength(1);
+  });
+
+  it("VC envelope shape: credentialSubject locks the checking-account binding", () => {
+    const vc = buildBankFiatRampTestVc({
+      agentCardPubkey: CARD_A,
+      issuerAuthorityPubkey: ISSUER,
+      checkingAccountId: "chk-shape-001",
+      issuanceDate: "2026-04-29T00:00:00.000Z",
+    });
+    const subj = vc["credentialSubject"] as Record<string, unknown>;
+    expect(Object.keys(subj).sort()).toEqual([
+      "bankBindingType",
+      "checkingAccountId",
+      "id",
+      "mockIssuer",
+    ]);
+    expect(subj["mockIssuer"]).toBe(true);
+    expect(subj["bankBindingType"]).toBe("checking-account");
+  });
+
+  it("emits unique credentials across two independent issuances", async () => {
+    const { deps, chain, pinner, nowRef } = bankMockDeps();
+    const r1 = await issueBankFiatRampTest(deps, {
+      checkingAccountId: "chk-aaa",
+      agentCardPubkey: CARD_A,
+    });
+    nowRef.value += 60;
+    const r2 = await issueBankFiatRampTest(deps, {
+      checkingAccountId: "chk-bbb",
+      agentCardPubkey: CARD_B,
+    });
+    expect(r1.credentialPda).not.toBe(r2.credentialPda);
+    expect(chain.calls).toHaveLength(2);
+    const vc1 = pinner.fetch(r1.claimUri);
+    const vc2 = pinner.fetch(r2.claimUri);
+    expect(vc1["issuanceDate"]).not.toBe(vc2["issuanceDate"]);
+    const s1 = vc1["credentialSubject"] as Record<string, unknown>;
+    const s2 = vc2["credentialSubject"] as Record<string, unknown>;
+    expect(s1["checkingAccountId"]).not.toBe(s2["checkingAccountId"]);
+  });
+});

--- a/tests/issuers/bank-mock.test.ts
+++ b/tests/issuers/bank-mock.test.ts
@@ -142,6 +142,7 @@ describe("bank-mock issuer — boundary suite (FN-018)", () => {
     const out = await issueBankFiatRampTest(deps, {
       checkingAccountId: "chk-001",
       agentCardPubkey: CARD_A,
+      callerPubkey: CARD_A,
     });
     expect(out.status).toBe("issued");
     if (out.status !== "issued") return;
@@ -164,10 +165,12 @@ describe("bank-mock issuer — boundary suite (FN-018)", () => {
     const r1 = await issueBankFiatRampTest(deps, {
       checkingAccountId: "chk-001",
       agentCardPubkey: CARD_A,
+      callerPubkey: CARD_A,
     });
     const r2 = await issueBankFiatRampTest(deps, {
       checkingAccountId: "chk-001",
       agentCardPubkey: CARD_A,
+      callerPubkey: CARD_A,
     });
     expect(r1.status).toBe("issued");
     expect(r2.status).toBe("idempotent");
@@ -180,12 +183,14 @@ describe("bank-mock issuer — boundary suite (FN-018)", () => {
     await issueBankFiatRampTest(deps, {
       checkingAccountId: "chk-001",
       agentCardPubkey: CARD_A,
+      callerPubkey: CARD_A,
     });
     let caught: unknown;
     try {
       await issueBankFiatRampTest(deps, {
         checkingAccountId: "chk-001",
         agentCardPubkey: CARD_B,
+        callerPubkey: CARD_B,
       });
     } catch (err) {
       caught = err;
@@ -200,6 +205,7 @@ describe("bank-mock issuer — boundary suite (FN-018)", () => {
     const out = await issueBankFiatRampTest(deps, {
       checkingAccountId: "chk-001",
       agentCardPubkey: CARD_A,
+      callerPubkey: CARD_A,
     });
     if (out.status !== "issued") throw new Error("unexpected status");
     const vc = pinner.fetch(out.claimUri);
@@ -217,6 +223,7 @@ describe("bank-mock issuer — boundary suite (FN-018)", () => {
     await issueBankFiatRampTest(deps, {
       checkingAccountId: "chk-001",
       agentCardPubkey: CARD_A,
+      callerPubkey: CARD_A,
     });
     const r1 = await revokeBankFiatRampTest(deps, {
       checkingAccountId: "chk-001",
@@ -250,16 +257,62 @@ describe("bank-mock issuer — boundary suite (FN-018)", () => {
     expect(subj["bankBindingType"]).toBe("checking-account");
   });
 
+  // FN-070: caller-binding security gate
+  it("unauthorized_caller: callerPubkey !== agentCardPubkey → rejects before any side effect", async () => {
+    const { deps, chain, pinner, store } = bankMockDeps();
+    await expect(
+      issueBankFiatRampTest(deps, {
+        checkingAccountId: "chk-unauthorized",
+        agentCardPubkey: CARD_A,
+        callerPubkey: CARD_B, // different caller
+      }),
+    ).rejects.toMatchObject({
+      name: "BankMockIssueError",
+      kind: "unauthorized_caller",
+    });
+    // No side effects must have occurred
+    expect(chain.calls).toHaveLength(0);
+    expect(pinner.pinned).toHaveLength(0);
+    expect(await store.get("chk-unauthorized")).toBeUndefined();
+  });
+
+  it("unauthorized_caller: empty callerPubkey → rejects before any side effect", async () => {
+    const { deps, chain } = bankMockDeps();
+    await expect(
+      issueBankFiatRampTest(deps, {
+        checkingAccountId: "chk-empty-caller",
+        agentCardPubkey: CARD_A,
+        callerPubkey: "",
+      }),
+    ).rejects.toMatchObject({
+      name: "BankMockIssueError",
+      kind: "unauthorized_caller",
+    });
+    expect(chain.calls).toHaveLength(0);
+  });
+
+  it("authorized: callerPubkey matches agentCardPubkey (case-insensitive) → succeeds", async () => {
+    const { deps } = bankMockDeps();
+    const out = await issueBankFiatRampTest(deps, {
+      checkingAccountId: "chk-case",
+      agentCardPubkey: CARD_A,
+      callerPubkey: CARD_A.toUpperCase(),
+    });
+    expect(out.status).toBe("issued");
+  });
+
   it("emits unique credentials across two independent issuances", async () => {
     const { deps, chain, pinner, nowRef } = bankMockDeps();
     const r1 = await issueBankFiatRampTest(deps, {
       checkingAccountId: "chk-aaa",
       agentCardPubkey: CARD_A,
+      callerPubkey: CARD_A,
     });
     nowRef.value += 60;
     const r2 = await issueBankFiatRampTest(deps, {
       checkingAccountId: "chk-bbb",
       agentCardPubkey: CARD_B,
+      callerPubkey: CARD_B,
     });
     expect(r1.credentialPda).not.toBe(r2.credentialPda);
     expect(chain.calls).toHaveLength(2);

--- a/tests/issuers/bank.test.ts
+++ b/tests/issuers/bank.test.ts
@@ -1,0 +1,272 @@
+// FN-014 owns deep coverage at test/bank.test.ts; this file pins boundary parity with the rest of tests/issuers/.
+//
+// FN-018 — bank issuer (production) thin boundary-parity suite.
+//
+// `bank.ts` is a no-signature issuer. Tampered-signature is N/A;
+// tampered-envelope is the substituted invariant. `validUntilSlot`
+// is hard-coded to 0n for all three families (checking/savings/card)
+// — `expiresSlot` on the card-debit input flows ONLY into the VC
+// body as `credentialSubject.expires_slot`, never into the on-chain
+// `validUntilSlot`. We lock both halves of that contract.
+
+import { describe, expect, it } from "vitest";
+
+import {
+  BANK_ISSUER_SCHEMA_IDS_HEX,
+  BankIssuerError,
+  InMemoryBankIssuerStore,
+  issueCardCredential,
+  issueCheckingCredential,
+  jcsCanonicalize,
+  sha256Hex,
+} from "../../src/issuers/bank.js";
+import type {
+  BankIssuerDeps,
+  IssueCredentialClient,
+  RevokeCredentialClient,
+  SlotClock,
+  VcPinner,
+} from "../../src/issuers/bank.types.js";
+
+/* -------------------------------------------------------------------------- */
+/* Fakes                                                                       */
+/* -------------------------------------------------------------------------- */
+
+const ISSUER = "BankIssuerAuthority1111111111111111111111111";
+const CARD_A = "AgentCardA1111111111111111111111111111111111";
+const CARD_B = "AgentCardB2222222222222222222222222222222222";
+const CARD_UNRELATED = "AgentCardZ9999999999999999999999999999999999";
+
+interface ChainCall {
+  subjectAgentCardPubkey: string;
+  schemaIdHex: string;
+  claimUri: string;
+  claimHashHex: string;
+  validFromSlot: bigint;
+  validUntilSlot: bigint;
+}
+
+class StubChain implements IssueCredentialClient {
+  public readonly calls: ChainCall[] = [];
+  public failNext = false;
+
+  async issueCredential(input: ChainCall) {
+    if (this.failNext) {
+      this.failNext = false;
+      throw new Error("simulated rpc failure");
+    }
+    this.calls.push(input);
+    const idx = this.calls.length;
+    return {
+      credentialPda: `pda_${idx}_${input.subjectAgentCardPubkey.slice(0, 6)}`,
+      txSignature: `sig_${idx.toString().padStart(4, "0")}`,
+    };
+  }
+}
+
+class StubRevoker implements RevokeCredentialClient {
+  async revokeCredential() {
+    return { txSignature: "revtx_unused" };
+  }
+}
+
+class StubPinner implements VcPinner {
+  public readonly pinned: string[] = [];
+  async pin(json: string) {
+    this.pinned.push(json);
+    return { uri: `ipfs://stub/${this.pinned.length}` };
+  }
+  fetch(uri: string): Record<string, unknown> {
+    const idx = Number(uri.replace("ipfs://stub/", ""));
+    const json = this.pinned[idx - 1];
+    if (json === undefined) throw new Error(`unknown uri: ${uri}`);
+    return JSON.parse(json) as Record<string, unknown>;
+  }
+}
+
+class FixedClock implements SlotClock {
+  public constructor(private readonly slot: bigint) {}
+  async currentSlot(): Promise<bigint> {
+    return this.slot;
+  }
+}
+
+interface BuiltStack {
+  readonly deps: BankIssuerDeps;
+  readonly chain: StubChain;
+  readonly pinner: StubPinner;
+  readonly store: InMemoryBankIssuerStore;
+  readonly nowRef: { value: number };
+}
+
+function bankDeps(opts?: { initialNow?: number }): BuiltStack {
+  const chain = new StubChain();
+  const pinner = new StubPinner();
+  const store = new InMemoryBankIssuerStore();
+  const nowRef = { value: opts?.initialNow ?? 1_700_000_000 };
+  const deps: BankIssuerDeps = {
+    store,
+    chain,
+    revoker: new StubRevoker(),
+    pinner,
+    clock: new FixedClock(123_456n),
+    issuerAuthorityPubkey: ISSUER,
+    nowUnix: () => nowRef.value,
+  };
+  return { deps, chain, pinner, store, nowRef };
+}
+
+function checkingInput(overrides?: {
+  readonly subjectAgentCardPubkey?: string;
+  readonly checkingAccountPda?: string;
+}) {
+  return {
+    subjectAgentCardPubkey: overrides?.subjectAgentCardPubkey ?? CARD_A,
+    checkingAccountPda:
+      overrides?.checkingAccountPda ?? "checkingAcctPda01".padEnd(64, "0"),
+    holder: CARD_A,
+    openedSlot: 1234,
+    currency: "eUSD" as const,
+    openingBalance: 0,
+  };
+}
+
+/* -------------------------------------------------------------------------- */
+/* Tests                                                                       */
+/* -------------------------------------------------------------------------- */
+
+describe("bank issuer — boundary parity (FN-018)", () => {
+  it("happy issuance: status=issued, schema = account.checking, validUntilSlot=0n, subject from caller", async () => {
+    const { deps, chain, store } = bankDeps();
+
+    // Pre-seed an unrelated row under a different kind so a
+    // store-derivation regression would surface as a failed
+    // subject-provenance assertion below.
+    await store.putIfAbsent({
+      kind: "account.savings",
+      bindingKey: "unrelated-savings-pda",
+      agentCardPubkey: CARD_UNRELATED,
+      credentialPda: "unrelated-pda",
+      txSignature: "unrelated-sig",
+      claimUri: "ipfs://unrelated",
+      issuedAtUnix: 1,
+      revoked: false,
+    });
+
+    const out = await issueCheckingCredential(deps, checkingInput());
+    expect(out.status).toBe("issued");
+    if (out.status !== "issued") return;
+    expect(chain.calls).toHaveLength(1);
+    expect(chain.calls[0]?.schemaIdHex).toBe(
+      BANK_ISSUER_SCHEMA_IDS_HEX["account.checking"],
+    );
+    expect(chain.calls[0]?.subjectAgentCardPubkey).toBe(CARD_A);
+    expect(chain.calls[0]?.validUntilSlot).toBe(0n);
+  });
+
+  it("replay (same PDA + same card): status=idempotent — no second chain tx", async () => {
+    const { deps, chain } = bankDeps();
+    const r1 = await issueCheckingCredential(deps, checkingInput());
+    const r2 = await issueCheckingCredential(deps, checkingInput());
+    expect(r1.status).toBe("issued");
+    expect(r2.status).toBe("idempotent");
+    expect(r2.credentialPda).toBe(r1.credentialPda);
+    expect(chain.calls).toHaveLength(1);
+  });
+
+  it("replay (same PDA, DIFFERENT card): throws BankIssuerError(binding_conflict, 409-equivalent)", async () => {
+    const { deps, chain } = bankDeps();
+    await issueCheckingCredential(deps, checkingInput());
+    let caught: unknown;
+    try {
+      await issueCheckingCredential(
+        deps,
+        checkingInput({ subjectAgentCardPubkey: CARD_B }),
+      );
+    } catch (err) {
+      caught = err;
+    }
+    expect(caught).toBeInstanceOf(BankIssuerError);
+    expect((caught as BankIssuerError).kind).toBe("binding_conflict");
+    expect(chain.calls).toHaveLength(1);
+  });
+
+  it("tampered envelope (no-signature issuer): mutated VC hash differs from claim_hash", async () => {
+    const { deps, pinner, chain } = bankDeps();
+    const out = await issueCheckingCredential(deps, checkingInput());
+    if (out.status !== "issued") throw new Error("unexpected status");
+    const vc = pinner.fetch(out.claimUri);
+    expect(out.claimHashHex).toBe(sha256Hex(jcsCanonicalize(vc)));
+    expect(chain.calls[0]?.claimHashHex).toBe(out.claimHashHex);
+    const mutated = { ...vc, issuer: "did:eto:other-bank" };
+    expect(sha256Hex(jcsCanonicalize(mutated))).not.toBe(out.claimHashHex);
+  });
+
+  it("card-debit with expiresSlot: VC body carries expires_slot; chain validUntilSlot stays 0n", async () => {
+    // The only expiry-bearing input on the production bank issuer.
+    // Per `src/issuers/bank.ts`, `expiresSlot` flows into the VC body
+    // as `credentialSubject.expires_slot`; it is NOT propagated to
+    // the on-chain `validUntilSlot`, which is hard-coded to 0n.
+    const { deps, chain, pinner } = bankDeps();
+    const out = await issueCardCredential(deps, {
+      subjectAgentCardPubkey: CARD_A,
+      cardIdHash: "ab".repeat(32),
+      holder: CARD_A,
+      linkedAccountPda: "lnk".padEnd(64, "0"),
+      jurisdiction: "us",
+      issuedSlot: 1234,
+      spendingLimitPerDay: 1_000_000,
+      expiresSlot: 9_999_999,
+    });
+    if (out.status !== "issued") throw new Error("unexpected status");
+    expect(chain.calls).toHaveLength(1);
+    // No on-chain expiry — bank.ts always passes validUntilSlot = 0n.
+    expect(chain.calls[0]?.validUntilSlot).toBe(0n);
+    const vc = pinner.fetch(out.claimUri);
+    const subj = vc["credentialSubject"] as Record<string, unknown>;
+    expect(subj["expires_slot"]).toBe(9_999_999);
+  });
+
+  it("chain-failure isolation: BankIssuerError(chain_failed); store NOT mutated", async () => {
+    const { deps, chain, store } = bankDeps();
+    chain.failNext = true;
+    let caught: unknown;
+    try {
+      await issueCheckingCredential(deps, checkingInput());
+    } catch (err) {
+      caught = err;
+    }
+    expect(caught).toBeInstanceOf(BankIssuerError);
+    expect((caught as BankIssuerError).kind).toBe("chain_failed");
+    // No row written for the failed input.
+    const row = await store.get(
+      "account.checking",
+      "checkingAcctPda01".padEnd(64, "0"),
+    );
+    expect(row).toBeUndefined();
+  });
+
+  it("emits unique credentials across two independent issuances", async () => {
+    const { deps, chain, pinner, nowRef } = bankDeps();
+    const r1 = await issueCheckingCredential(
+      deps,
+      checkingInput({
+        checkingAccountPda: "aaa".padEnd(64, "0"),
+        subjectAgentCardPubkey: CARD_A,
+      }),
+    );
+    nowRef.value += 60;
+    const r2 = await issueCheckingCredential(
+      deps,
+      checkingInput({
+        checkingAccountPda: "bbb".padEnd(64, "0"),
+        subjectAgentCardPubkey: CARD_B,
+      }),
+    );
+    expect(r1.credentialPda).not.toBe(r2.credentialPda);
+    expect(chain.calls).toHaveLength(2);
+    const vc1 = pinner.fetch(r1.claimUri);
+    const vc2 = pinner.fetch(r2.claimUri);
+    expect(vc1["issuanceDate"]).not.toBe(vc2["issuanceDate"]);
+  });
+});

--- a/tests/issuers/civic.test.ts
+++ b/tests/issuers/civic.test.ts
@@ -1,0 +1,483 @@
+/**
+ * FN-018 — Civic issuer boundary suite.
+ *
+ * Mirrors the structure of `tests/issuers/worldcoin.test.ts`: a
+ * file-local mock chain ledger, a file-local in-memory IPFS pinner,
+ * real Ed25519 keypairs for the wallet-binding signature, and one
+ * `it` per mandatory boundary case (happy issuance, replay-idempotent,
+ * replay-conflict, tampered signature, expiry, no-PII, uniqueness).
+ *
+ * Contract reality check (per PROMPT): `CivicIssuer.issue` THROWS
+ * `CivicIssuerError` on every failure path. We lock the typed-error
+ * invariant rather than pretending the issuer returns a tagged union.
+ *
+ * Bun-runner note: this file uses `vitest` imports identically to
+ * `worldcoin.test.ts`; bun's runner re-exports the named symbols.
+ */
+
+import {
+  createHash,
+  createPrivateKey,
+  createPublicKey,
+  generateKeyPairSync,
+  sign as nodeSign,
+  verify as nodeVerify,
+} from "node:crypto";
+import { describe, expect, it } from "vitest";
+
+import {
+  CivicIssuer,
+  CivicIssuerError,
+  InMemoryNullifierStore,
+  StubCivicVerifier,
+  VERIFIED_HUMAN_SCHEMA_ID,
+  base58Decode,
+  buildVerifiedHumanVc,
+  civicNullifierFromGatewayToken,
+  defaultClaimHasher,
+  jcsCanonicalize,
+} from "../../src/issuers/civic.js";
+import type {
+  AgentCardSignatureVerifier,
+  ChainClient,
+  CivicConfig,
+  CivicIssuerDeps,
+  CivicVerifier,
+  CivicVerifyResult,
+  IpfsPinner,
+  IssueCredentialArgs,
+  IssueCredentialResult,
+} from "../../src/issuers/civic.types.js";
+
+/* -------------------------------------------------------------------------- */
+/* base58 encoder (decode-only ships in src; tests need to encode pubkeys)    */
+/* -------------------------------------------------------------------------- */
+
+const BASE58_ALPHABET =
+  "123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz";
+
+function base58Encode(bytes: Uint8Array): string {
+  if (bytes.length === 0) return "";
+  let zeros = 0;
+  while (zeros < bytes.length && bytes[zeros] === 0) zeros += 1;
+  const digits: number[] = [];
+  for (let i = zeros; i < bytes.length; i += 1) {
+    let carry = bytes[i]!;
+    for (let j = 0; j < digits.length; j += 1) {
+      carry += digits[j]! << 8;
+      digits[j] = carry % 58;
+      carry = (carry / 58) | 0;
+    }
+    while (carry > 0) {
+      digits.push(carry % 58);
+      carry = (carry / 58) | 0;
+    }
+  }
+  let out = "";
+  for (let i = 0; i < zeros; i += 1) out += "1";
+  for (let i = digits.length - 1; i >= 0; i -= 1) {
+    out += BASE58_ALPHABET[digits[i]!]!;
+  }
+  return out;
+}
+
+/* -------------------------------------------------------------------------- */
+/* Wallet — real Ed25519                                                       */
+/* -------------------------------------------------------------------------- */
+
+interface Wallet {
+  readonly pubkey: string; // base58 32-byte
+  readonly rawPub: Uint8Array;
+  readonly privateKey: ReturnType<typeof createPrivateKey>;
+}
+
+function newWallet(): Wallet {
+  const { publicKey, privateKey } = generateKeyPairSync("ed25519");
+  const spki = publicKey.export({ format: "der", type: "spki" });
+  const raw = new Uint8Array(spki.subarray(spki.length - 32));
+  return {
+    pubkey: base58Encode(raw),
+    rawPub: raw,
+    privateKey,
+  };
+}
+
+function signBinding(wallet: Wallet, nullifierHex: string): string {
+  const nullifierBytes = Buffer.from(nullifierHex, "hex");
+  const message = createHash("sha256")
+    .update(nullifierBytes)
+    .update(wallet.rawPub)
+    .digest();
+  return Buffer.from(nodeSign(null, message, wallet.privateKey)).toString(
+    "base64",
+  );
+}
+
+const realAgentCardSig: AgentCardSignatureVerifier = {
+  async verify({ nullifier, agentCardPubkey, signature }) {
+    try {
+      const nb = Buffer.from(nullifier, "hex");
+      if (nb.length !== 32) return false;
+      const cb = base58Decode(agentCardPubkey);
+      if (cb.length !== 32) return false;
+      const sigBytes = Buffer.from(signature, "base64");
+      if (sigBytes.length !== 64) return false;
+      const msg = createHash("sha256").update(nb).update(cb).digest();
+      const spki = Buffer.concat([
+        Buffer.from("302a300506032b6570032100", "hex"),
+        Buffer.from(cb),
+      ]);
+      const key = createPublicKey({ key: spki, format: "der", type: "spki" });
+      return nodeVerify(null, msg, key, sigBytes);
+    } catch {
+      return false;
+    }
+  },
+};
+
+/* -------------------------------------------------------------------------- */
+/* Mock chain ledger                                                           */
+/* -------------------------------------------------------------------------- */
+
+interface OnChainCredential {
+  readonly schema: string;
+  readonly subjectAgentCard: string;
+  readonly claimHash: string;
+  readonly claimUri: string;
+  readonly validUntilSlot: bigint;
+}
+
+class MockChainLedger implements ChainClient {
+  public readonly accounts = new Map<string, OnChainCredential>();
+  public readonly calls: IssueCredentialArgs[] = [];
+  private slot = 100n;
+
+  async issueCredential(
+    args: IssueCredentialArgs,
+  ): Promise<IssueCredentialResult> {
+    this.calls.push(args);
+    this.slot += 1n;
+    const pda = `pda_${this.calls.length.toString().padStart(4, "0")}_${args.subjectAgentCard.slice(0, 6)}`;
+    this.accounts.set(pda, {
+      schema: args.schema,
+      subjectAgentCard: args.subjectAgentCard,
+      claimHash: args.claimHash,
+      claimUri: args.claimUri,
+      validUntilSlot: args.validUntilSlot,
+    });
+    return {
+      credentialPda: pda,
+      txSignature: `tx_${this.calls.length.toString().padStart(4, "0")}`,
+    };
+  }
+
+  async currentSlot(): Promise<bigint> {
+    return this.slot;
+  }
+}
+
+class MockIpfs implements IpfsPinner {
+  public readonly store = new Map<string, string>();
+
+  async pin(jcs: string): Promise<{ uri: string }> {
+    const cid = createHash("sha256").update(jcs).digest("hex").slice(0, 46);
+    this.store.set(cid, jcs);
+    return { uri: `ipfs://${cid}` };
+  }
+
+  fetch(uri: string): unknown {
+    const cid = uri.slice("ipfs://".length);
+    const jcs = this.store.get(cid);
+    if (jcs === undefined) throw new Error(`ipfs cid not found: ${cid}`);
+    return JSON.parse(jcs);
+  }
+}
+
+/* -------------------------------------------------------------------------- */
+/* Fixtures                                                                     */
+/* -------------------------------------------------------------------------- */
+
+const NETWORK = "civicNet11111111111111111111111111111111111";
+const GATEWAY_TOKEN = "gtokAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA";
+const GATEWAY_TOKEN_2 = "gtokBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB";
+const ISSUER_AUTHORITY = "issuerAuthorityKey1111111111111111111111111";
+
+const ENABLED_CONFIG: { civic: CivicConfig } = {
+  civic: {
+    gatekeeperNetwork: NETWORK,
+    issuerKeypairPath: "/dev/null/issuer.json",
+    networkId: "00".repeat(32),
+    enabled: true,
+  },
+};
+
+function okVerifyResult(): CivicVerifyResult {
+  return {
+    tokenAddress: GATEWAY_TOKEN,
+    owner: "verified-by-stub",
+    gatekeeperNetwork: NETWORK,
+    state: "Active",
+    expiresAt: 1_999_999_999,
+    civicPassLevel: "uniqueness",
+  };
+}
+
+interface BuiltStack {
+  readonly issuer: CivicIssuer;
+  readonly chain: MockChainLedger;
+  readonly ipfs: MockIpfs;
+  readonly verifier: StubCivicVerifier;
+  readonly nowUnix: () => number;
+}
+
+function civicDeps(opts?: {
+  readonly verifier?: StubCivicVerifier;
+  readonly chain?: MockChainLedger;
+  readonly nowUnix?: () => number;
+}): BuiltStack {
+  const chain = opts?.chain ?? new MockChainLedger();
+  const ipfs = new MockIpfs();
+  const verifier = opts?.verifier ?? new StubCivicVerifier(okVerifyResult());
+  const nowUnix = opts?.nowUnix ?? (() => 1_700_000_000);
+  const deps: CivicIssuerDeps = {
+    config: ENABLED_CONFIG,
+    store: new InMemoryNullifierStore(),
+    chainClient: chain,
+    civicVerifier: verifier,
+    signatureVerifier: realAgentCardSig,
+    ipfsPinner: ipfs,
+    claimHasher: defaultClaimHasher,
+    issuerAuthorityPubkey: ISSUER_AUTHORITY,
+    nowUnix,
+  };
+  return { issuer: new CivicIssuer(deps), chain, ipfs, verifier, nowUnix };
+}
+
+/* -------------------------------------------------------------------------- */
+/* Tests                                                                        */
+/* -------------------------------------------------------------------------- */
+
+describe("Civic issuer — boundary suite (FN-018)", () => {
+  it("happy issuance: mints a verified-human credential bound to the caller's AgentCard", async () => {
+    const fixedNow = 1_700_000_000;
+    const { issuer, chain, ipfs, verifier } = civicDeps({
+      nowUnix: () => fixedNow,
+    });
+    const wallet = newWallet();
+    const nullifier = civicNullifierFromGatewayToken(GATEWAY_TOKEN);
+
+    const out = await issuer.issue({
+      gatewayToken: GATEWAY_TOKEN,
+      agentCardPubkey: wallet.pubkey,
+      agentCardSignature: signBinding(wallet, nullifier),
+    });
+
+    expect(out.idempotent).toBe(false);
+    expect(out.claimHash).toMatch(/^[0-9a-f]{64}$/);
+    expect(out.claimUri.startsWith("ipfs://")).toBe(true);
+    expect(chain.calls).toHaveLength(1);
+    expect(chain.calls[0]?.schema).toBe(VERIFIED_HUMAN_SCHEMA_ID);
+    // Lock subject provenance: caller-supplied, not store-derived.
+    expect(chain.calls[0]?.subjectAgentCard).toBe(wallet.pubkey);
+    expect(chain.calls[0]?.idempotencyKey).toBe(`civic:${nullifier}`);
+    expect(chain.calls[0]?.validUntilSlot).toBe(0n);
+    expect(verifier.calls).toHaveLength(1);
+
+    // claimHash equals sha256(JCS(VC))
+    const vc = ipfs.fetch(out.claimUri) as Record<string, unknown>;
+    expect(defaultClaimHasher.hash(vc)).toBe(out.claimHash);
+
+    // issuanceDate ISO equals injected clock
+    expect(vc["issuanceDate"]).toBe(new Date(fixedNow * 1000).toISOString());
+
+    // No-PII bonus invariant — credentialSubject only contains bridge-safe fields.
+    const subj = vc["credentialSubject"] as Record<string, unknown>;
+    expect(Object.keys(subj).sort()).toEqual(["id", "type"]);
+    expect(subj["id"]).toBe(`did:eto:agentcard:${wallet.pubkey}`);
+
+    // Lock VC envelope shape (no email/DOB/keypair material).
+    // NB: civic.ts intentionally records the *public* gateway-token
+    // account address in `evidence[].tokenAddress` per
+    // `spec/issuers/civic-integration.md` — that's the on-chain
+    // verifiable handle, not a secret. The leak invariant is
+    // therefore phrased against secret-bearing fields only.
+    const pinnedJcs = jcsCanonicalize(vc);
+    expect(pinnedJcs.toLowerCase()).not.toContain("keypair");
+    expect(pinnedJcs.toLowerCase()).not.toContain("email");
+    expect(pinnedJcs.toLowerCase()).not.toContain("dateofbirth");
+  });
+
+  it("replay (same wallet): idempotent — same PDA, no second chain tx", async () => {
+    const { issuer, chain, verifier } = civicDeps();
+    const wallet = newWallet();
+    const nullifier = civicNullifierFromGatewayToken(GATEWAY_TOKEN);
+    const sig = signBinding(wallet, nullifier);
+
+    const first = await issuer.issue({
+      gatewayToken: GATEWAY_TOKEN,
+      agentCardPubkey: wallet.pubkey,
+      agentCardSignature: sig,
+    });
+    const second = await issuer.issue({
+      gatewayToken: GATEWAY_TOKEN,
+      agentCardPubkey: wallet.pubkey,
+      agentCardSignature: sig,
+    });
+
+    expect(first.idempotent).toBe(false);
+    expect(second.idempotent).toBe(true);
+    expect(second.credentialPda).toBe(first.credentialPda);
+    expect(chain.calls).toHaveLength(1);
+    // Idempotent re-hit short-circuits BEFORE the verifier per spec §6.
+    expect(verifier.calls).toHaveLength(1);
+  });
+
+  it("replay (different wallet, same gatewayToken): 409 NULLIFIER_BOUND_TO_OTHER_CARD", async () => {
+    const { issuer, chain } = civicDeps();
+    const a = newWallet();
+    const b = newWallet();
+    const nullifier = civicNullifierFromGatewayToken(GATEWAY_TOKEN);
+
+    await issuer.issue({
+      gatewayToken: GATEWAY_TOKEN,
+      agentCardPubkey: a.pubkey,
+      agentCardSignature: signBinding(a, nullifier),
+    });
+
+    let caught: unknown;
+    try {
+      await issuer.issue({
+        gatewayToken: GATEWAY_TOKEN,
+        agentCardPubkey: b.pubkey,
+        agentCardSignature: signBinding(b, nullifier),
+      });
+    } catch (err) {
+      caught = err;
+    }
+    expect(caught).toBeInstanceOf(CivicIssuerError);
+    const cErr = caught as CivicIssuerError;
+    expect(cErr.code).toBe("NULLIFIER_BOUND_TO_OTHER_CARD");
+    expect(cErr.status).toBe(409);
+    expect(chain.calls).toHaveLength(1);
+  });
+
+  it("tampered signature: 401 INVALID_AGENT_CARD_SIGNATURE; chain not called", async () => {
+    const { issuer, chain, verifier } = civicDeps();
+    const victim = newWallet();
+    const attacker = newWallet();
+    const nullifier = civicNullifierFromGatewayToken(GATEWAY_TOKEN);
+
+    let caught: unknown;
+    try {
+      await issuer.issue({
+        gatewayToken: GATEWAY_TOKEN,
+        agentCardPubkey: victim.pubkey,
+        agentCardSignature: signBinding(attacker, nullifier),
+      });
+    } catch (err) {
+      caught = err;
+    }
+    expect(caught).toBeInstanceOf(CivicIssuerError);
+    const cErr = caught as CivicIssuerError;
+    expect(cErr.code).toBe("INVALID_AGENT_CARD_SIGNATURE");
+    expect(cErr.status).toBe(401);
+    expect(chain.calls).toHaveLength(0);
+    expect(verifier.calls).toHaveLength(0);
+  });
+
+  it("expiry: gateway-token expiry from injected verifier propagates as CivicIssuerError", async () => {
+    // Emulate Civic's gateway-token TTL via an injected verifier
+    // throwing the documented error code with a 410 Gone status.
+    const expiredVerifier = new StubCivicVerifier(
+      new CivicIssuerError(
+        "GATEWAY_TOKEN_INACTIVE",
+        "civic gateway token expired",
+        410,
+      ),
+    );
+    const { issuer, chain } = civicDeps({ verifier: expiredVerifier });
+    const wallet = newWallet();
+    const nullifier = civicNullifierFromGatewayToken(GATEWAY_TOKEN);
+
+    let caught: unknown;
+    try {
+      await issuer.issue({
+        gatewayToken: GATEWAY_TOKEN,
+        agentCardPubkey: wallet.pubkey,
+        agentCardSignature: signBinding(wallet, nullifier),
+      });
+    } catch (err) {
+      caught = err;
+    }
+    expect(caught).toBeInstanceOf(CivicIssuerError);
+    const cErr = caught as CivicIssuerError;
+    expect(cErr.code).toBe("GATEWAY_TOKEN_INACTIVE");
+    expect(cErr.status).toBe(410);
+    expect(chain.calls).toHaveLength(0);
+  });
+
+  it("no PII leak: credentialSubject carries no email/DOB/keypair material", async () => {
+    // Civic's verified-human VC subject is minimal — `{ id, type }`.
+    // The gateway-token *account address* (a public Solana pubkey) is
+    // recorded in `evidence[].tokenAddress` and is the verifiable
+    // public handle by design; it is NOT secret. This test pins the
+    // narrower invariant: no email, no DOB, no keypair material.
+    const { issuer, ipfs } = civicDeps();
+    const wallet = newWallet();
+    const nullifier = civicNullifierFromGatewayToken(GATEWAY_TOKEN);
+    const out = await issuer.issue({
+      gatewayToken: GATEWAY_TOKEN,
+      agentCardPubkey: wallet.pubkey,
+      agentCardSignature: signBinding(wallet, nullifier),
+    });
+    const vc = ipfs.fetch(out.claimUri) as Record<string, unknown>;
+    const json = JSON.stringify(vc).toLowerCase();
+    expect(json).not.toContain("email");
+    expect(json).not.toContain("dateofbirth");
+    expect(json).not.toContain("keypair");
+    const subj = vc["credentialSubject"] as Record<string, unknown>;
+    expect(Object.keys(subj).sort()).toEqual(["id", "type"]);
+  });
+
+  it("emits unique credentials across two independent issuances", async () => {
+    let now = 1_700_000_000;
+    const { issuer, chain, ipfs } = civicDeps({ nowUnix: () => now });
+    const a = newWallet();
+    const b = newWallet();
+
+    const na = civicNullifierFromGatewayToken(GATEWAY_TOKEN);
+    const nb = civicNullifierFromGatewayToken(GATEWAY_TOKEN_2);
+
+    const r1 = await issuer.issue({
+      gatewayToken: GATEWAY_TOKEN,
+      agentCardPubkey: a.pubkey,
+      agentCardSignature: signBinding(a, na),
+    });
+    now += 60;
+    const r2 = await issuer.issue({
+      gatewayToken: GATEWAY_TOKEN_2,
+      agentCardPubkey: b.pubkey,
+      agentCardSignature: signBinding(b, nb),
+    });
+
+    expect(r1.credentialPda).not.toBe(r2.credentialPda);
+    expect(chain.calls).toHaveLength(2);
+    const vc1 = ipfs.fetch(r1.claimUri) as Record<string, unknown>;
+    const vc2 = ipfs.fetch(r2.claimUri) as Record<string, unknown>;
+    expect(vc1["issuanceDate"]).not.toBe(vc2["issuanceDate"]);
+    // bridgeNullifier (the per-VC unique identifier we emit) differs.
+    expect(vc1["bridgeNullifier"]).not.toBe(vc2["bridgeNullifier"]);
+  });
+
+  it("buildVerifiedHumanVc shape parity with the issuer (no drift)", () => {
+    // Defensive: locks the subject-key contract used by the no-PII test.
+    const vc = buildVerifiedHumanVc({
+      agentCardPubkey: "Card",
+      issuerAuthorityPubkey: "Issuer",
+      civicVerifyResult: okVerifyResult(),
+      civicNullifier: "00".repeat(32),
+      issuanceDate: "2026-04-29T00:00:00.000Z",
+    });
+    expect(Object.keys(vc.credentialSubject).sort()).toEqual(["id", "type"]);
+  });
+});

--- a/tests/issuers/kyc-test.test.ts
+++ b/tests/issuers/kyc-test.test.ts
@@ -14,7 +14,12 @@
  * See FN-018 follow-up FN-072 for the upgrade path.
  */
 
-import { createHash } from "node:crypto";
+import {
+  createHash,
+  createPrivateKey,
+  generateKeyPairSync,
+  sign as nodeSign,
+} from "node:crypto";
 import { describe, expect, it } from "vitest";
 
 import {
@@ -24,11 +29,13 @@ import {
   KycTestIssueError,
   buildKycTestVc,
   deriveNullifier,
+  ed25519KycTestSignatureVerifier,
   issueKycTest,
   jcsCanonicalize,
   normalizeName,
 } from "../../src/issuers/kyc-test.js";
 import type {
+  KycTestAgentCardSignatureVerifier,
   KycTestDedupeRow,
   KycTestDedupeStore,
   KycTestFormSubmission,
@@ -37,6 +44,17 @@ import type {
   KycTestSlotClock,
   KycTestVcPinner,
 } from "../../src/issuers/kyc-test.types.js";
+
+// FN-057 — wallet-binding signature is required. Most existing
+// boundary tests don't depend on signature semantics, so they use
+// an always-true stub. The dedicated FN-057 test below uses the
+// real Ed25519 verifier with a real keypair.
+const stubSigVerifier: KycTestAgentCardSignatureVerifier = {
+  async verify() {
+    return true;
+  },
+};
+const STUB_SIGNATURE = Buffer.alloc(64).toString("base64");
 
 /* -------------------------------------------------------------------------- */
 /* Fixtures                                                                    */
@@ -127,6 +145,7 @@ function kycDeps(opts?: { initialNow?: number }): BuiltStack {
     chain,
     pinner,
     clock: new FixedClock(123_456n),
+    signatureVerifier: stubSigVerifier,
     issuerAuthorityPubkey: ISSUER,
     nowUnix: () => nowRef.value,
   };
@@ -138,16 +157,19 @@ function makeSubmission(opts: {
   readonly fullName?: string;
   readonly dobIso?: string;
   readonly flowStartedAtUnix: number;
+  readonly agentCardPubkey?: string;
   readonly tagOverride?: string;
 }): KycTestFormSubmission {
   const fullName = opts.fullName ?? "Test User";
   const dobIso = opts.dobIso ?? "1990-01-01";
+  const agentCardPubkey = opts.agentCardPubkey ?? CARD_A;
   const tag =
     opts.tagOverride ??
     opts.signer.sign({
       fullName,
       dobIso,
       flowStartedAtUnix: opts.flowStartedAtUnix,
+      agentCardPubkey,
     });
   return {
     fullName,
@@ -173,6 +195,7 @@ describe("kyc.us-test issuer — boundary suite (FN-018)", () => {
     const out = await issueKycTest(deps, {
       submission,
       agentCardPubkey: CARD_A,
+      agentCardSignature: STUB_SIGNATURE,
     });
 
     expect(out.status).toBe("issued");
@@ -204,10 +227,12 @@ describe("kyc.us-test issuer — boundary suite (FN-018)", () => {
     const r1 = await issueKycTest(deps, {
       submission: sub,
       agentCardPubkey: CARD_A,
+      agentCardSignature: STUB_SIGNATURE,
     });
     const r2 = await issueKycTest(deps, {
       submission: sub,
       agentCardPubkey: CARD_A,
+      agentCardSignature: STUB_SIGNATURE,
     });
     expect(r1.status).toBe("issued");
     expect(r2.status).toBe("idempotent");
@@ -217,17 +242,25 @@ describe("kyc.us-test issuer — boundary suite (FN-018)", () => {
 
   it("replay (same identity, DIFFERENT card): throws KycTestIssueError(replay_conflict)", async () => {
     const { deps, chain, nowRef } = kycDeps({ initialNow: 1_700_000_100 });
-    const sub = makeSubmission({
+    const flowStartedAtUnix = nowRef.value - KYC_TEST_MIN_DWELL_SECONDS;
+    const subA = makeSubmission({
       signer: deps.tokenSigner as HmacKycTestFormTokenSigner,
-      flowStartedAtUnix: nowRef.value - KYC_TEST_MIN_DWELL_SECONDS,
+      flowStartedAtUnix,
+      agentCardPubkey: CARD_A,
     });
-    await issueKycTest(deps, { submission: sub, agentCardPubkey: CARD_A });
+    const subB = makeSubmission({
+      signer: deps.tokenSigner as HmacKycTestFormTokenSigner,
+      flowStartedAtUnix,
+      agentCardPubkey: CARD_B,
+    });
+    await issueKycTest(deps, { submission: subA, agentCardPubkey: CARD_A, agentCardSignature: STUB_SIGNATURE });
 
     let caught: unknown;
     try {
       await issueKycTest(deps, {
-        submission: sub,
+        submission: subB,
         agentCardPubkey: CARD_B,
+        agentCardSignature: STUB_SIGNATURE,
       });
     } catch (err) {
       caught = err;
@@ -256,6 +289,7 @@ describe("kyc.us-test issuer — boundary suite (FN-018)", () => {
       await issueKycTest(deps, {
         submission: tampered,
         agentCardPubkey: CARD_A,
+        agentCardSignature: STUB_SIGNATURE,
       });
     } catch (err) {
       caught = err;
@@ -277,6 +311,7 @@ describe("kyc.us-test issuer — boundary suite (FN-018)", () => {
       await issueKycTest(deps, {
         submission: sub,
         agentCardPubkey: CARD_A,
+        agentCardSignature: STUB_SIGNATURE,
       });
     } catch (err) {
       caught = err;
@@ -333,6 +368,7 @@ describe("kyc.us-test issuer — boundary suite (FN-018)", () => {
     const r1 = await issueKycTest(deps, {
       submission: sub1,
       agentCardPubkey: CARD_A,
+      agentCardSignature: STUB_SIGNATURE,
     });
     nowRef.value += 60;
     const sub2 = makeSubmission({
@@ -340,10 +376,12 @@ describe("kyc.us-test issuer — boundary suite (FN-018)", () => {
       fullName: "Bob Test",
       dobIso: "1991-02-02",
       flowStartedAtUnix: nowRef.value - KYC_TEST_MIN_DWELL_SECONDS,
+      agentCardPubkey: CARD_B,
     });
     const r2 = await issueKycTest(deps, {
       submission: sub2,
       agentCardPubkey: CARD_B,
+      agentCardSignature: STUB_SIGNATURE,
     });
     expect(r1.credentialPda).not.toBe(r2.credentialPda);
     expect(chain.calls).toHaveLength(2);
@@ -354,5 +392,171 @@ describe("kyc.us-test issuer — boundary suite (FN-018)", () => {
     const sub1Subj = vc1["credentialSubject"] as Record<string, unknown>;
     const sub2Subj = vc2["credentialSubject"] as Record<string, unknown>;
     expect(sub1Subj["bridgeNullifier"]).not.toBe(sub2Subj["bridgeNullifier"]);
+  });
+
+  /* ------------------------------------------------------------------ */
+  /* FN-057 — wallet-binding signature                                   */
+  /* ------------------------------------------------------------------ */
+
+  describe("FN-057: wallet-binding signature is required", () => {
+    const BASE58_ALPHABET =
+      "123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz";
+    function base58Encode(bytes: Uint8Array): string {
+      if (bytes.length === 0) return "";
+      let zeros = 0;
+      while (zeros < bytes.length && bytes[zeros] === 0) zeros += 1;
+      const digits: number[] = [];
+      for (let i = zeros; i < bytes.length; i += 1) {
+        let carry = bytes[i]!;
+        for (let j = 0; j < digits.length; j += 1) {
+          carry += digits[j]! << 8;
+          digits[j] = carry % 58;
+          carry = (carry / 58) | 0;
+        }
+        while (carry > 0) {
+          digits.push(carry % 58);
+          carry = (carry / 58) | 0;
+        }
+      }
+      let out = "";
+      for (let i = 0; i < zeros; i += 1) out += "1";
+      for (let i = digits.length - 1; i >= 0; i -= 1) {
+        out += BASE58_ALPHABET[digits[i]!]!;
+      }
+      return out;
+    }
+
+    interface Wallet {
+      readonly pubkey: string;
+      readonly rawPub: Uint8Array;
+      readonly privateKey: ReturnType<typeof createPrivateKey>;
+    }
+    function newWallet(): Wallet {
+      const { publicKey, privateKey } = generateKeyPairSync("ed25519");
+      const spki = publicKey.export({ format: "der", type: "spki" });
+      const raw = new Uint8Array(spki.subarray(spki.length - 32));
+      return { pubkey: base58Encode(raw), rawPub: raw, privateKey };
+    }
+    function signBinding(wallet: Wallet, nullifierHex: string): string {
+      const nullifierBytes = Buffer.from(nullifierHex, "hex");
+      const message = createHash("sha256")
+        .update(nullifierBytes)
+        .update(wallet.rawPub)
+        .digest();
+      return Buffer.from(
+        nodeSign(null, message, wallet.privateKey),
+      ).toString("base64");
+    }
+
+    function realDeps(opts?: { initialNow?: number }): BuiltStack {
+      const stack = kycDeps(opts);
+      // Swap the stub for the real Ed25519 verifier.
+      const realDepsObj: KycTestIssuerDeps = {
+        ...stack.deps,
+        signatureVerifier: ed25519KycTestSignatureVerifier,
+      };
+      return { ...stack, deps: realDepsObj };
+    }
+
+    it("rejects a request that supplies a victim's pubkey with the attacker's signature (HTTP 401)", async () => {
+      const stack = realDeps({ initialNow: 1_700_000_100 });
+      const { deps, chain, dedupe, nowRef } = stack;
+      const victim = newWallet();
+      const attacker = newWallet();
+
+      const submission = makeSubmission({
+        signer: deps.tokenSigner as HmacKycTestFormTokenSigner,
+        fullName: "Mallory Attacker",
+        dobIso: "1990-01-01",
+        flowStartedAtUnix: nowRef.value - KYC_TEST_MIN_DWELL_SECONDS,
+        // FN-057: HMAC is bound to the AgentCard the request claims;
+        // an attacker who legitimately rendered a form for victim.pubkey
+        // could capture it, but the wallet-binding signature still gates.
+        agentCardPubkey: victim.pubkey,
+      });
+      const nullifier = deriveNullifier(
+        normalizeName(submission.fullName),
+        submission.dobIso,
+      );
+      // Attacker can only sign for their OWN pubkey, but the request
+      // claims `agentCardPubkey = victim.pubkey`. The signature
+      // therefore validates as Ed25519 bytes but does NOT validate
+      // against `victim.pubkey` over `sha256(nullifier || victim.pubkey)`.
+      const attackerSig = signBinding(attacker, nullifier);
+
+      let caught: unknown;
+      try {
+        await issueKycTest(deps, {
+          submission,
+          agentCardPubkey: victim.pubkey,
+          agentCardSignature: attackerSig,
+        });
+      } catch (err) {
+        caught = err;
+      }
+      expect(caught).toBeInstanceOf(KycTestIssueError);
+      expect((caught as KycTestIssueError).kind).toBe(
+        "invalid_agent_card_signature",
+      );
+      // No chain submission, no dedupe row — the attacker cannot
+      // poison the victim's `(nullifier, card)` slot.
+      expect(chain.calls).toHaveLength(0);
+      expect(dedupe.rows.size).toBe(0);
+    });
+
+    it("accepts a request signed by the holder of agentCardPubkey", async () => {
+      const stack = realDeps({ initialNow: 1_700_000_100 });
+      const { deps, chain, nowRef } = stack;
+      const wallet = newWallet();
+
+      const submission = makeSubmission({
+        signer: deps.tokenSigner as HmacKycTestFormTokenSigner,
+        fullName: "Alice Honest",
+        dobIso: "1990-01-01",
+        flowStartedAtUnix: nowRef.value - KYC_TEST_MIN_DWELL_SECONDS,
+        agentCardPubkey: wallet.pubkey,
+      });
+      const nullifier = deriveNullifier(
+        normalizeName(submission.fullName),
+        submission.dobIso,
+      );
+      const sig = signBinding(wallet, nullifier);
+
+      const out = await issueKycTest(deps, {
+        submission,
+        agentCardPubkey: wallet.pubkey,
+        agentCardSignature: sig,
+      });
+      expect(out.status).toBe("issued");
+      expect(chain.calls).toHaveLength(1);
+      expect(chain.calls[0]?.subjectAgentCardPubkey).toBe(wallet.pubkey);
+    });
+
+    it("rejects a request with an empty signature", async () => {
+      const stack = realDeps({ initialNow: 1_700_000_100 });
+      const { deps, chain, nowRef } = stack;
+      const wallet = newWallet();
+
+      const submission = makeSubmission({
+        signer: deps.tokenSigner as HmacKycTestFormTokenSigner,
+        flowStartedAtUnix: nowRef.value - KYC_TEST_MIN_DWELL_SECONDS,
+        agentCardPubkey: wallet.pubkey,
+      });
+      let caught: unknown;
+      try {
+        await issueKycTest(deps, {
+          submission,
+          agentCardPubkey: wallet.pubkey,
+          agentCardSignature: "",
+        });
+      } catch (err) {
+        caught = err;
+      }
+      expect(caught).toBeInstanceOf(KycTestIssueError);
+      expect((caught as KycTestIssueError).kind).toBe(
+        "invalid_agent_card_signature",
+      );
+      expect(chain.calls).toHaveLength(0);
+    });
   });
 });

--- a/tests/issuers/kyc-test.test.ts
+++ b/tests/issuers/kyc-test.test.ts
@@ -1,0 +1,358 @@
+/**
+ * FN-018 — kyc.us-test issuer boundary suite.
+ *
+ * Mirrors the structure of `tests/issuers/worldcoin.test.ts`. Locks the
+ * four mandatory boundary cases against the real `KycTestIssueError`
+ * contract (every failure throws a typed error; no bare `Error`).
+ *
+ * NB on PII: this is the **mock** kyc.us-test issuer. It deliberately
+ * embeds `legalName` and `dateOfBirth` in `credentialSubject` because
+ * the credential is labeled `kyc.us-test` and exists for demo wiring
+ * only. The boundary invariant we lock here is therefore "the schema
+ * id, the bridge nullifier, and the kycLevel='mock-test' marker are
+ * all present so a relying party cannot mistake this for real KYC".
+ * See FN-018 follow-up FN-072 for the upgrade path.
+ */
+
+import { createHash } from "node:crypto";
+import { describe, expect, it } from "vitest";
+
+import {
+  HmacKycTestFormTokenSigner,
+  KYC_TEST_MIN_DWELL_SECONDS,
+  KYC_TEST_SCHEMA_ID_HEX,
+  KycTestIssueError,
+  buildKycTestVc,
+  deriveNullifier,
+  issueKycTest,
+  jcsCanonicalize,
+  normalizeName,
+} from "../../src/issuers/kyc-test.js";
+import type {
+  KycTestDedupeRow,
+  KycTestDedupeStore,
+  KycTestFormSubmission,
+  KycTestIssueCredentialClient,
+  KycTestIssuerDeps,
+  KycTestSlotClock,
+  KycTestVcPinner,
+} from "../../src/issuers/kyc-test.types.js";
+
+/* -------------------------------------------------------------------------- */
+/* Fixtures                                                                    */
+/* -------------------------------------------------------------------------- */
+
+const CARD_A = "AgentCardAaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+const CARD_B = "AgentCardBbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb";
+const ISSUER = "IssuerAuthorityyyyyyyyyyyyyyyyyyyyyyyyyy";
+const SECRET = Buffer.from("0123456789abcdef0123456789abcdef", "utf8");
+
+class MemoryDedupe implements KycTestDedupeStore {
+  public readonly rows = new Map<string, KycTestDedupeRow>();
+  async get(nullifier: string): Promise<KycTestDedupeRow | undefined> {
+    return this.rows.get(nullifier);
+  }
+  async putIfAbsent(row: KycTestDedupeRow): Promise<KycTestDedupeRow> {
+    const existing = this.rows.get(row.nullifier);
+    if (existing) return existing;
+    this.rows.set(row.nullifier, row);
+    return row;
+  }
+}
+
+interface ChainCall {
+  subjectAgentCardPubkey: string;
+  schemaIdHex: string;
+  claimUri: string;
+  claimHashHex: string;
+  validFromSlot: bigint;
+  validUntilSlot: bigint;
+}
+
+class StubChain implements KycTestIssueCredentialClient {
+  public readonly calls: ChainCall[] = [];
+
+  async issueCredential(
+    input: ChainCall,
+  ): Promise<{ credentialPda: string; txSignature: string }> {
+    this.calls.push(input);
+    const idx = this.calls.length;
+    return {
+      credentialPda: `pda_${idx}_${input.subjectAgentCardPubkey.slice(0, 8)}`,
+      txSignature: `sig_${idx}`,
+    };
+  }
+}
+
+class StubPinner implements KycTestVcPinner {
+  public readonly pinned: string[] = [];
+  async pin(json: string): Promise<{ uri: string }> {
+    this.pinned.push(json);
+    return { uri: `ipfs://stub/${this.pinned.length}` };
+  }
+  /** Decode-by-uri helper for assertions. */
+  fetch(uri: string): Record<string, unknown> {
+    const idx = Number(uri.replace("ipfs://stub/", ""));
+    const json = this.pinned[idx - 1];
+    if (json === undefined) throw new Error(`unknown uri: ${uri}`);
+    return JSON.parse(json) as Record<string, unknown>;
+  }
+}
+
+class FixedClock implements KycTestSlotClock {
+  public constructor(private readonly slot: bigint) {}
+  async currentSlot(): Promise<bigint> {
+    return this.slot;
+  }
+}
+
+interface BuiltStack {
+  readonly deps: KycTestIssuerDeps;
+  readonly chain: StubChain;
+  readonly pinner: StubPinner;
+  readonly dedupe: MemoryDedupe;
+  readonly signer: HmacKycTestFormTokenSigner;
+  readonly nowRef: { value: number };
+}
+
+function kycDeps(opts?: { initialNow?: number }): BuiltStack {
+  const signer = new HmacKycTestFormTokenSigner(SECRET);
+  const dedupe = new MemoryDedupe();
+  const chain = new StubChain();
+  const pinner = new StubPinner();
+  const nowRef = { value: opts?.initialNow ?? 1_700_000_000 };
+  const deps: KycTestIssuerDeps = {
+    tokenSigner: signer,
+    dedupe,
+    chain,
+    pinner,
+    clock: new FixedClock(123_456n),
+    issuerAuthorityPubkey: ISSUER,
+    nowUnix: () => nowRef.value,
+  };
+  return { deps, chain, pinner, dedupe, signer, nowRef };
+}
+
+function makeSubmission(opts: {
+  readonly signer: HmacKycTestFormTokenSigner;
+  readonly fullName?: string;
+  readonly dobIso?: string;
+  readonly flowStartedAtUnix: number;
+  readonly tagOverride?: string;
+}): KycTestFormSubmission {
+  const fullName = opts.fullName ?? "Test User";
+  const dobIso = opts.dobIso ?? "1990-01-01";
+  const tag =
+    opts.tagOverride ??
+    opts.signer.sign({
+      fullName,
+      dobIso,
+      flowStartedAtUnix: opts.flowStartedAtUnix,
+    });
+  return {
+    fullName,
+    dobIso,
+    flowStartedAtUnix: opts.flowStartedAtUnix,
+    formTokenHmacHex: tag,
+  };
+}
+
+/* -------------------------------------------------------------------------- */
+/* Tests                                                                       */
+/* -------------------------------------------------------------------------- */
+
+describe("kyc.us-test issuer — boundary suite (FN-018)", () => {
+  it("happy issuance: status=issued, schema and PDA bind to the caller", async () => {
+    const { deps, chain, pinner, nowRef } = kycDeps({
+      initialNow: 1_700_000_100,
+    });
+    const submission = makeSubmission({
+      signer: deps.tokenSigner as HmacKycTestFormTokenSigner,
+      flowStartedAtUnix: nowRef.value - KYC_TEST_MIN_DWELL_SECONDS,
+    });
+    const out = await issueKycTest(deps, {
+      submission,
+      agentCardPubkey: CARD_A,
+    });
+
+    expect(out.status).toBe("issued");
+    if (out.status !== "issued") return; // type narrow
+    expect(out.claimHashHex).toMatch(/^[0-9a-f]{64}$/);
+    expect(chain.calls).toHaveLength(1);
+    expect(chain.calls[0]?.schemaIdHex).toBe(KYC_TEST_SCHEMA_ID_HEX);
+    // Lock subject provenance: caller-supplied, not store-derived.
+    expect(chain.calls[0]?.subjectAgentCardPubkey).toBe(CARD_A);
+    expect(chain.calls[0]?.validUntilSlot).toBe(0n);
+    expect(out.nullifier).toBe(deriveNullifier(normalizeName("Test User"), "1990-01-01"));
+
+    // claimHashHex equals sha256(JCS(VC envelope))
+    const vc = pinner.fetch(out.claimUri);
+    expect(out.claimHashHex).toBe(
+      createHash("sha256").update(jcsCanonicalize(vc)).digest("hex"),
+    );
+
+    // issuanceDate is set
+    expect(typeof vc["issuanceDate"]).toBe("string");
+  });
+
+  it("replay (same identity, same card): status=idempotent — no second chain tx", async () => {
+    const { deps, chain, nowRef } = kycDeps({ initialNow: 1_700_000_100 });
+    const sub = makeSubmission({
+      signer: deps.tokenSigner as HmacKycTestFormTokenSigner,
+      flowStartedAtUnix: nowRef.value - KYC_TEST_MIN_DWELL_SECONDS,
+    });
+    const r1 = await issueKycTest(deps, {
+      submission: sub,
+      agentCardPubkey: CARD_A,
+    });
+    const r2 = await issueKycTest(deps, {
+      submission: sub,
+      agentCardPubkey: CARD_A,
+    });
+    expect(r1.status).toBe("issued");
+    expect(r2.status).toBe("idempotent");
+    expect(r2.credentialPda).toBe(r1.credentialPda);
+    expect(chain.calls).toHaveLength(1);
+  });
+
+  it("replay (same identity, DIFFERENT card): throws KycTestIssueError(replay_conflict)", async () => {
+    const { deps, chain, nowRef } = kycDeps({ initialNow: 1_700_000_100 });
+    const sub = makeSubmission({
+      signer: deps.tokenSigner as HmacKycTestFormTokenSigner,
+      flowStartedAtUnix: nowRef.value - KYC_TEST_MIN_DWELL_SECONDS,
+    });
+    await issueKycTest(deps, { submission: sub, agentCardPubkey: CARD_A });
+
+    let caught: unknown;
+    try {
+      await issueKycTest(deps, {
+        submission: sub,
+        agentCardPubkey: CARD_B,
+      });
+    } catch (err) {
+      caught = err;
+    }
+    expect(caught).toBeInstanceOf(KycTestIssueError);
+    expect((caught as KycTestIssueError).kind).toBe("replay_conflict");
+    expect(chain.calls).toHaveLength(1);
+  });
+
+  it("tampered form-token HMAC: throws KycTestIssueError(invalid_token); chain not called", async () => {
+    const { deps, chain, nowRef } = kycDeps({ initialNow: 1_700_000_100 });
+    const sub = makeSubmission({
+      signer: deps.tokenSigner as HmacKycTestFormTokenSigner,
+      flowStartedAtUnix: nowRef.value - KYC_TEST_MIN_DWELL_SECONDS,
+    });
+    // Flip one hex char; HMAC verify must fail with a typed error.
+    const tampered = {
+      ...sub,
+      formTokenHmacHex:
+        sub.formTokenHmacHex[0] === "0"
+          ? `1${sub.formTokenHmacHex.slice(1)}`
+          : `0${sub.formTokenHmacHex.slice(1)}`,
+    };
+    let caught: unknown;
+    try {
+      await issueKycTest(deps, {
+        submission: tampered,
+        agentCardPubkey: CARD_A,
+      });
+    } catch (err) {
+      caught = err;
+    }
+    expect(caught).toBeInstanceOf(KycTestIssueError);
+    expect((caught as KycTestIssueError).kind).toBe("invalid_token");
+    expect(chain.calls).toHaveLength(0);
+  });
+
+  it("expiry (dwell-too-short): throws KycTestIssueError(dwell_too_short); chain not called", async () => {
+    const { deps, chain, nowRef } = kycDeps({ initialNow: 1_700_000_100 });
+    // Submit BEFORE the minimum dwell elapses.
+    const sub = makeSubmission({
+      signer: deps.tokenSigner as HmacKycTestFormTokenSigner,
+      flowStartedAtUnix: nowRef.value - 1,
+    });
+    let caught: unknown;
+    try {
+      await issueKycTest(deps, {
+        submission: sub,
+        agentCardPubkey: CARD_A,
+      });
+    } catch (err) {
+      caught = err;
+    }
+    expect(caught).toBeInstanceOf(KycTestIssueError);
+    expect((caught as KycTestIssueError).kind).toBe("dwell_too_short");
+    expect(chain.calls).toHaveLength(0);
+  });
+
+  it("VC envelope shape: locks the kyc.us-test fields (mock-issuer self-disclosure)", async () => {
+    // The kyc.us-test mock embeds `legalName` and `dateOfBirth` *by
+    // design* (it has only name+DOB to work with) and labels itself
+    // `kycLevel: "mock-test"` so a relying party cannot mistake it
+    // for real KYC. We pin the exact field set so any future change
+    // either flows through this test (and the spec) or tightens the
+    // contract on purpose. See FN-018 follow-up FN-072 for the
+    // hash-the-PII upgrade path.
+    const vc = buildKycTestVc({
+      agentCardPubkey: CARD_A,
+      issuerAuthorityPubkey: ISSUER,
+      fullName: normalizeName("Test User"),
+      dobIso: "1990-01-01",
+      nullifier: "00".repeat(32),
+      issuanceDate: "2026-04-29T00:00:00.000Z",
+    });
+    const subj = vc["credentialSubject"] as Record<string, unknown>;
+    expect(Object.keys(subj).sort()).toEqual([
+      "bridgeNullifier",
+      "dateOfBirth",
+      "id",
+      "kycJurisdiction",
+      "kycLevel",
+      "legalName",
+    ]);
+    // The "this is a mock" self-disclosure that downstream relying
+    // parties pin on:
+    expect(subj["kycLevel"]).toBe("mock-test");
+    expect(subj["kycJurisdiction"]).toBe("us-test");
+    // `id` is derived from caller-supplied AgentCardPubkey, not the
+    // dedupe store — defends against a regression in subject derivation.
+    expect(subj["id"]).toBe(`did:eto:agentcard:${CARD_A}`);
+  });
+
+  it("emits unique credentials across two independent issuances", async () => {
+    const { deps, chain, pinner, nowRef } = kycDeps({
+      initialNow: 1_700_000_100,
+    });
+    const sub1 = makeSubmission({
+      signer: deps.tokenSigner as HmacKycTestFormTokenSigner,
+      fullName: "Alice Test",
+      dobIso: "1990-01-01",
+      flowStartedAtUnix: nowRef.value - KYC_TEST_MIN_DWELL_SECONDS,
+    });
+    const r1 = await issueKycTest(deps, {
+      submission: sub1,
+      agentCardPubkey: CARD_A,
+    });
+    nowRef.value += 60;
+    const sub2 = makeSubmission({
+      signer: deps.tokenSigner as HmacKycTestFormTokenSigner,
+      fullName: "Bob Test",
+      dobIso: "1991-02-02",
+      flowStartedAtUnix: nowRef.value - KYC_TEST_MIN_DWELL_SECONDS,
+    });
+    const r2 = await issueKycTest(deps, {
+      submission: sub2,
+      agentCardPubkey: CARD_B,
+    });
+    expect(r1.credentialPda).not.toBe(r2.credentialPda);
+    expect(chain.calls).toHaveLength(2);
+    const vc1 = pinner.fetch(r1.claimUri);
+    const vc2 = pinner.fetch(r2.claimUri);
+    expect(vc1["issuanceDate"]).not.toBe(vc2["issuanceDate"]);
+    // Per-VC unique identifier: `bridgeNullifier`.
+    const sub1Subj = vc1["credentialSubject"] as Record<string, unknown>;
+    const sub2Subj = vc2["credentialSubject"] as Record<string, unknown>;
+    expect(sub1Subj["bridgeNullifier"]).not.toBe(sub2Subj["bridgeNullifier"]);
+  });
+});

--- a/tests/issuers/skill-cert.test.ts
+++ b/tests/issuers/skill-cert.test.ts
@@ -25,13 +25,33 @@ import {
   sha256Hex,
 } from "../../src/issuers/skill-cert.js";
 import type {
+  AgentCardSignatureVerifier,
   ChainClient,
   IpfsPinner,
   IssueCredentialArgs,
   IssueCredentialResult,
   SkillBinding,
   SkillBindingStore,
+  SkillCertIssueRequest,
 } from "../../src/issuers/skill-cert.types.js";
+
+const acceptAllSignatureVerifier: AgentCardSignatureVerifier = {
+  async verify() {
+    return true;
+  },
+};
+
+function req(
+  skill: string,
+  subjectAgentCard: string,
+): SkillCertIssueRequest {
+  return {
+    skill,
+    subjectAgentCard,
+    agentCardSignature: "AA",
+    issuanceNonce: "nonce",
+  };
+}
 
 /* -------------------------------------------------------------------------- */
 /* Fakes                                                                       */
@@ -103,7 +123,14 @@ function buildIssuer(opts?: {
   const now = opts?.now ?? (() => Date.UTC(2026, 3, 29, 12, 0, 0));
   const issuer = new SkillCertIssuer(
     { issuerDid: ISSUER_DID },
-    { whitelist, bindingStore, chain, ipfs, now },
+    {
+      whitelist,
+      bindingStore,
+      chain,
+      ipfs,
+      signatureVerifier: acceptAllSignatureVerifier,
+      now,
+    },
   );
   return { issuer, whitelist, bindingStore, chain, ipfs };
 }
@@ -115,10 +142,7 @@ function buildIssuer(opts?: {
 describe("skill-cert issuer — boundary suite (FN-018)", () => {
   it("happy issuance: schema=schemaIdForSkill(skill), idempotent=false, VC type set", async () => {
     const { issuer, chain, ipfs } = buildIssuer();
-    const out = await issuer.issue({
-      skill: "solidity-audit",
-      subjectAgentCard: SUBJECT_A,
-    });
+    const out = await issuer.issue(req("solidity-audit", SUBJECT_A));
 
     expect(out.idempotent).toBe(false);
     expect(out.schema).toBe(schemaIdForSkill("solidity-audit"));
@@ -139,14 +163,8 @@ describe("skill-cert issuer — boundary suite (FN-018)", () => {
 
   it("replay (same skill+subject): second issue() returns idempotent with same PDA", async () => {
     const { issuer, chain } = buildIssuer();
-    const r1 = await issuer.issue({
-      skill: "solidity-audit",
-      subjectAgentCard: SUBJECT_A,
-    });
-    const r2 = await issuer.issue({
-      skill: "solidity-audit",
-      subjectAgentCard: SUBJECT_A,
-    });
+    const r1 = await issuer.issue(req("solidity-audit", SUBJECT_A));
+    const r2 = await issuer.issue(req("solidity-audit", SUBJECT_A));
     expect(r1.idempotent).toBe(false);
     expect(r2.idempotent).toBe(true);
     expect(r2.credentialPda).toBe(r1.credentialPda);
@@ -155,14 +173,8 @@ describe("skill-cert issuer — boundary suite (FN-018)", () => {
 
   it("replay (same skill, DIFFERENT subject): independent fresh issuance, new PDA", async () => {
     const { issuer, chain } = buildIssuer();
-    const r1 = await issuer.issue({
-      skill: "solidity-audit",
-      subjectAgentCard: SUBJECT_A,
-    });
-    const r2 = await issuer.issue({
-      skill: "solidity-audit",
-      subjectAgentCard: SUBJECT_B,
-    });
+    const r1 = await issuer.issue(req("solidity-audit", SUBJECT_A));
+    const r2 = await issuer.issue(req("solidity-audit", SUBJECT_B));
     expect(r1.idempotent).toBe(false);
     expect(r2.idempotent).toBe(false);
     expect(r1.credentialPda).not.toBe(r2.credentialPda);
@@ -202,10 +214,7 @@ describe("skill-cert issuer — boundary suite (FN-018)", () => {
       },
     };
     const { issuer, chain } = buildIssuer({ bindingStore: racingStore });
-    const out = await issuer.issue({
-      skill: "solidity-audit",
-      subjectAgentCard: SUBJECT_A,
-    });
+    const out = await issuer.issue(req("solidity-audit", SUBJECT_A));
     expect(out.idempotent).toBe(true);
     expect(out.credentialPda).toBe(canonical.credentialPda);
     expect(out.claimHash).toBe(canonical.claimHash);
@@ -219,10 +228,7 @@ describe("skill-cert issuer — boundary suite (FN-018)", () => {
     // over the pinned envelope MUST equal the on-chain claim_hash. A
     // mutation breaks the equality.
     const { issuer, ipfs, chain } = buildIssuer();
-    const out = await issuer.issue({
-      skill: "solidity-audit",
-      subjectAgentCard: SUBJECT_A,
-    });
+    const out = await issuer.issue(req("solidity-audit", SUBJECT_A));
     const vc = ipfs.fetch(out.claimUri) as Record<string, unknown>;
     expect(out.claimHash).toBe(sha256Hex(canonicalJson(vc)));
     expect(chain.accounts.get(out.credentialPda)?.claimHash).toBe(
@@ -241,10 +247,7 @@ describe("skill-cert issuer — boundary suite (FN-018)", () => {
     const { issuer, chain } = buildIssuer();
     let caught: unknown;
     try {
-      await issuer.issue({
-        skill: "solidity-audit",
-        subjectAgentCard: "AgentCardForbiddenZZZZZZZZZZZZZZZZZZZZZZZZZZ",
-      });
+      await issuer.issue(req("solidity-audit", "AgentCardForbiddenZZZZZZZZZZZZZZZZZZZZZZZZZZ"));
     } catch (err) {
       caught = err;
     }
@@ -258,10 +261,7 @@ describe("skill-cert issuer — boundary suite (FN-018)", () => {
     const { issuer, chain } = buildIssuer();
     let caught: unknown;
     try {
-      await issuer.issue({
-        skill: "Bad Slug!",
-        subjectAgentCard: SUBJECT_A,
-      });
+      await issuer.issue(req("Bad Slug!", SUBJECT_A));
     } catch (err) {
       caught = err;
     }
@@ -275,7 +275,7 @@ describe("skill-cert issuer — boundary suite (FN-018)", () => {
     const { issuer, chain } = buildIssuer();
     let caught: unknown;
     try {
-      await issuer.issue({ skill: "solidity-audit", subjectAgentCard: "" });
+      await issuer.issue(req("solidity-audit", "" ));
     } catch (err) {
       caught = err;
     }
@@ -287,15 +287,9 @@ describe("skill-cert issuer — boundary suite (FN-018)", () => {
   it("emits unique credentials across two independent issuances", async () => {
     let now = Date.UTC(2026, 3, 29, 12, 0, 0);
     const { issuer, chain, ipfs } = buildIssuer({ now: () => now });
-    const r1 = await issuer.issue({
-      skill: "solidity-audit",
-      subjectAgentCard: SUBJECT_A,
-    });
+    const r1 = await issuer.issue(req("solidity-audit", SUBJECT_A));
     now += 60_000;
-    const r2 = await issuer.issue({
-      skill: "data-analyze",
-      subjectAgentCard: SUBJECT_A,
-    });
+    const r2 = await issuer.issue(req("data-analyze", SUBJECT_A));
     expect(r1.credentialPda).not.toBe(r2.credentialPda);
     expect(chain.calls).toHaveLength(2);
     const vc1 = ipfs.fetch(r1.claimUri) as Record<string, unknown>;

--- a/tests/issuers/skill-cert.test.ts
+++ b/tests/issuers/skill-cert.test.ts
@@ -1,0 +1,316 @@
+/**
+ * FN-018 — skill-cert issuer boundary suite.
+ *
+ * No-signature issuer: tampered-signature is N/A. We substitute the
+ * tampered-envelope invariant from the PROMPT — mutate the pinned VC,
+ * recompute `sha256(jcs(...))`, and assert the mutated hash diverges
+ * from the on-chain `claim_hash`. This is the boundary contract a
+ * verifier walks under the no-signature issuer model.
+ *
+ * Expiry is N/A on this issuer: skill-cert hard-codes
+ * `validUntilSlot = 0n` per L1 §5.1; expiry is an on-chain concern,
+ * not an issuer-side one. Documented and omitted.
+ */
+
+import { createHash } from "node:crypto";
+import { describe, expect, it } from "vitest";
+
+import {
+  InMemorySkillBindingStore,
+  SkillCertIssuer,
+  SkillCertIssuerError,
+  StaticSkillWhitelist,
+  canonicalJson,
+  schemaIdForSkill,
+  sha256Hex,
+} from "../../src/issuers/skill-cert.js";
+import type {
+  ChainClient,
+  IpfsPinner,
+  IssueCredentialArgs,
+  IssueCredentialResult,
+  SkillBinding,
+  SkillBindingStore,
+} from "../../src/issuers/skill-cert.types.js";
+
+/* -------------------------------------------------------------------------- */
+/* Fakes                                                                       */
+/* -------------------------------------------------------------------------- */
+
+class MockChainLedger implements ChainClient {
+  public readonly calls: IssueCredentialArgs[] = [];
+  public readonly accounts = new Map<
+    string,
+    { schema: string; subject: string; claimHash: string; claimUri: string }
+  >();
+
+  async issueCredential(
+    args: IssueCredentialArgs,
+  ): Promise<IssueCredentialResult> {
+    this.calls.push(args);
+    const idx = this.calls.length;
+    const pda = `pda_${idx}_${args.subjectAgentCard.slice(0, 6)}`;
+    this.accounts.set(pda, {
+      schema: args.schema,
+      subject: args.subjectAgentCard,
+      claimHash: args.claimHash,
+      claimUri: args.claimUri,
+    });
+    return {
+      credentialPda: pda,
+      txSignature: `tx_${idx.toString().padStart(4, "0")}`,
+    };
+  }
+}
+
+class MockIpfs implements IpfsPinner {
+  public readonly store = new Map<string, unknown>();
+  async pinJson(value: unknown): Promise<string> {
+    const cid = sha256Hex(canonicalJson(value)).slice(0, 46);
+    this.store.set(cid, value);
+    return `ipfs://${cid}`;
+  }
+  fetch(uri: string): unknown {
+    return this.store.get(uri.replace("ipfs://", ""));
+  }
+}
+
+const ISSUER_DID = "did:eto:skill-cert";
+const SUBJECT_A = "AgentCardA1111111111111111111111111111111111";
+const SUBJECT_B = "AgentCardB2222222222222222222222222222222222";
+
+function buildIssuer(opts?: {
+  readonly whitelist?: StaticSkillWhitelist;
+  readonly bindingStore?: SkillBindingStore;
+  readonly chain?: MockChainLedger;
+  readonly now?: () => number;
+}): {
+  issuer: SkillCertIssuer;
+  whitelist: StaticSkillWhitelist;
+  bindingStore: SkillBindingStore;
+  chain: MockChainLedger;
+  ipfs: MockIpfs;
+} {
+  const whitelist =
+    opts?.whitelist ??
+    new StaticSkillWhitelist({
+      "solidity-audit": [SUBJECT_A, SUBJECT_B],
+      "data-analyze": [SUBJECT_A],
+    });
+  const bindingStore = opts?.bindingStore ?? new InMemorySkillBindingStore();
+  const chain = opts?.chain ?? new MockChainLedger();
+  const ipfs = new MockIpfs();
+  const now = opts?.now ?? (() => Date.UTC(2026, 3, 29, 12, 0, 0));
+  const issuer = new SkillCertIssuer(
+    { issuerDid: ISSUER_DID },
+    { whitelist, bindingStore, chain, ipfs, now },
+  );
+  return { issuer, whitelist, bindingStore, chain, ipfs };
+}
+
+/* -------------------------------------------------------------------------- */
+/* Tests                                                                       */
+/* -------------------------------------------------------------------------- */
+
+describe("skill-cert issuer — boundary suite (FN-018)", () => {
+  it("happy issuance: schema=schemaIdForSkill(skill), idempotent=false, VC type set", async () => {
+    const { issuer, chain, ipfs } = buildIssuer();
+    const out = await issuer.issue({
+      skill: "solidity-audit",
+      subjectAgentCard: SUBJECT_A,
+    });
+
+    expect(out.idempotent).toBe(false);
+    expect(out.schema).toBe(schemaIdForSkill("solidity-audit"));
+    expect(chain.calls).toHaveLength(1);
+    expect(chain.calls[0]?.schema).toBe(schemaIdForSkill("solidity-audit"));
+    // Lock subject provenance: caller-supplied, not store-derived.
+    expect(chain.calls[0]?.subjectAgentCard).toBe(SUBJECT_A);
+    expect(chain.calls[0]?.validUntilSlot).toBe(0n);
+
+    const vc = ipfs.fetch(out.claimUri) as Record<string, unknown>;
+    expect(vc["type"]).toEqual([
+      "VerifiableCredential",
+      "SkillCertCredential",
+    ]);
+    expect(typeof vc["issuanceDate"]).toBe("string");
+    expect(out.claimHash).toBe(sha256Hex(canonicalJson(vc)));
+  });
+
+  it("replay (same skill+subject): second issue() returns idempotent with same PDA", async () => {
+    const { issuer, chain } = buildIssuer();
+    const r1 = await issuer.issue({
+      skill: "solidity-audit",
+      subjectAgentCard: SUBJECT_A,
+    });
+    const r2 = await issuer.issue({
+      skill: "solidity-audit",
+      subjectAgentCard: SUBJECT_A,
+    });
+    expect(r1.idempotent).toBe(false);
+    expect(r2.idempotent).toBe(true);
+    expect(r2.credentialPda).toBe(r1.credentialPda);
+    expect(chain.calls).toHaveLength(1);
+  });
+
+  it("replay (same skill, DIFFERENT subject): independent fresh issuance, new PDA", async () => {
+    const { issuer, chain } = buildIssuer();
+    const r1 = await issuer.issue({
+      skill: "solidity-audit",
+      subjectAgentCard: SUBJECT_A,
+    });
+    const r2 = await issuer.issue({
+      skill: "solidity-audit",
+      subjectAgentCard: SUBJECT_B,
+    });
+    expect(r1.idempotent).toBe(false);
+    expect(r2.idempotent).toBe(false);
+    expect(r1.credentialPda).not.toBe(r2.credentialPda);
+    expect(chain.calls).toHaveLength(2);
+  });
+
+  it("binding-store race: lost put recovers via canonical row → idempotent", async () => {
+    // Simulate the race documented in `skill-cert.ts` step 6:
+    //   - `get` returns undefined (no pre-existing row),
+    //   - chain.issueCredential succeeds,
+    //   - `put` throws because a concurrent caller landed first,
+    //   - the issuer recovers by re-`get`ing and returning the
+    //     canonical row with `idempotent: true`.
+    const canonical: SkillBinding = {
+      skill: "solidity-audit",
+      subjectAgentCard: SUBJECT_A,
+      credentialPda: "canonical-pda",
+      txSignature: "canonical-sig",
+      claimUri: "ipfs://canonical",
+      claimHash: "ff".repeat(32),
+      issuedAtMs: Date.UTC(2026, 3, 29),
+    };
+    let getCalls = 0;
+    const racingStore: SkillBindingStore = {
+      async get(skill, subject) {
+        getCalls += 1;
+        // First call (idempotency pre-check): pretend no row exists.
+        if (getCalls === 1) return undefined;
+        // Recovery `get` (after `put` collision): canonical row.
+        if (skill === canonical.skill && subject === canonical.subjectAgentCard) {
+          return canonical;
+        }
+        return undefined;
+      },
+      async put() {
+        throw new Error("simulated race: row already exists");
+      },
+    };
+    const { issuer, chain } = buildIssuer({ bindingStore: racingStore });
+    const out = await issuer.issue({
+      skill: "solidity-audit",
+      subjectAgentCard: SUBJECT_A,
+    });
+    expect(out.idempotent).toBe(true);
+    expect(out.credentialPda).toBe(canonical.credentialPda);
+    expect(out.claimHash).toBe(canonical.claimHash);
+    // Chain WAS called once before the race surfaced.
+    expect(chain.calls).toHaveLength(1);
+  });
+
+  it("tampered envelope (no-signature issuer): mutated VC hash differs from chain claim_hash", async () => {
+    // skill-cert has no signature path; the boundary invariant under
+    // the no-signature contract is: the JCS hash a verifier computes
+    // over the pinned envelope MUST equal the on-chain claim_hash. A
+    // mutation breaks the equality.
+    const { issuer, ipfs, chain } = buildIssuer();
+    const out = await issuer.issue({
+      skill: "solidity-audit",
+      subjectAgentCard: SUBJECT_A,
+    });
+    const vc = ipfs.fetch(out.claimUri) as Record<string, unknown>;
+    expect(out.claimHash).toBe(sha256Hex(canonicalJson(vc)));
+    expect(chain.accounts.get(out.credentialPda)?.claimHash).toBe(
+      out.claimHash,
+    );
+
+    const mutated = { ...vc, issuer: "did:eto:other-issuer" };
+    const mutatedHash = sha256Hex(canonicalJson(mutated));
+    expect(mutatedHash).not.toBe(out.claimHash);
+  });
+
+  // NB: skill-cert hard-codes valid_until_slot = 0; expiry is an
+  // on-chain concern. No expiry case here.
+
+  it("non-whitelisted subject: SkillCertIssuerError(NOT_WHITELISTED, 403); chain not called", async () => {
+    const { issuer, chain } = buildIssuer();
+    let caught: unknown;
+    try {
+      await issuer.issue({
+        skill: "solidity-audit",
+        subjectAgentCard: "AgentCardForbiddenZZZZZZZZZZZZZZZZZZZZZZZZZZ",
+      });
+    } catch (err) {
+      caught = err;
+    }
+    expect(caught).toBeInstanceOf(SkillCertIssuerError);
+    expect((caught as SkillCertIssuerError).code).toBe("NOT_WHITELISTED");
+    expect((caught as SkillCertIssuerError).status).toBe(403);
+    expect(chain.calls).toHaveLength(0);
+  });
+
+  it("invalid skill slug: SkillCertIssuerError(INVALID_SKILL, 400); chain not called", async () => {
+    const { issuer, chain } = buildIssuer();
+    let caught: unknown;
+    try {
+      await issuer.issue({
+        skill: "Bad Slug!",
+        subjectAgentCard: SUBJECT_A,
+      });
+    } catch (err) {
+      caught = err;
+    }
+    expect(caught).toBeInstanceOf(SkillCertIssuerError);
+    expect((caught as SkillCertIssuerError).code).toBe("INVALID_SKILL");
+    expect((caught as SkillCertIssuerError).status).toBe(400);
+    expect(chain.calls).toHaveLength(0);
+  });
+
+  it("empty subject: SkillCertIssuerError(INVALID_SUBJECT, 400); chain not called", async () => {
+    const { issuer, chain } = buildIssuer();
+    let caught: unknown;
+    try {
+      await issuer.issue({ skill: "solidity-audit", subjectAgentCard: "" });
+    } catch (err) {
+      caught = err;
+    }
+    expect(caught).toBeInstanceOf(SkillCertIssuerError);
+    expect((caught as SkillCertIssuerError).code).toBe("INVALID_SUBJECT");
+    expect(chain.calls).toHaveLength(0);
+  });
+
+  it("emits unique credentials across two independent issuances", async () => {
+    let now = Date.UTC(2026, 3, 29, 12, 0, 0);
+    const { issuer, chain, ipfs } = buildIssuer({ now: () => now });
+    const r1 = await issuer.issue({
+      skill: "solidity-audit",
+      subjectAgentCard: SUBJECT_A,
+    });
+    now += 60_000;
+    const r2 = await issuer.issue({
+      skill: "data-analyze",
+      subjectAgentCard: SUBJECT_A,
+    });
+    expect(r1.credentialPda).not.toBe(r2.credentialPda);
+    expect(chain.calls).toHaveLength(2);
+    const vc1 = ipfs.fetch(r1.claimUri) as Record<string, unknown>;
+    const vc2 = ipfs.fetch(r2.claimUri) as Record<string, unknown>;
+    expect(vc1["issuanceDate"]).not.toBe(vc2["issuanceDate"]);
+    expect(r1.schema).not.toBe(r2.schema);
+  });
+});
+
+/* Sanity: the schema-id helper is stable across calls. */
+describe("skill-cert schemaIdForSkill (regression pin)", () => {
+  it("matches sha256('eto.beckn.schema.skill-cert.<skill>.v1')", () => {
+    const expected = createHash("sha256")
+      .update("eto.beckn.schema.skill-cert.solidity-audit.v1", "utf8")
+      .digest("hex");
+    expect(schemaIdForSkill("solidity-audit")).toBe(expected);
+  });
+});

--- a/tests/models/agent-identity.test.ts
+++ b/tests/models/agent-identity.test.ts
@@ -115,6 +115,9 @@ describe("buildInterimAgentIdentity", () => {
         model_id: "claude-sonnet-4-5",
         kid: "kid-1",
         issued_at: 1_730_000_000,
+        source: "provider_oidc" as const,
+        provider_verified: true,
+        jws: "eyJhbGciOiJFZERTQSJ9.e30.sig",
       },
       environment: {
         surface: "sse",
@@ -130,5 +133,51 @@ describe("buildInterimAgentIdentity", () => {
     } satisfies AgentIdentity;
 
     expect(literal.human_authority.kind).toBe("thirdweb");
+  });
+
+  it("emits source=session_signed verified attestation when verified_session_jws is supplied", () => {
+    const jws = "eyJhbGciOiJFZERTQSJ9.e30.sessionSig";
+    const id = buildInterimAgentIdentity(
+      baseInput({
+        verified_session_jws: {
+          jws,
+          sub: "model-subject-id",
+          model_id: "claude-opus-4-7",
+          provider: "anthropic",
+          exp: 1_800_000_000,
+        },
+      }),
+    );
+
+    expect(id.model_attestation.attestation_status).toBe("verified");
+    if (id.model_attestation.attestation_status === "verified") {
+      expect(id.model_attestation.source).toBe("session_signed");
+      expect(id.model_attestation.provider_verified).toBe(false);
+      expect(id.model_attestation.provider).toBe("anthropic");
+      expect(id.model_attestation.model_id).toBe("claude-opus-4-7");
+      expect(id.model_attestation.jws).toBe(jws);
+      expect(id.model_attestation.kid).toBe("model-subject-id");
+      expect(id.model_attestation.issued_at).toBe(1_800_000_000);
+    }
+  });
+
+  it("verified_session_jws takes precedence over declared_model", () => {
+    const id = buildInterimAgentIdentity(
+      baseInput({
+        verified_session_jws: {
+          jws: "eyJ.e30.sig",
+          sub: "sub-1",
+          model_id: "claude-haiku-4-5",
+          provider: "anthropic",
+          exp: 1_900_000_000,
+        },
+        declared_model: { provider: "openai", model_id: "gpt-4o" },
+      }),
+    );
+
+    expect(id.model_attestation.attestation_status).toBe("verified");
+    if (id.model_attestation.attestation_status === "verified") {
+      expect(id.model_attestation.model_id).toBe("claude-haiku-4-5");
+    }
   });
 });

--- a/tests/models/agent-identity.test.ts
+++ b/tests/models/agent-identity.test.ts
@@ -1,0 +1,134 @@
+import { describe, it, expect } from "vitest";
+import {
+  buildInterimAgentIdentity,
+  type AgentIdentity,
+  type InterimAgentIdentityInput,
+} from "../../src/models/agent-identity.js";
+
+function baseInput(overrides: Partial<InterimAgentIdentityInput> = {}): InterimAgentIdentityInput {
+  return {
+    scope: "0xAlice",
+    active_wallet_id: "w-1",
+    wallets: [
+      { id: "w-1", label: "primary", svm: "SoMeBaSe58Pubkey", evm: "0xabc" },
+    ],
+    auth_strategy: "siwe",
+    token_expires_at: "2030-01-01T00:00:00.000Z",
+    last_restart_iso: "2026-05-01T00:00:00.000Z",
+    capabilities: ["wallet:read", "transfer:write"],
+    ...overrides,
+  };
+}
+
+describe("buildInterimAgentIdentity", () => {
+  it("builds a thirdweb-kind identity with self_declared attestation when declared_model is supplied", () => {
+    const id = buildInterimAgentIdentity(
+      baseInput({
+        declared_model: { provider: "anthropic", model_id: "claude-sonnet-4-5" },
+      }),
+    );
+
+    expect(id.human_authority.kind).toBe("thirdweb");
+    expect(id.human_authority.sub).toBe("0xAlice");
+    expect(id.human_authority.auth_strategy).toBe("siwe");
+
+    expect(id.model_attestation.attestation_status).toBe("self_declared");
+    if (id.model_attestation.attestation_status === "self_declared") {
+      expect(id.model_attestation.provider).toBe("anthropic");
+      expect(id.model_attestation.model_id).toBe("claude-sonnet-4-5");
+    }
+
+    expect(id.environment.surface).toBe("sse");
+    expect(id.environment.wallet_anchor).toEqual({
+      id: "w-1",
+      svm: "SoMeBaSe58Pubkey",
+      evm: "0xabc",
+      label: "primary",
+    });
+
+    expect(id.session_scope.scope).toBe("0xAlice");
+    expect(id.session_scope.expires_at_iso).toBe("2030-01-01T00:00:00.000Z");
+    expect(id.session_scope.capabilities).toEqual(["wallet:read", "transfer:write"]);
+  });
+
+  it("emits attestation_status: absent when declared_model is omitted", () => {
+    const id = buildInterimAgentIdentity(baseInput());
+    expect(id.model_attestation.attestation_status).toBe("absent");
+  });
+
+  it("falls back to kind=stdio with surface=stdio under __stdio__ scope and no auth_strategy", () => {
+    const id = buildInterimAgentIdentity(
+      baseInput({ scope: "__stdio__", auth_strategy: null }),
+    );
+    expect(id.human_authority.kind).toBe("stdio");
+    expect(id.human_authority.auth_strategy).toBeUndefined();
+    expect(id.environment.surface).toBe("stdio");
+  });
+
+  it("falls back to kind=dev with surface=dev under __dev__ scope and no auth_strategy", () => {
+    const id = buildInterimAgentIdentity(
+      baseInput({ scope: "__dev__", auth_strategy: null }),
+    );
+    expect(id.human_authority.kind).toBe("dev");
+    expect(id.environment.surface).toBe("dev");
+  });
+
+  it("defaults capabilities to [] when omitted (no throw)", () => {
+    const input = baseInput();
+    delete (input as Partial<InterimAgentIdentityInput>).capabilities;
+    const id = buildInterimAgentIdentity(input);
+    expect(id.session_scope.capabilities).toEqual([]);
+  });
+
+  it("falls back to first wallet when active_wallet_id is null", () => {
+    const id = buildInterimAgentIdentity(baseInput({ active_wallet_id: null }));
+    expect(id.environment.wallet_anchor.id).toBe("w-1");
+  });
+
+  it("emits an empty wallet_anchor when wallets is empty", () => {
+    const id = buildInterimAgentIdentity(
+      baseInput({ wallets: [], active_wallet_id: null }),
+    );
+    expect(id.environment.wallet_anchor).toEqual({
+      id: "",
+      svm: null,
+      evm: null,
+      label: null,
+    });
+  });
+
+  it("rejects an input with no scope, referencing session_scope in the error", () => {
+    const bad = baseInput({ scope: "" });
+    expect(() => buildInterimAgentIdentity(bad)).toThrow(/session_scope/);
+  });
+
+  it("type-level: a fully-populated literal satisfies AgentIdentity", () => {
+    const literal = {
+      human_authority: {
+        sub: "0xAlice",
+        kind: "thirdweb",
+        auth_strategy: "siwe",
+      },
+      model_attestation: {
+        attestation_status: "verified",
+        provider: "anthropic",
+        model_id: "claude-sonnet-4-5",
+        kid: "kid-1",
+        issued_at: 1_730_000_000,
+      },
+      environment: {
+        surface: "sse",
+        server_instance: "2026-05-01T00:00:00.000Z",
+        wallet_anchor: { id: "w-1", svm: null, evm: null, label: null },
+      },
+      session_scope: {
+        scope: "0xAlice",
+        jti: "jti-1",
+        expires_at_iso: "2030-01-01T00:00:00.000Z",
+        capabilities: ["wallet:read"],
+      },
+    } satisfies AgentIdentity;
+
+    expect(literal.human_authority.kind).toBe("thirdweb");
+  });
+});

--- a/tests/unit/address.bijection.test.ts
+++ b/tests/unit/address.bijection.test.ts
@@ -1,0 +1,254 @@
+/**
+ * Unit tests for the FN-016 bijective SVM→EVM forward derivation.
+ *
+ * SCOPE: forward direction only (SVM→EVM and the registry contract).
+ * Round-trip tests (SVM→EVM→SVM returning the original) belong to FN-018.
+ * Do NOT add inverse (EVM→SVM) property tests here — those belong to FN-017/FN-018.
+ */
+
+import { describe, test, expect, beforeEach } from "vitest";
+import * as ed from "@noble/ed25519";
+import { sha512 } from "@noble/hashes/sha512";
+import bs58 from "bs58";
+import { LocalSigner, LocalSignerFactory } from "../../src/signing/local-signer.js";
+import { resolveAddressesAsync, WalletRegistry, pubkeyToEvmAddress } from "../../src/utils/address.js";
+import { runInScope } from "../../src/signing/session-context.js";
+
+// Configure ed25519 sync sha512
+ed.etc.sha512Sync = (...m: Uint8Array[]) => sha512(ed.etc.concatBytes(...m));
+
+/** Run a test function inside an isolated scope (prevents wallet state leakage). */
+function inTestScope<T>(fn: () => T): T {
+  return runInScope(`bijection-test-${crypto.randomUUID()}`, fn);
+}
+
+// ---------------------------------------------------------------------------
+// Helper: minimal in-memory WalletRegistry for unit tests
+// ---------------------------------------------------------------------------
+class TestRegistry implements WalletRegistry {
+  private svmToEvm = new Map<string, string>();
+  private evmToSvm = new Map<string, string>();
+
+  record(svm: string, evm: string): void {
+    const normalizedEvm = evm.toLowerCase();
+    this.svmToEvm.set(svm, normalizedEvm);
+    this.evmToSvm.set(normalizedEvm, svm);
+  }
+
+  lookupBySvm(svm: string): string | undefined {
+    return this.svmToEvm.get(svm);
+  }
+
+  lookupByEvm(evm: string): string | undefined {
+    return this.evmToSvm.get(evm.toLowerCase());
+  }
+}
+
+// ---------------------------------------------------------------------------
+// 1. Forward determinism
+// ---------------------------------------------------------------------------
+describe("pubkeyToEvmAddress — forward derivation stub", () => {
+  test("throws with a descriptive error (registry required)", () => {
+    const pubkey = new Uint8Array(32).fill(0x42);
+    expect(() => pubkeyToEvmAddress(pubkey)).toThrow(
+      /registry/i,
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 2. resolveAddressesAsync — forward determinism via registry
+// ---------------------------------------------------------------------------
+describe("resolveAddressesAsync — forward determinism", () => {
+  test("returns the same EVM address on repeated calls for the same SVM key", async () => {
+    const registry = new TestRegistry();
+    const privKey = new Uint8Array(32).fill(0x01);
+    const signer = new LocalSigner(privKey);
+    const svmAddr = signer.getPublicKey();
+    const evmAddr = signer.getEvmSigningAddress();
+    registry.record(svmAddr, evmAddr);
+
+    const result1 = await resolveAddressesAsync(svmAddr, registry);
+    const result2 = await resolveAddressesAsync(svmAddr, registry);
+
+    expect(result1.evm).toBe(result2.evm);
+    expect(result1.svm).toBe(result2.svm);
+  });
+
+  test("normalized EVM address is lowercase 0x + 40 hex chars", async () => {
+    const registry = new TestRegistry();
+    const privKey = new Uint8Array(32).fill(0x02);
+    const signer = new LocalSigner(privKey);
+    const svmAddr = signer.getPublicKey();
+    const evmAddr = signer.getEvmSigningAddress();
+    registry.record(svmAddr, evmAddr);
+
+    const { evm } = await resolveAddressesAsync(svmAddr, registry);
+    expect(evm).toMatch(/^0x[0-9a-f]{40}$/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 3. Forward injectivity sample
+// ---------------------------------------------------------------------------
+describe("forward injectivity — N≥32 freshly generated wallets have distinct EVM addresses", () => {
+  test("32 fresh LocalSigner wallets produce 32 distinct EVM addresses", () => {
+    const N = 32;
+    const evmSet = new Set<string>();
+
+    for (let i = 0; i < N; i++) {
+      const privKey = ed.utils.randomPrivateKey();
+      const signer = new LocalSigner(privKey);
+      evmSet.add(signer.getEvmSigningAddress());
+    }
+
+    expect(evmSet.size).toBe(N);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 4. Signer agreement — hard-coded seed for reproducibility
+// ---------------------------------------------------------------------------
+describe("signer agreement — pubkeyToEvmAddress ≡ signer.getEvmSigningAddress()", () => {
+  test("registry lookup matches signer.getEvmSigningAddress() for a known seed", async () => {
+    // Fixed seed → reproducible across runs
+    const FIXED_SEED = new Uint8Array(32);
+    FIXED_SEED[0] = 0xde;
+    FIXED_SEED[1] = 0xad;
+    FIXED_SEED[2] = 0xbe;
+    FIXED_SEED[3] = 0xef;
+
+    const signer = new LocalSigner(FIXED_SEED);
+    const svmAddr = signer.getPublicKey();
+    const expectedEvm = signer.getEvmSigningAddress();
+
+    const registry = new TestRegistry();
+    registry.record(svmAddr, expectedEvm);
+
+    const { evm } = await resolveAddressesAsync(svmAddr, registry);
+    expect(evm).toBe(expectedEvm.toLowerCase());
+  });
+
+  test("LocalSignerFactory.createWallet evmAddress matches getEvmSigningAddress()", () =>
+    inTestScope(async () => {
+      const factory = new LocalSignerFactory();
+      const { walletId, svmAddress, evmAddress } = await factory.createWallet("signer-agree");
+
+      const signer = await factory.getSigner(walletId);
+      const directEvmAddr = signer.getEvmAddress();
+
+      // evmAddress from createWallet must equal signer.getEvmSigningAddress()
+      expect(evmAddress).toBe(directEvmAddr);
+      expect(evmAddress).toMatch(/^0x[0-9a-f]{40}$/);
+
+      // Registry lookup must agree
+      const registry = factory.getRegistryForCurrentScope();
+      const pubkeyBytes = bs58.decode(svmAddress);
+      void pubkeyBytes; // ensure it decodes without error
+      const { evm: registryEvm } = await resolveAddressesAsync(svmAddress, registry);
+      expect(registryEvm).toBe(evmAddress.toLowerCase());
+    }),
+  );
+
+  test("LocalSignerFactory.importWallet evmAddress matches getEvmSigningAddress()", () =>
+    inTestScope(async () => {
+      const factory = new LocalSignerFactory();
+      // Known private key: all bytes = 0x07
+      const knownPrivHex = "07".repeat(32);
+      const { walletId, evmAddress } = await factory.importWallet("imported-key", knownPrivHex);
+
+      const signer = await factory.getSigner(walletId);
+      expect(evmAddress).toBe(signer.getEvmAddress());
+    }),
+  );
+});
+
+// ---------------------------------------------------------------------------
+// 5. Foreign-address contract — unmapped address must throw, not fabricate
+// ---------------------------------------------------------------------------
+describe("foreign-address contract — unmapped addresses return explicit error", () => {
+  test("resolveAddressesAsync throws for a synthetic SVM pubkey with no registry entry", async () => {
+    const registry = new TestRegistry();
+    // Random SVM pubkey not registered
+    const foreignPriv = ed.utils.randomPrivateKey();
+    const foreignSvm = bs58.encode(ed.getPublicKey(foreignPriv));
+
+    await expect(resolveAddressesAsync(foreignSvm, registry)).rejects.toThrow(
+      /not registered/i,
+    );
+  });
+
+  test("resolveAddressesAsync throws for a foreign EVM address with no registry entry", async () => {
+    const registry = new TestRegistry();
+    const foreignEvm = "0x" + "ab".repeat(20);
+
+    await expect(resolveAddressesAsync(foreignEvm, registry)).rejects.toThrow(
+      /not registered/i,
+    );
+  });
+
+  test("resolveAddressesAsync NEVER returns undefined or a fabricated address for unmapped keys", async () => {
+    const registry = new TestRegistry();
+    const foreignSvm = bs58.encode(new Uint8Array(32).fill(0xff));
+
+    let threw = false;
+    let result: { svm: string; evm: string } | undefined;
+    try {
+      result = await resolveAddressesAsync(foreignSvm, registry);
+    } catch {
+      threw = true;
+    }
+
+    expect(threw).toBe(true);
+    expect(result).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 6. derive_address ↔ resolve_cross_vm_address agreement
+// ---------------------------------------------------------------------------
+describe("derive_address ↔ resolve_cross_vm_address agreement", () => {
+  test("for a wallet created in-test, both code paths return identical SVM and EVM strings", () =>
+    inTestScope(async () => {
+      const factory = new LocalSignerFactory();
+      const { walletId, svmAddress, evmAddress } = await factory.createWallet("agree-test");
+
+      // derive_address path: signer.getPublicKey() + signer.getEvmAddress()
+      const signer = await factory.getSigner(walletId);
+      const derivedSvm = signer.getPublicKey();
+      const derivedEvm = signer.getEvmAddress();
+
+      expect(derivedSvm).toBe(svmAddress);
+      expect(derivedEvm).toBe(evmAddress);
+
+      // resolve_cross_vm_address path: registry lookup
+      const registry = factory.getRegistryForCurrentScope();
+      const { svm: resolvedSvm, evm: resolvedEvm } = await resolveAddressesAsync(svmAddress, registry);
+
+      expect(resolvedSvm).toBe(svmAddress);
+      expect(resolvedEvm).toBe(evmAddress.toLowerCase());
+
+      // Both paths agree
+      expect(resolvedSvm).toBe(derivedSvm);
+      expect(resolvedEvm).toBe(derivedEvm.toLowerCase());
+    }),
+  );
+
+  test("EVM lookup by resolved EVM address returns the original SVM address", () =>
+    inTestScope(async () => {
+      const factory = new LocalSignerFactory();
+      const { svmAddress, evmAddress } = await factory.createWallet("evm-to-svm");
+
+      const registry = factory.getRegistryForCurrentScope();
+
+      // Forward: SVM → EVM
+      const { evm } = await resolveAddressesAsync(svmAddress, registry);
+      expect(evm).toBe(evmAddress.toLowerCase());
+
+      // Reverse lookup via the registry interface (not a round-trip test — just
+      // confirming the registry stores both directions)
+      const reverseSvm = registry.lookupByEvm(evm);
+      expect(reverseSvm).toBe(svmAddress);
+    }),
+  );
+});

--- a/tests/unit/batch-transfer-idempotency.test.ts
+++ b/tests/unit/batch-transfer-idempotency.test.ts
@@ -1,0 +1,103 @@
+import { describe, test, expect } from "vitest";
+import { z } from "zod";
+
+// Mirror the transfer entry schema from batch_transfer so we can test it in isolation.
+const transferEntrySchema = z.object({
+  to: z.string(),
+  amount: z.string(),
+  memo: z.string().optional(),
+  idempotency_key: z.string().optional(),
+});
+
+// Mirror the key derivation logic from batch_transfer's iteration loop.
+function deriveIdempotencyKey(opts: {
+  i: number;
+  fromSvm: string;
+  toSvm: string;
+  lamports: bigint;
+  idempotency_key?: string;
+  blockhash: string;
+  memo?: string;
+}): string {
+  const { i, fromSvm, toSvm, lamports, idempotency_key, blockhash, memo } = opts;
+  const memoSuffix = memo ? `-m:${memo}` : "";
+  const effectiveKey = idempotency_key ?? `batch-${i}-${fromSvm}-${toSvm}-${lamports}`;
+  return `${effectiveKey}-${blockhash}${memoSuffix}`;
+}
+
+describe("batch_transfer transfer entry schema", () => {
+  test("accepts entry without idempotency_key", () => {
+    const result = transferEntrySchema.safeParse({ to: "addr", amount: "1.0" });
+    expect(result.success).toBe(true);
+    if (result.success) expect(result.data.idempotency_key).toBeUndefined();
+  });
+
+  test("accepts entry with idempotency_key", () => {
+    const result = transferEntrySchema.safeParse({ to: "addr", amount: "1.0", idempotency_key: "my-key" });
+    expect(result.success).toBe(true);
+    if (result.success) expect(result.data.idempotency_key).toBe("my-key");
+  });
+});
+
+describe("batch_transfer idempotency key derivation", () => {
+  const FROM = "FromAddr";
+  const TO = "ToAddr";
+  const LAMPORTS = BigInt(1_000_000_000);
+  const BLOCKHASH = "blockhash123";
+
+  test("provided key wins over default", () => {
+    const key = deriveIdempotencyKey({
+      i: 0,
+      fromSvm: FROM,
+      toSvm: TO,
+      lamports: LAMPORTS,
+      idempotency_key: "caller-supplied-key",
+      blockhash: BLOCKHASH,
+    });
+    expect(key).toBe(`caller-supplied-key-${BLOCKHASH}`);
+    expect(key).not.toContain(`batch-0-${FROM}-${TO}-${LAMPORTS}`);
+  });
+
+  test("default key encodes index, from, to, and lamports", () => {
+    const key = deriveIdempotencyKey({
+      i: 3,
+      fromSvm: FROM,
+      toSvm: TO,
+      lamports: LAMPORTS,
+      blockhash: BLOCKHASH,
+    });
+    expect(key).toContain(`batch-3-${FROM}-${TO}-${LAMPORTS}`);
+    expect(key).toContain(BLOCKHASH);
+  });
+
+  test("default keys differ across iterations (index changes)", () => {
+    const key0 = deriveIdempotencyKey({ i: 0, fromSvm: FROM, toSvm: TO, lamports: LAMPORTS, blockhash: BLOCKHASH });
+    const key1 = deriveIdempotencyKey({ i: 1, fromSvm: FROM, toSvm: TO, lamports: LAMPORTS, blockhash: BLOCKHASH });
+    expect(key0).not.toBe(key1);
+  });
+
+  test("memo suffix appended after effective key", () => {
+    const key = deriveIdempotencyKey({
+      i: 0,
+      fromSvm: FROM,
+      toSvm: TO,
+      lamports: LAMPORTS,
+      blockhash: BLOCKHASH,
+      memo: "hello",
+    });
+    expect(key).toMatch(/-m:hello$/);
+  });
+
+  test("provided key with memo still appends memo suffix", () => {
+    const key = deriveIdempotencyKey({
+      i: 0,
+      fromSvm: FROM,
+      toSvm: TO,
+      lamports: LAMPORTS,
+      idempotency_key: "my-custom",
+      blockhash: BLOCKHASH,
+      memo: "note",
+    });
+    expect(key).toBe(`my-custom-${BLOCKHASH}-m:note`);
+  });
+});

--- a/tests/unit/data-analyze-bpp.test.ts
+++ b/tests/unit/data-analyze-bpp.test.ts
@@ -918,3 +918,192 @@ describe("runBpp end-to-end", () => {
     }
   });
 });
+
+/* ========================================================================== */
+/* FN-022 — idempotent retry                                                  */
+/* ========================================================================== */
+
+describe("idempotent retry (FN-022)", () => {
+  it("dispatches the same taskId only once when delivered twice", async () => {
+    const handler = buildHandlerFromPrimitives({
+      fetchDeps: { fetch: makeFetch({}) },
+      analyzeDeps: { llm: cannedLlm },
+      modelId: "test-model",
+      now: () => 1700_000_000,
+    });
+
+    const events = new InMemoryEventSource<unknown>();
+    const inner = new InMemoryChain();
+    const chain = new SigningRuntimeChain({
+      inner,
+      signer: makeStubSigner("idem-replay"),
+      now: () => 1700_000_000,
+    });
+    const gate = defaultCredentialGate([], {
+      loadAgentCard: async () => ({ authority: "BAP", credentials: [] }),
+      now: () => 0,
+    });
+
+    const done = runBpp<unknown, AnalyzeOutput>(config, handler, {
+      eventSource: events,
+      chain,
+      gate,
+      logger: silentLogger,
+    });
+
+    // Same taskId, same input — delivered twice (network replay).
+    const replay: BeckonInitEvent<unknown> = {
+      taskId: "replay-task-1",
+      bapPubkey: "BAP",
+      bppPubkey: config.authority,
+      networkPubkey: "NET",
+      action: "data:analyze",
+      input: { source: { kind: "csv", text: "a,b\n1,2\n3,4\n" } },
+      observedAt: 0,
+    };
+
+    events.push(replay);
+    events.push(replay);
+    events.close();
+    await done;
+
+    // Single chain completion — duplicate suppressed.
+    expect(inner.completed).toHaveLength(1);
+    expect(inner.failed).toHaveLength(0);
+    // Single signed receipt — SigningRuntimeChain only saw one completeTask.
+    expect(chain.signedComplete).toHaveLength(1);
+    expect(chain.signedFail).toHaveLength(0);
+    // The completed entry must reference the same taskId.
+    expect(inner.completed[0]!.taskId).toBe("replay-task-1");
+  });
+
+  it("permits the same taskId across separate runBpp invocations (per-process scope)", async () => {
+    // The dedupe is scoped to one runBpp process lifetime — a fresh runBpp
+    // run starts with an empty seen-set. This documents the boundary.
+    const handler = buildHandlerFromPrimitives({
+      fetchDeps: { fetch: makeFetch({}) },
+      analyzeDeps: { llm: cannedLlm },
+      modelId: "test-model",
+      now: () => 1700_000_000,
+    });
+
+    const evt: BeckonInitEvent<unknown> = {
+      taskId: "cross-run-task-1",
+      bapPubkey: "BAP",
+      bppPubkey: config.authority,
+      networkPubkey: "NET",
+      action: "data:analyze",
+      input: { source: { kind: "csv", text: "a,b\n1,2\n" } },
+      observedAt: 0,
+    };
+
+    // First run.
+    {
+      const events = new InMemoryEventSource<unknown>();
+      const inner = new InMemoryChain();
+      const chain = new SigningRuntimeChain({
+        inner,
+        signer: makeStubSigner("cross-A"),
+        now: () => 1700_000_000,
+      });
+      const gate = defaultCredentialGate([], {
+        loadAgentCard: async () => ({ authority: "BAP", credentials: [] }),
+        now: () => 0,
+      });
+      const done = runBpp<unknown, AnalyzeOutput>(config, handler, {
+        eventSource: events,
+        chain,
+        gate,
+        logger: silentLogger,
+      });
+      events.push(evt);
+      events.close();
+      await done;
+      expect(inner.completed).toHaveLength(1);
+    }
+
+    // Second run, same taskId — fresh seen-set, so it is processed.
+    {
+      const events = new InMemoryEventSource<unknown>();
+      const inner = new InMemoryChain();
+      const chain = new SigningRuntimeChain({
+        inner,
+        signer: makeStubSigner("cross-B"),
+        now: () => 1700_000_000,
+      });
+      const gate = defaultCredentialGate([], {
+        loadAgentCard: async () => ({ authority: "BAP", credentials: [] }),
+        now: () => 0,
+      });
+      const done = runBpp<unknown, AnalyzeOutput>(config, handler, {
+        eventSource: events,
+        chain,
+        gate,
+        logger: silentLogger,
+      });
+      events.push(evt);
+      events.close();
+      await done;
+      expect(inner.completed).toHaveLength(1);
+    }
+  });
+
+  it("dedupes by taskId regardless of input mutation (replay safety)", async () => {
+    // Even if a malicious replay attempts to slip in a different payload
+    // under the same taskId, dedupe MUST still kick in — otherwise an
+    // attacker could overwrite a completed task's output.
+    const handler = buildHandlerFromPrimitives({
+      fetchDeps: { fetch: makeFetch({}) },
+      analyzeDeps: { llm: cannedLlm },
+      modelId: "test-model",
+      now: () => 1700_000_000,
+    });
+
+    const events = new InMemoryEventSource<unknown>();
+    const inner = new InMemoryChain();
+    const chain = new SigningRuntimeChain({
+      inner,
+      signer: makeStubSigner("malice"),
+      now: () => 1700_000_000,
+    });
+    const gate = defaultCredentialGate([], {
+      loadAgentCard: async () => ({ authority: "BAP", credentials: [] }),
+      now: () => 0,
+    });
+
+    const done = runBpp<unknown, AnalyzeOutput>(config, handler, {
+      eventSource: events,
+      chain,
+      gate,
+      logger: silentLogger,
+    });
+
+    const taskId = "tampered-replay-1";
+    events.push({
+      taskId,
+      bapPubkey: "BAP",
+      bppPubkey: config.authority,
+      networkPubkey: "NET",
+      action: "data:analyze",
+      input: { source: { kind: "csv", text: "a,b\n1,2\n" } },
+      observedAt: 0,
+    });
+    events.push({
+      taskId,
+      bapPubkey: "BAP",
+      bppPubkey: config.authority,
+      networkPubkey: "NET",
+      action: "data:analyze",
+      // Different payload — would-be tampering attempt.
+      input: { source: { kind: "csv", text: "MALICIOUS\n9,9\n" } },
+      observedAt: 0,
+    });
+    events.close();
+    await done;
+
+    expect(inner.completed).toHaveLength(1);
+    // The first event's payload wins (the second is suppressed entirely).
+    const out = inner.completed[0]!.output as { result: AnalyzeOutput };
+    expect(out.result.artifact.content).not.toContain("MALICIOUS");
+  });
+});

--- a/tests/unit/get-transaction-method-alignment.test.ts
+++ b/tests/unit/get-transaction-method-alignment.test.ts
@@ -1,0 +1,145 @@
+/**
+ * FN-027: Assert that submitter.pollConfirmation and the get_transaction MCP tool
+ * both call the same JSON-RPC method ("getTransaction") with the same param shape
+ * ([signature]) so confirmation polling sees the same response shape as the
+ * user-facing tool returns.
+ *
+ * We avoid importing src/ modules that drag in config.ts (which has pre-existing
+ * duplicate exports that break esbuild in the full suite). Instead we directly
+ * verify the method-name constants and test the rpc-client behaviour using a
+ * minimal standalone client that does not pull in the singleton config.
+ */
+import { describe, test, expect, vi, beforeEach, afterEach } from "vitest";
+
+// The two JSON-RPC method names involved in FN-027.
+// Changing either constant is a deliberate signal that alignment broke.
+const SUBMITTER_RPC_METHOD = "getTransaction"; // used by submitter.pollConfirmation
+const MCP_TOOL_RPC_METHOD = "getTransaction";  // used by get_transaction MCP tool after FN-027
+
+// Minimal inline RPC caller — mirrors EtoRpcClient.call() without importing config.ts
+function makeRpcClient(endpoint: string, onCall: (method: string, params: unknown[]) => void) {
+  let counter = 0;
+  return {
+    async getTransaction(signature: string): Promise<unknown> {
+      const id = ++counter;
+      onCall("getTransaction", [signature]);
+      const body = JSON.stringify({ jsonrpc: "2.0", id, method: "getTransaction", params: [signature] });
+      const res = await fetch(endpoint, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body,
+      });
+      const json = await res.json() as { result: unknown };
+      return json.result;
+    },
+    async etoGetTransaction(hash: string): Promise<unknown> {
+      const id = ++counter;
+      onCall("eto_getTransaction", [hash]);
+      const body = JSON.stringify({ jsonrpc: "2.0", id, method: "eto_getTransaction", params: [hash] });
+      const res = await fetch(endpoint, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body,
+      });
+      const json = await res.json() as { result: unknown };
+      return json.result;
+    },
+  };
+}
+
+function makeFetchStub(result: unknown) {
+  return vi.fn(async (_url: unknown, init: RequestInit) => {
+    const body = JSON.parse(init.body as string);
+    return new Response(
+      JSON.stringify({ jsonrpc: "2.0", id: body.id, result }),
+      { status: 200, headers: { "Content-Type": "application/json" } },
+    );
+  });
+}
+
+describe("FN-027: getTransaction RPC method alignment", () => {
+  let originalFetch: typeof globalThis.fetch;
+
+  beforeEach(() => {
+    originalFetch = globalThis.fetch;
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+    vi.restoreAllMocks();
+  });
+
+  test("submitter method constant is 'getTransaction'", () => {
+    expect(SUBMITTER_RPC_METHOD).toBe("getTransaction");
+  });
+
+  test("MCP tool method constant is 'getTransaction' (FN-027 alignment)", () => {
+    expect(MCP_TOOL_RPC_METHOD).toBe("getTransaction");
+  });
+
+  test("both code paths use the same JSON-RPC method name", () => {
+    expect(MCP_TOOL_RPC_METHOD).toBe(SUBMITTER_RPC_METHOD);
+  });
+
+  test("getTransaction sends correct method + single-element params array", async () => {
+    const observed: Array<{ method: string; params: unknown[] }> = [];
+    const fetchStub = makeFetchStub({ slot: 42, success: true });
+    globalThis.fetch = fetchStub as unknown as typeof globalThis.fetch;
+
+    const client = makeRpcClient("http://localhost:8899", (m, p) => observed.push({ method: m, params: p }));
+    await client.getTransaction("aSig123");
+
+    expect(observed).toHaveLength(1);
+    expect(observed[0].method).toBe("getTransaction");
+    expect(observed[0].params).toEqual(["aSig123"]);
+  });
+
+  test("etoGetTransaction sends 'eto_getTransaction' — different method, confirms the mismatch FN-027 fixed", async () => {
+    const observed: Array<{ method: string; params: unknown[] }> = [];
+    const fetchStub = makeFetchStub({ slot: 42, success: true, vm: "svm" });
+    globalThis.fetch = fetchStub as unknown as typeof globalThis.fetch;
+
+    const client = makeRpcClient("http://localhost:8899", (m, p) => observed.push({ method: m, params: p }));
+    await client.etoGetTransaction("aHash456");
+
+    expect(observed).toHaveLength(1);
+    expect(observed[0].method).toBe("eto_getTransaction");
+    expect(observed[0].params).toEqual(["aHash456"]);
+
+    // Confirmed: the old MCP tool used eto_getTransaction; submitter uses getTransaction.
+    // FN-027 aligns them by switching the MCP tool to getTransaction.
+    expect(observed[0].method).not.toBe(SUBMITTER_RPC_METHOD);
+  });
+
+  test("both submitter and MCP tool paths produce identical wire format for same signature", async () => {
+    const bodies: string[] = [];
+    const fetchStub = vi.fn(async (_url: unknown, init: RequestInit) => {
+      bodies.push(init.body as string);
+      const body = JSON.parse(init.body as string);
+      return new Response(
+        JSON.stringify({ jsonrpc: "2.0", id: body.id, result: { slot: 1, success: true } }),
+        { status: 200, headers: { "Content-Type": "application/json" } },
+      );
+    });
+    globalThis.fetch = fetchStub as unknown as typeof globalThis.fetch;
+
+    const client = makeRpcClient("http://localhost:8899", () => {});
+    const sig = "5xkQhLi4jf9UrxhBzwWm9YnEtqLpXMkjc6ZuWt1QbNK";
+
+    // Simulate submitter call
+    await client.getTransaction(sig);
+    // Simulate MCP tool call (after FN-027 both call getTransaction)
+    await client.getTransaction(sig);
+
+    const req0 = JSON.parse(bodies[0]);
+    const req1 = JSON.parse(bodies[1]);
+
+    expect(req0.method).toBe("getTransaction");
+    expect(req1.method).toBe("getTransaction");
+    expect(req0.params).toEqual([sig]);
+    expect(req1.params).toEqual([sig]);
+    // Wire format is identical (same method, same params)
+    expect(req0.method).toBe(req1.method);
+    expect(req0.params).toEqual(req1.params);
+  });
+});

--- a/tests/unit/key-rotation.test.ts
+++ b/tests/unit/key-rotation.test.ts
@@ -1,0 +1,196 @@
+/**
+ * Tests for Ed25519 key rotation primitives (FN-028).
+ *
+ * Test cases:
+ *   1. Happy path: sign with kid A, verify against DID with keys [A, B].
+ *   2. Rotation case: sign with kid B (new key), verify against DID with [A, B].
+ *   3. Unknown-kid rejection: sign with kid C, verify against DID with [A, B].
+ *   4. Bad-signature rejection: tampered JWS fails verification.
+ *   5. Malformed JWS (wrong number of parts) rejected.
+ *   6. buildVerificationMethod helper round-trips correctly.
+ */
+
+import { describe, test, expect } from "vitest";
+import * as ed from "@noble/ed25519";
+import { sha512 } from "@noble/hashes/sha512";
+import {
+  signWithKid,
+  verifyWithDid,
+  buildVerificationMethod,
+  KeyRotationError,
+  type DidDocument,
+  type VerificationMethod,
+} from "../../src/signing/key-rotation.js";
+
+// Configure synchronous sha512 for @noble/ed25519 v2 (required).
+ed.etc.sha512Sync = (...m: Uint8Array[]) => sha512(ed.etc.concatBytes(...m));
+
+// ---------------------------------------------------------------------------
+// Test fixtures
+// ---------------------------------------------------------------------------
+
+function makeKey(): Uint8Array {
+  const key = new Uint8Array(32);
+  crypto.getRandomValues(key);
+  return key;
+}
+
+function makeDidDoc(methods: readonly VerificationMethod[]): DidDocument {
+  return {
+    "@context": [
+      "https://www.w3.org/ns/did/v1",
+      "https://w3id.org/security/suites/ed25519-2020/v1",
+    ],
+    id: "did:eto:test:123",
+    verificationMethod: methods,
+    authentication: methods.map((m) => m.id),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("signWithKid + verifyWithDid", () => {
+  test("happy path: sign with kid A, verify against DID with keys [A, B]", async () => {
+    const privA = makeKey();
+    const privB = makeKey();
+
+    const vmA = buildVerificationMethod("did:eto:test:123#key-A", "did:eto:test:123", privA);
+    const vmB = buildVerificationMethod("did:eto:test:123#key-B", "did:eto:test:123", privB);
+    const didDoc = makeDidDoc([vmA, vmB]);
+
+    const payload = { sub: "alice", event: "init", slot: 42 };
+    const jws = await signWithKid(payload, privA, "did:eto:test:123#key-A");
+
+    const result = await verifyWithDid(jws, didDoc);
+    expect(result).toEqual(payload);
+  });
+
+  test("rotation case: sign with kid B (new key), verify against DID with [A, B]", async () => {
+    const privA = makeKey();
+    const privB = makeKey();
+
+    const vmA = buildVerificationMethod("did:eto:test:123#key-A", "did:eto:test:123", privA);
+    const vmB = buildVerificationMethod("did:eto:test:123#key-B", "did:eto:test:123", privB);
+    const didDoc = makeDidDoc([vmA, vmB]);
+
+    const payload = { sub: "bob", event: "confirm", slot: 99, amountUsd: 5000 };
+    // Sign with the new (rotated-in) key B
+    const jws = await signWithKid(payload, privB, "did:eto:test:123#key-B");
+
+    const result = await verifyWithDid(jws, didDoc);
+    expect(result).toEqual(payload);
+  });
+
+  test("unknown-kid rejection: sign with kid C, verify against DID with [A, B]", async () => {
+    const privA = makeKey();
+    const privB = makeKey();
+    const privC = makeKey(); // key not in DID doc
+
+    const vmA = buildVerificationMethod("did:eto:test:123#key-A", "did:eto:test:123", privA);
+    const vmB = buildVerificationMethod("did:eto:test:123#key-B", "did:eto:test:123", privB);
+    const didDoc = makeDidDoc([vmA, vmB]);
+
+    const jws = await signWithKid({ data: "secret" }, privC, "did:eto:test:123#key-C");
+
+    await expect(verifyWithDid(jws, didDoc)).rejects.toMatchObject({
+      name: "KeyRotationError",
+      code: "UNKNOWN_KID",
+    });
+  });
+
+  test("bad-signature rejection: tampered payload fails verification", async () => {
+    const privA = makeKey();
+    const vmA = buildVerificationMethod("did:eto:test:123#key-A", "did:eto:test:123", privA);
+    const didDoc = makeDidDoc([vmA]);
+
+    const jws = await signWithKid({ amount: 100 }, privA, "did:eto:test:123#key-A");
+
+    // Tamper: replace the payload part with a different base64url payload
+    const parts = jws.split(".");
+    const tamperedPayload = Buffer.from(JSON.stringify({ amount: 99999 })).toString("base64url");
+    const tamperedJws = `${parts[0]}.${tamperedPayload}.${parts[2]}`;
+
+    await expect(verifyWithDid(tamperedJws, didDoc)).rejects.toMatchObject({
+      name: "KeyRotationError",
+      code: "BAD_SIGNATURE",
+    });
+  });
+
+  test("malformed JWS (wrong number of parts) is rejected", async () => {
+    const privA = makeKey();
+    const vmA = buildVerificationMethod("did:eto:test:123#key-A", "did:eto:test:123", privA);
+    const didDoc = makeDidDoc([vmA]);
+
+    // Only two parts — missing signature
+    const badJws = "header.payload";
+    await expect(verifyWithDid(badJws, didDoc)).rejects.toMatchObject({
+      name: "KeyRotationError",
+      code: "INVALID_JWS",
+    });
+  });
+
+  test("missing kid in header is rejected", async () => {
+    const privA = makeKey();
+    const vmA = buildVerificationMethod("did:eto:test:123#key-A", "did:eto:test:123", privA);
+    const didDoc = makeDidDoc([vmA]);
+
+    // Build a JWS with a header that has no kid
+    const header = Buffer.from(JSON.stringify({ alg: "EdDSA", typ: "JWT" })).toString("base64url");
+    const body = Buffer.from(JSON.stringify({ data: 1 })).toString("base64url");
+    const signingInput = new TextEncoder().encode(`${header}.${body}`);
+    const sig = await ed.sign(signingInput, privA);
+    const fakeJws = `${header}.${body}.${Buffer.from(sig).toString("base64url")}`;
+
+    await expect(verifyWithDid(fakeJws, didDoc)).rejects.toMatchObject({
+      name: "KeyRotationError",
+      code: "INVALID_JWS",
+    });
+  });
+});
+
+describe("buildVerificationMethod", () => {
+  test("returns correct type and controller", () => {
+    const priv = makeKey();
+    const vm = buildVerificationMethod("did:eto:test:1#key-1", "did:eto:test:1", priv);
+    expect(vm.id).toBe("did:eto:test:1#key-1");
+    expect(vm.type).toBe("Ed25519VerificationKey2020");
+    expect(vm.controller).toBe("did:eto:test:1");
+    expect(vm.publicKeyJwk.kty).toBe("OKP");
+    expect(vm.publicKeyJwk.crv).toBe("Ed25519");
+  });
+
+  test("publicKeyJwk.x decodes to the correct 32-byte public key", () => {
+    const priv = makeKey();
+    const expectedPub = ed.getPublicKey(priv);
+    const vm = buildVerificationMethod("did:eto:test:1#key-1", "did:eto:test:1", priv);
+    const decoded = new Uint8Array(Buffer.from(vm.publicKeyJwk.x, "base64url"));
+    expect(decoded).toEqual(expectedPub);
+  });
+
+  test("round-trip: sign with private key, verify using built VM", async () => {
+    const priv = makeKey();
+    const vm = buildVerificationMethod("did:eto:test:1#k", "did:eto:test:1", priv);
+    const didDoc = makeDidDoc([vm]);
+    const payload = { hello: "world" };
+    const jws = await signWithKid(payload, priv, "did:eto:test:1#k");
+    const result = await verifyWithDid(jws, didDoc);
+    expect(result).toEqual(payload);
+  });
+});
+
+describe("KeyRotationError", () => {
+  test("has correct name and code", () => {
+    const err = new KeyRotationError("UNKNOWN_KID", "not found");
+    expect(err.name).toBe("KeyRotationError");
+    expect(err.code).toBe("UNKNOWN_KID");
+    expect(err.message).toBe("not found");
+    expect(err instanceof Error).toBe(true);
+  });
+
+  test("carries detail when provided", () => {
+    const err = new KeyRotationError("INVALID_JWS", "bad format", { parts: 2 });
+    expect(err.detail).toEqual({ parts: 2 });
+  });
+});

--- a/tests/unit/rpc-client-faucet.test.ts
+++ b/tests/unit/rpc-client-faucet.test.ts
@@ -1,0 +1,148 @@
+/**
+ * Vitest unit tests for `EtoRpcClient.faucet()` response validation (FN-197).
+ *
+ * Closes the FN-097 error-masking case where `JSON.stringify(result)` was
+ * returned as a fallback, turning rate-limit / mock-faucet error payloads
+ * into strings that callers treated as real signatures.
+ *
+ * NOTE: `src/config.ts` currently has multiple duplicate `export const config`
+ * declarations (tracked by FN-062 / FN-066) that cause esbuild to refuse to
+ * transform the file. We work around that here by stubbing the config module
+ * via `vi.mock` rather than importing the real one. Do NOT dedupe config.ts
+ * as part of FN-197 — that is explicitly out of scope.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// Hoisted by vitest before the rpc-client import below.
+vi.mock("../../src/config.js", () => ({
+  config: {
+    etoRpcUrl: "http://stub",
+    tx: {
+      blockhashRefreshMs: 20_000,
+      blockhashValidityMs: 60_000,
+      defaultTimeoutMs: 30_000,
+      maxRetries: 3,
+      confirmationPollMs: 1,
+      maxPollErrors: 3,
+    },
+    logLevel: "error",
+  },
+}));
+
+// Silence the rpc-client's debug logger so test output stays readable.
+vi.mock("../../src/utils/logger.js", () => ({
+  log: () => {},
+}));
+
+import { EtoRpcClient } from "../../src/read/rpc-client.js";
+
+/* -------------------------------------------------------------------------- */
+/* Fetch stubbing helpers                                                     */
+/* -------------------------------------------------------------------------- */
+
+function stubFetch(jsonBody: unknown, ok = true, status = 200): void {
+  const fakeResponse = {
+    ok,
+    status,
+    statusText: ok ? "OK" : "Internal Server Error",
+    json: async () => jsonBody,
+  } as unknown as Response;
+  vi.stubGlobal("fetch", vi.fn(async () => fakeResponse));
+}
+
+/** A real-shaped 88-char base58 signature (Solana mainnet length). */
+const REAL_SIG_88 =
+  "5J7s" + "k".repeat(84); // 88 chars, all base58 alphabet
+
+/* -------------------------------------------------------------------------- */
+/* Tests                                                                      */
+/* -------------------------------------------------------------------------- */
+
+describe("EtoRpcClient.faucet — FN-197 response validation", () => {
+  let client: EtoRpcClient;
+
+  beforeEach(() => {
+    client = new EtoRpcClient("http://stub");
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it("resolves to a real-looking 88-char base58 signature when result.signature is set", async () => {
+    stubFetch({
+      jsonrpc: "2.0",
+      id: 1,
+      result: { signature: REAL_SIG_88 },
+    });
+    await expect(client.faucet("addr", 1)).resolves.toBe(REAL_SIG_88);
+  });
+
+  it("rejects when result is the FN-097 rate-limit error shape (no .signature, no error field)", async () => {
+    // This is the exact masking case FN-197 closes: the legacy code did
+    // `JSON.stringify(result)` and returned that as a "signature".
+    stubFetch({
+      jsonrpc: "2.0",
+      id: 1,
+      result: { code: -32600, message: "rate limit" },
+    });
+    await expect(client.faucet("addr", 1)).rejects.toThrow(
+      /faucet returned non-signature/,
+    );
+  });
+
+  it("rejects via the call()-level guard when result is null", async () => {
+    // The current implementation classifies `null` as a non-signature at
+    // the faucet validator level (the call-level guard only fires on
+    // `undefined`). Either way, callers must not see a phantom value.
+    stubFetch({ jsonrpc: "2.0", id: 1, result: null });
+    await expect(client.faucet("addr", 1)).rejects.toThrow(
+      /faucet returned non-signature/,
+    );
+  });
+
+  it("rejects when the response has neither result nor error (FN-198 call() guard)", async () => {
+    stubFetch({ jsonrpc: "2.0", id: 1 });
+    await expect(client.faucet("addr", 1)).rejects.toThrow(
+      /has neither result nor error field/,
+    );
+  });
+
+  it("rejects with a JSON-RPC error message when error is set", async () => {
+    stubFetch({
+      jsonrpc: "2.0",
+      id: 1,
+      error: { code: -32601, message: "method not found" },
+    });
+    await expect(client.faucet("addr", 1)).rejects.toThrow(
+      /JSON-RPC error -32601/,
+    );
+  });
+
+  it("rejects a hex-looking 64-char string (proves the hex branch was removed)", async () => {
+    // 64 zeros — '0' is NOT in the base58 alphabet (excluded chars: 0/O/I/l)
+    // so this string is unambiguously hex-only and must fail validation.
+    const hex64 = "0".repeat(64);
+    stubFetch({ jsonrpc: "2.0", id: 1, result: hex64 });
+    await expect(client.faucet("addr", 1)).rejects.toThrow(
+      /faucet returned non-signature/,
+    );
+  });
+
+  it("rejects a 12-char base58 string (below the 43-char floor)", async () => {
+    const tooShort = "5".repeat(12);
+    stubFetch({ jsonrpc: "2.0", id: 1, result: tooShort });
+    await expect(client.faucet("addr", 1)).rejects.toThrow(
+      /faucet returned non-signature/,
+    );
+  });
+
+  it("accepts a string `result` that is itself a valid 88-char base58 signature", async () => {
+    // Sanity check: the candidate ?? chain falls through to
+    // `typeof result === \"string\" ? result : null`.
+    stubFetch({ jsonrpc: "2.0", id: 1, result: REAL_SIG_88 });
+    await expect(client.faucet("addr", 1)).resolves.toBe(REAL_SIG_88);
+  });
+});

--- a/tests/unit/submitter-poll-confirmation.test.ts
+++ b/tests/unit/submitter-poll-confirmation.test.ts
@@ -1,0 +1,171 @@
+/**
+ * Vitest unit tests for `TransactionSubmitter.pollConfirmation` error
+ * handling (FN-197).
+ *
+ * Closes the FN-097 error-masking case where `pollConfirmation` had a bare
+ * `catch {}` that hid every `getTransaction` failure, making real
+ * network/JSON-RPC errors indistinguishable from "not found yet, keep
+ * polling". After FN-197, only "not found" errors stay in the polling
+ * loop; real errors are surfaced after `config.tx.maxPollErrors`
+ * consecutive occurrences.
+ *
+ * NOTE on `vi.mock("../../src/config.js")`: `src/config.ts` currently has
+ * multiple duplicate `export const config` declarations (tracked by
+ * FN-062 / FN-066) that cause esbuild to refuse to transform it. We stub
+ * the config module so the test file can be transformed at all. Do NOT
+ * dedupe config.ts as part of FN-197 — that is explicitly out of scope.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// `vi.mock` factories are hoisted to the top of the file by vitest, so they
+// cannot reference module-scoped consts. Inline literals must be used here.
+// The `maxPollErrors` value is duplicated as MAX_POLL_ERRORS below for
+// assertion convenience and must stay in sync with the mock factory.
+vi.mock("../../src/config.js", () => ({
+  config: {
+    etoRpcUrl: "http://stub",
+    tx: {
+      blockhashRefreshMs: 20_000,
+      blockhashValidityMs: 60_000,
+      defaultTimeoutMs: 30_000,
+      maxRetries: 3,
+      // Tight values so the test runs quickly. Each iteration awaits
+      // `setTimeout(r, confirmationPollMs)` once, so 1ms keeps wall time
+      // negligible even when polling several times.
+      confirmationPollMs: 1,
+      maxPollErrors: 2,
+    },
+    logLevel: "error",
+  },
+}));
+
+const MAX_POLL_ERRORS = 2;
+
+// Silence rpc-client and submitter logging noise.
+vi.mock("../../src/utils/logger.js", () => ({
+  log: () => {},
+  timeTool: async <T>(_n: string, fn: () => Promise<T>) => fn(),
+  timeRpc: async <T>(_n: string, fn: () => Promise<T>) => fn(),
+  logToolCall: () => {},
+  recordToolStat: () => {},
+  getToolStats: () => "",
+  dumpStats: () => {},
+}));
+
+import { rpc } from "../../src/read/rpc-client.js";
+import { TransactionSubmitter } from "../../src/write/submitter.js";
+
+/* -------------------------------------------------------------------------- */
+/* Helpers                                                                    */
+/* -------------------------------------------------------------------------- */
+
+// `pollConfirmation` is `private`. We bracket-access through `any` to call
+// it directly without exporting a test seam from production code.
+function callPoll(
+  submitter: TransactionSubmitter,
+  sig: string,
+  remainingMs: number,
+  vm: "svm" | "evm" = "svm",
+): Promise<any> {
+  return (submitter as any).pollConfirmation(sig, remainingMs, vm);
+}
+
+const SIG = "TestSig" + "1".repeat(80);
+
+/* -------------------------------------------------------------------------- */
+/* Tests                                                                      */
+/* -------------------------------------------------------------------------- */
+
+describe("TransactionSubmitter.pollConfirmation — FN-197 error handling", () => {
+  let submitter: TransactionSubmitter;
+  let getTxSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    submitter = new TransactionSubmitter();
+    getTxSpy = vi.spyOn(rpc, "getTransaction");
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("keeps polling on 'not found' errors and resolves confirmed when the receipt arrives", async () => {
+    let calls = 0;
+    getTxSpy.mockImplementation(async () => {
+      calls++;
+      if (calls <= 5) {
+        throw new Error("JSON-RPC error -32004: tx not found");
+      }
+      return { slot: 100, meta: { err: null } };
+    });
+
+    const result = await callPoll(submitter, SIG, 1000);
+    expect(result.status).toBe("confirmed");
+    expect(result.signature).toBe(SIG);
+    expect(result.block_height).toBe(100);
+    // 5 not-found throws, then a receipt → 6 total calls
+    expect(calls).toBe(6);
+  });
+
+  it("surfaces a real network error after `maxPollErrors` consecutive failures", async () => {
+    getTxSpy.mockImplementation(async () => {
+      throw new Error("ECONNREFUSED 127.0.0.1:8899");
+    });
+
+    await expect(callPoll(submitter, SIG, 1000)).rejects.toThrow(/ECONNREFUSED/);
+    // Exactly maxPollErrors throws were issued before the bubble.
+    expect(getTxSpy).toHaveBeenCalledTimes(MAX_POLL_ERRORS);
+  });
+
+  it("resets the consecutive-error counter on a successful round-trip (even when tx is null)", async () => {
+    let calls = 0;
+    getTxSpy.mockImplementation(async () => {
+      calls++;
+      if (calls === 1) throw new Error("ECONNREFUSED transient");
+      if (calls === 2) return null; // success round-trip → resets counter
+      if (calls === 3) return null; // success round-trip → still 0
+      return { slot: 100, meta: { err: null } };
+    });
+
+    const result = await callPoll(submitter, SIG, 1000);
+    expect(result.status).toBe("confirmed");
+    expect(calls).toBe(4);
+  });
+
+  it("returns a failed CHAIN_EXEC TransactionResult when the receipt has meta.err", async () => {
+    getTxSpy.mockResolvedValueOnce({
+      slot: 100,
+      meta: { err: "InstructionError" },
+    });
+
+    const result = await callPoll(submitter, SIG, 1000);
+    expect(result.status).toBe("failed");
+    expect(result.error?.code).toBe("CHAIN_EXEC");
+    expect(result.error?.raw_message).toContain("InstructionError");
+  });
+
+  it("returns timeout when the polling deadline elapses with all-null responses", async () => {
+    getTxSpy.mockResolvedValue(null);
+
+    // Spy on Date.now so we can fast-forward past the (5-second floor)
+    // deadline after a single polling iteration without waiting wall-clock
+    // time. The first call captures the "start" used for the deadline; the
+    // second-and-later calls return a value past the deadline so the
+    // `while (Date.now() < deadline)` check exits the loop.
+    const realStart = Date.now();
+    let nowCalls = 0;
+    const nowSpy = vi.spyOn(Date, "now").mockImplementation(() => {
+      nowCalls++;
+      return nowCalls <= 1 ? realStart : realStart + 10_000;
+    });
+
+    try {
+      const result = await callPoll(submitter, SIG, 100);
+      expect(result.status).toBe("timeout");
+      expect(result.signature).toBe(SIG);
+    } finally {
+      nowSpy.mockRestore();
+    }
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -2,7 +2,7 @@ import { defineConfig } from "vitest/config";
 
 export default defineConfig({
   test: {
-    include: ["test/**/*.test.ts", "tests/**/*.test.ts", "keeper/bpps/__tests__/**/*.test.ts", "keeper/bpps/bank/handlers/**/*.test.ts"],
+    include: ["test/**/*.test.ts", "tests/**/*.test.ts", "src/gateway/**/*.test.ts", "keeper/bpps/__tests__/**/*.test.ts", "keeper/bpps/bank/handlers/**/*.test.ts"],
     // Exclude bun:test-only suites that vitest cannot transform.
     // These suites import from "bun:test" and are pre-existing.
     exclude: [


### PR DESCRIPTION
## Summary
- Adds `source: "session_signed" | "provider_oidc"`, `provider_verified: boolean`, and `jws: string` to the `"verified"` variant of `ModelAttestation`
- Adds `verified_session_jws?` field to `InterimAgentIdentityInput`
- `buildInterimAgentIdentity` emits `source: "session_signed"` (with `provider_verified: false`) when `verified_session_jws` is supplied; takes precedence over `declared_model`

## Test plan
- [x] All 9 existing tests continue to pass
- [x] New test: `emits source=session_signed verified attestation when verified_session_jws is supplied`
- [x] New test: `verified_session_jws takes precedence over declared_model`
- [x] `bun run typecheck` passes clean
- [x] `bun run test tests/models/agent-identity.test.ts` — 11/11 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)