### PR TITLE
feat(FN-078): refactor data-analyze to FN-201 acceptance layout

### DIFF
--- a/keeper/bpps/data-analyze/analyzers/profiler.ts
+++ b/keeper/bpps/data-analyze/analyzers/profiler.ts
@@ -1,0 +1,510 @@
+/**
+ * CSV profiler for the `data:analyze` BPP (FN-079).
+ *
+ * Implements a small RFC 4180 compliant parser (handles quoted fields
+ * with embedded commas, escaped `""`, CRLF and LF line endings, and a
+ * configurable delimiter), a delimiter auto-detector, per-column type
+ * inference (`boolean | integer | number | date | string | mixed`),
+ * and lightweight summary statistics + anomaly flags. Pure functions
+ * — only an optional `rng` is injected for deterministic sampling.
+ *
+ * Bounds (kept here so the LLM step has predictable input size):
+ *  - distinct enumeration capped at 10 000 per column.
+ *  - top-K categorical reporting only when `distinctCount ≤ 50`.
+ *  - sample rows: first 20 + up to 20 uniformly-random from the rest.
+ *  - cell strings truncated at 256 chars with an ellipsis.
+ */
+
+import type {
+  ColumnProfile,
+  DatasetProfile,
+  InferredType,
+} from "../types.js";
+
+/* -------------------------------------------------------------------------- */
+/* Public API                                                                 */
+/* -------------------------------------------------------------------------- */
+
+export interface ProfileOpts {
+  readonly delimiter: "," | ";" | "\t" | "auto";
+  readonly hasHeader: boolean;
+  readonly maxRows: number;
+}
+
+export interface ProfileDeps {
+  /** Default `Math.random`. */
+  readonly rng?: () => number;
+}
+
+export interface DatasetSample {
+  readonly columns: readonly string[];
+  readonly head: ReadonlyArray<readonly string[]>;
+  readonly random: ReadonlyArray<readonly string[]>;
+}
+
+export interface ProfileResult {
+  readonly profile: DatasetProfile;
+  readonly sample: DatasetSample;
+  readonly truncated: boolean;
+  /** Internal-only anomaly flags per column (parallel to `profile.columns`). */
+  readonly columnFlags: readonly ColumnFlags[];
+}
+
+export interface ColumnFlags {
+  readonly highNullRate: boolean;
+  readonly allDistinct: boolean;
+  readonly monotonic: boolean;
+  readonly constant: boolean;
+  readonly outlierHeavy: boolean;
+}
+
+const DISTINCT_CAP = 10_000;
+const TOPVALUES_THRESHOLD = 50;
+const TOPVALUES_K = 5;
+const HEAD_SAMPLE_SIZE = 20;
+const RANDOM_SAMPLE_SIZE = 20;
+const CELL_TRUNCATE = 256;
+const SAMPLE_LINE_BUDGET = 4 * 1024;
+
+const NULL_TOKENS = new Set([""]); // configurable; default = empty string only
+const TRUE_TOKENS = new Set(["true", "1"]);
+const FALSE_TOKENS = new Set(["false", "0"]);
+const ISO_DATE_RE =
+  /^\d{4}-\d{2}-\d{2}(?:[T ]\d{2}:\d{2}(?::\d{2}(?:\.\d+)?)?(?:Z|[+-]\d{2}:?\d{2})?)?$/;
+
+/* -------------------------------------------------------------------------- */
+/* profileCsv                                                                 */
+/* -------------------------------------------------------------------------- */
+
+export function profileCsv(
+  text: string,
+  opts: ProfileOpts,
+  deps?: ProfileDeps,
+): ProfileResult {
+  const delimiter =
+    opts.delimiter === "auto" ? detectDelimiter(text) : opts.delimiter;
+
+  const allRows = parseCsv(text, delimiter);
+  if (allRows.length === 0) {
+    return emptyResult(delimiter);
+  }
+
+  const headerRow = opts.hasHeader ? allRows[0]! : null;
+  const dataStart = opts.hasHeader ? 1 : 0;
+  const totalDataRows = allRows.length - dataStart;
+  const truncated = totalDataRows > opts.maxRows;
+  const dataEnd = dataStart + Math.min(totalDataRows, opts.maxRows);
+  const dataRows = allRows.slice(dataStart, dataEnd);
+
+  const columnCount = computeColumnCount(allRows);
+  const columnNames = buildColumnNames(headerRow, columnCount);
+
+  // Pad short rows so column accessors are total.
+  const padded: string[][] = dataRows.map((r) => {
+    if (r.length === columnCount) return [...r];
+    const out = [...r];
+    while (out.length < columnCount) out.push("");
+    return out.slice(0, columnCount);
+  });
+
+  const columns: ColumnProfile[] = [];
+  const columnFlags: ColumnFlags[] = [];
+  for (let c = 0; c < columnCount; c++) {
+    const cells = padded.map((r) => r[c]!);
+    const { profile, flags } = profileColumn(columnNames[c]!, cells);
+    columns.push(profile);
+    columnFlags.push(flags);
+  }
+
+  const profile: DatasetProfile = {
+    rowCount: padded.length,
+    columnCount,
+    columns,
+    delimiter,
+    encoding: "utf-8",
+    truncated,
+  };
+
+  const sample = buildSample(columnNames, padded, deps?.rng ?? Math.random);
+  return { profile, sample, truncated, columnFlags };
+}
+
+function emptyResult(delimiter: "," | ";" | "\t"): ProfileResult {
+  return {
+    profile: {
+      rowCount: 0,
+      columnCount: 0,
+      columns: [],
+      delimiter,
+      encoding: "utf-8",
+      truncated: false,
+    },
+    sample: { columns: [], head: [], random: [] },
+    truncated: false,
+    columnFlags: [],
+  };
+}
+
+function computeColumnCount(rows: readonly (readonly string[])[]): number {
+  let n = 0;
+  for (const r of rows) if (r.length > n) n = r.length;
+  return n;
+}
+
+function buildColumnNames(
+  header: readonly string[] | null,
+  columnCount: number,
+): string[] {
+  const out: string[] = [];
+  for (let i = 0; i < columnCount; i++) {
+    if (header && header[i] && header[i]!.trim() !== "") {
+      out.push(header[i]!);
+    } else {
+      out.push(`col_${i + 1}`);
+    }
+  }
+  return out;
+}
+
+/* -------------------------------------------------------------------------- */
+/* Delimiter auto-detect                                                      */
+/* -------------------------------------------------------------------------- */
+
+export function detectDelimiter(text: string): "," | ";" | "\t" {
+  const head = text.slice(0, 10 * 1024);
+  // Count outside quotes to avoid mis-counting embedded delimiters.
+  let inQuotes = false;
+  let comma = 0;
+  let semi = 0;
+  let tab = 0;
+  for (let i = 0; i < head.length; i++) {
+    const ch = head[i];
+    if (ch === '"') {
+      // toggle, with awareness of escaped ""
+      if (inQuotes && head[i + 1] === '"') {
+        i++;
+        continue;
+      }
+      inQuotes = !inQuotes;
+      continue;
+    }
+    if (inQuotes) continue;
+    if (ch === ",") comma++;
+    else if (ch === ";") semi++;
+    else if (ch === "\t") tab++;
+  }
+  const max = Math.max(comma, semi, tab);
+  if (max === 0) return ",";
+  if (tab === max) return "\t";
+  if (semi === max) return ";";
+  return ",";
+}
+
+/* -------------------------------------------------------------------------- */
+/* RFC 4180 parser                                                            */
+/* -------------------------------------------------------------------------- */
+
+/**
+ * Minimal RFC 4180 parser. Supports:
+ *   - quoted fields with embedded delimiters and newlines,
+ *   - escaped `""` inside quoted fields,
+ *   - CRLF and LF line endings,
+ *   - configurable single-character delimiter,
+ *   - skipping a trailing empty record produced by a final newline.
+ */
+export function parseCsv(
+  text: string,
+  delimiter: "," | ";" | "\t",
+): string[][] {
+  const rows: string[][] = [];
+  let row: string[] = [];
+  let cell = "";
+  let inQuotes = false;
+  const len = text.length;
+
+  for (let i = 0; i < len; i++) {
+    const ch = text[i];
+    if (inQuotes) {
+      if (ch === '"') {
+        if (text[i + 1] === '"') {
+          cell += '"';
+          i++;
+        } else {
+          inQuotes = false;
+        }
+      } else {
+        cell += ch;
+      }
+      continue;
+    }
+    // not in quotes
+    if (ch === '"' && cell.length === 0) {
+      inQuotes = true;
+    } else if (ch === delimiter) {
+      row.push(cell);
+      cell = "";
+    } else if (ch === "\r") {
+      // swallow CR; treat the following LF as the terminator
+      if (text[i + 1] === "\n") i++;
+      row.push(cell);
+      rows.push(row);
+      row = [];
+      cell = "";
+    } else if (ch === "\n") {
+      row.push(cell);
+      rows.push(row);
+      row = [];
+      cell = "";
+    } else {
+      cell += ch;
+    }
+  }
+  // Trailing field (no terminator before EOF).
+  if (cell.length > 0 || row.length > 0) {
+    row.push(cell);
+    rows.push(row);
+  }
+  // Drop a single trailing empty row produced by a final newline.
+  if (
+    rows.length > 0 &&
+    rows[rows.length - 1]!.length === 1 &&
+    rows[rows.length - 1]![0] === ""
+  ) {
+    rows.pop();
+  }
+  return rows;
+}
+
+/* -------------------------------------------------------------------------- */
+/* Per-column profile                                                         */
+/* -------------------------------------------------------------------------- */
+
+function profileColumn(
+  name: string,
+  cells: readonly string[],
+): { profile: ColumnProfile; flags: ColumnFlags } {
+  let nonNull = 0;
+  let nullCount = 0;
+  const distinct = new Map<string, number>();
+  let distinctOverflow = false;
+
+  // Type inference candidates — set to false as we encounter a non-fitting cell.
+  let canBool = true;
+  let canInt = true;
+  let canNum = true;
+  let canDate = true;
+
+  // Welford for numeric stats.
+  let n = 0;
+  let mean = 0;
+  let m2 = 0;
+  let min = Number.POSITIVE_INFINITY;
+  let max = Number.NEGATIVE_INFINITY;
+  const numericValues: number[] = [];
+
+  let stringMin: string | undefined;
+  let stringMax: string | undefined;
+
+  let monotonicInc = true;
+  let monotonicDec = true;
+  let prev: number | null = null;
+
+  for (const raw of cells) {
+    if (NULL_TOKENS.has(raw)) {
+      nullCount++;
+      continue;
+    }
+    nonNull++;
+
+    if (!distinctOverflow) {
+      distinct.set(raw, (distinct.get(raw) ?? 0) + 1);
+      if (distinct.size > DISTINCT_CAP) distinctOverflow = true;
+    }
+
+    const lower = raw.toLowerCase();
+    if (canBool && !(TRUE_TOKENS.has(lower) || FALSE_TOKENS.has(lower))) {
+      canBool = false;
+    }
+    if (canInt) {
+      if (!/^-?\d+$/.test(raw)) canInt = false;
+    }
+    let asNum: number | null = null;
+    if (canNum) {
+      // Allow integers + decimals + scientific notation.
+      if (/^-?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?$/.test(raw)) {
+        asNum = Number(raw);
+        if (!Number.isFinite(asNum)) canNum = false;
+      } else {
+        canNum = false;
+      }
+    } else {
+      if (/^-?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?$/.test(raw)) {
+        const v = Number(raw);
+        if (Number.isFinite(v)) asNum = v;
+      }
+    }
+    if (canDate && !ISO_DATE_RE.test(raw)) canDate = false;
+
+    if (asNum !== null) {
+      n++;
+      const delta = asNum - mean;
+      mean += delta / n;
+      m2 += delta * (asNum - mean);
+      if (asNum < min) min = asNum;
+      if (asNum > max) max = asNum;
+      numericValues.push(asNum);
+      if (prev !== null) {
+        if (asNum < prev) monotonicInc = false;
+        if (asNum > prev) monotonicDec = false;
+      }
+      prev = asNum;
+    } else {
+      monotonicInc = false;
+      monotonicDec = false;
+    }
+
+    if (stringMin === undefined || raw < stringMin) stringMin = raw;
+    if (stringMax === undefined || raw > stringMax) stringMax = raw;
+  }
+
+  // Derive type, ranking by specificity.
+  let inferredType: InferredType;
+  if (nonNull === 0) {
+    inferredType = "string";
+  } else if (canBool) {
+    inferredType = "boolean";
+  } else if (canInt) {
+    inferredType = "integer";
+  } else if (canNum) {
+    inferredType = "number";
+  } else if (canDate) {
+    inferredType = "date";
+  } else {
+    // mixed if there's a partial numeric/date intermixing detected; else string.
+    // Heuristic: if some values parsed as numbers but not all, mark mixed.
+    inferredType = numericValues.length > 0 && numericValues.length < nonNull
+      ? "mixed"
+      : "string";
+  }
+
+  const distinctCount = distinctOverflow ? DISTINCT_CAP : distinct.size;
+  const isNumeric = inferredType === "integer" || inferredType === "number";
+
+  const profile: ColumnProfile = {
+    name,
+    inferredType,
+    nonNullCount: nonNull,
+    nullCount,
+    distinctCount,
+    ...(isNumeric && n > 0
+      ? {
+          min,
+          max,
+          mean,
+          stddev: n > 1 ? Math.sqrt(m2 / (n - 1)) : 0,
+        }
+      : stringMin !== undefined && !isNumeric
+        ? { min: stringMin, max: stringMax! }
+        : {}),
+    ...(distinctCount > 0 && distinctCount <= TOPVALUES_THRESHOLD
+      ? { topValues: topK(distinct, TOPVALUES_K) }
+      : {}),
+  };
+
+  // Anomaly flags
+  const total = nonNull + nullCount;
+  const highNullRate = total > 0 && nullCount / total > 0.3;
+  const allDistinct = nonNull >= 2 && distinctCount === nonNull && !distinctOverflow;
+  const constant = nonNull >= 2 && distinctCount === 1;
+  const monotonic =
+    isNumeric && n >= 2 && (monotonicInc || monotonicDec) && !constant;
+  const outlierHeavy =
+    isNumeric && n >= 8 && iqrOutlierRate(numericValues) > 0.05;
+
+  const flags: ColumnFlags = {
+    highNullRate,
+    allDistinct,
+    monotonic,
+    constant,
+    outlierHeavy,
+  };
+
+  return { profile, flags };
+}
+
+function topK(
+  counts: ReadonlyMap<string, number>,
+  k: number,
+): Array<{ value: string; count: number }> {
+  const entries = Array.from(counts.entries()).sort((a, b) => b[1] - a[1]);
+  return entries.slice(0, k).map(([value, count]) => ({ value, count }));
+}
+
+function iqrOutlierRate(values: readonly number[]): number {
+  const sorted = [...values].sort((a, b) => a - b);
+  const q1 = quantile(sorted, 0.25);
+  const q3 = quantile(sorted, 0.75);
+  const iqr = q3 - q1;
+  if (iqr === 0) return 0;
+  const lo = q1 - 1.5 * iqr;
+  const hi = q3 + 1.5 * iqr;
+  let outliers = 0;
+  for (const v of sorted) if (v < lo || v > hi) outliers++;
+  return outliers / sorted.length;
+}
+
+function quantile(sorted: readonly number[], q: number): number {
+  if (sorted.length === 0) return 0;
+  const pos = (sorted.length - 1) * q;
+  const base = Math.floor(pos);
+  const rest = pos - base;
+  const lo = sorted[base]!;
+  const hi = sorted[base + 1] ?? lo;
+  return lo + (hi - lo) * rest;
+}
+
+/* -------------------------------------------------------------------------- */
+/* Sampling                                                                   */
+/* -------------------------------------------------------------------------- */
+
+function buildSample(
+  columns: readonly string[],
+  rows: readonly (readonly string[])[],
+  rng: () => number,
+): DatasetSample {
+  const head = rows.slice(0, HEAD_SAMPLE_SIZE).map(truncateRow);
+  // Random sample from rows beyond `head`.
+  const remainder = rows.length > HEAD_SAMPLE_SIZE ? rows.slice(HEAD_SAMPLE_SIZE) : [];
+  const randomRows: string[][] = [];
+  if (remainder.length > 0) {
+    const pickCount = Math.min(RANDOM_SAMPLE_SIZE, remainder.length);
+    const seen = new Set<number>();
+    while (randomRows.length < pickCount && seen.size < remainder.length) {
+      const idx = Math.floor(rng() * remainder.length);
+      if (seen.has(idx)) continue;
+      seen.add(idx);
+      randomRows.push(truncateRow(remainder[idx]!));
+    }
+  }
+  return { columns, head, random: randomRows };
+}
+
+function truncateRow(row: readonly string[]): string[] {
+  let used = 0;
+  const out: string[] = [];
+  for (const cell of row) {
+    let trimmed = cell;
+    if (trimmed.length > CELL_TRUNCATE) {
+      trimmed = trimmed.slice(0, CELL_TRUNCATE - 1) + "…";
+    }
+    if (used + trimmed.length > SAMPLE_LINE_BUDGET) {
+      out.push(trimmed.slice(0, Math.max(0, SAMPLE_LINE_BUDGET - used)) + "…");
+      // Fill the remaining columns with empty placeholders.
+      while (out.length < row.length) out.push("");
+      return out;
+    }
+    out.push(trimmed);
+    used += trimmed.length + 1;
+  }
+  return out;
+}

--- a/keeper/bpps/data-analyze/handler.ts
+++ b/keeper/bpps/data-analyze/handler.ts
@@ -82,7 +82,7 @@ export function createDataAnalyzeHandler(
         profiled.profile.columnCount === 0 ||
         profiled.profile.rowCount === 0
       ) {
-        return { status: "failure", reason: "empty_dataset" };
+        return { status: "failure", reason: "data-analyze:planner:empty-dataset" };
       }
 
       // 3. Analyze.
@@ -171,6 +171,7 @@ function stableReason(err: unknown): string {
     "source_too_large",
     "encoding_unsupported",
     "unsupported_content_type",
+    "data-analyze:planner:",
     "empty_dataset",
     "llm_invalid_response",
   ];

--- a/keeper/bpps/data-analyze/planner.ts
+++ b/keeper/bpps/data-analyze/planner.ts
@@ -1,0 +1,282 @@
+/**
+ * Anthropic-backed analyser for the `data:analyze` BPP (FN-079).
+ *
+ * Production wires `LlmClient` to `@anthropic-ai/sdk` (resolved
+ * structurally so this file does NOT take a static import on the SDK
+ * — keeps `keeper/` runnable without it). Tests inject a fake
+ * `LlmClient` whose canned `AnalysisReport` we then assert against.
+ *
+ * The LLM only ever sees the structured `DatasetProfile` plus a
+ * bounded `sample` (head + random) — never the raw CSV body. This is
+ * a privacy + cost guardrail: callers can submit datasets that exceed
+ * the model's context window, and the BPP will still produce a
+ * meaningful narrative without leaking unbounded raw rows.
+ */
+
+import { createHash } from "node:crypto";
+import type { DatasetProfile, AnalysisReport, ColumnProfile } from "./types.js";
+import { zAnalysisReport } from "./types.js";
+import type { ColumnFlags, DatasetSample } from "./analyzers/profiler.js";
+
+/* -------------------------------------------------------------------------- */
+/* LlmClient seam                                                             */
+/* -------------------------------------------------------------------------- */
+
+export interface LlmRequest {
+  readonly profile: DatasetProfile;
+  readonly sample: DatasetSample;
+  readonly question?: string;
+  readonly modelId: string;
+}
+
+export interface LlmClient {
+  analyze(req: LlmRequest): Promise<AnalysisReport>;
+}
+
+/* -------------------------------------------------------------------------- */
+/* Anthropic adapter                                                          */
+/* -------------------------------------------------------------------------- */
+
+/**
+ * Structural shape we require from an Anthropic SDK client. Captured
+ * here (instead of importing `@anthropic-ai/sdk` types) so this file
+ * compiles whether or not the SDK is installed.
+ */
+export interface AnthropicLike {
+  readonly messages: {
+    create(args: {
+      model: string;
+      max_tokens: number;
+      system: string;
+      messages: ReadonlyArray<{ role: "user"; content: string }>;
+    }): Promise<{
+      content: ReadonlyArray<{ type: string; text?: string }>;
+    }>;
+  };
+}
+
+const SYSTEM_PROMPT = [
+  "You are a precise data analyst.",
+  "You are given a `DatasetProfile` (column types, summary statistics,",
+  "anomaly flags) and a small `sample` (column names + head + random",
+  "rows). You may also be given an optional focus `question`.",
+  "",
+  "Reply with STRICT JSON matching this TypeScript interface and no",
+  "surrounding prose:",
+  "",
+  "  interface AnalysisReport {",
+  "    summary: string;            // 2–4 sentences",
+  "    findings: string[];         // 3–8 specific observations",
+  "    anomalies: string[];        // 0–8 quality / shape concerns",
+  "    suggestedQuestions: string[]; // 3–6 next-step questions",
+  "    answer?: string;            // ≤ 200 words, only if `question` set",
+  "  }",
+  "",
+  "Cite specific column names. Do not invent statistics — quote only",
+  "values present in the profile. Do not output the sample verbatim.",
+].join("\n");
+
+export class AnthropicLlmClient implements LlmClient {
+  public constructor(private readonly client: AnthropicLike) {}
+
+  public async analyze(req: LlmRequest): Promise<AnalysisReport> {
+    const userPrompt = buildUserPrompt(req);
+
+    const resp = await this.client.messages.create({
+      model: req.modelId,
+      max_tokens: 2048,
+      system: SYSTEM_PROMPT,
+      messages: [{ role: "user", content: userPrompt }],
+    });
+
+    const text = resp.content
+      .filter((b) => b.type === "text" && typeof b.text === "string")
+      .map((b) => b.text!)
+      .join("")
+      .trim();
+
+    if (text.length === 0) throw new Error("data-analyze:planner:llm-invalid");
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(extractJsonObject(text));
+    } catch {
+      throw new Error("data-analyze:planner:llm-invalid");
+    }
+    const result = zAnalysisReport.safeParse(parsed);
+    if (!result.success) throw new Error("data-analyze:planner:llm-invalid");
+    return result.data as AnalysisReport;
+  }
+}
+
+function buildUserPrompt(req: LlmRequest): string {
+  const lines: string[] = [];
+  lines.push("# DatasetProfile");
+  lines.push(JSON.stringify(req.profile, null, 2));
+  lines.push("");
+  lines.push("# Sample");
+  lines.push(JSON.stringify(req.sample, null, 2));
+  if (req.question) {
+    lines.push("");
+    lines.push("# Question");
+    lines.push(req.question);
+  }
+  lines.push("");
+  lines.push("Reply with strict JSON only.");
+  return lines.join("\n");
+}
+
+/**
+ * Extract the first balanced `{...}` JSON object from a string. Lets
+ * the parser tolerate models that wrap their output in code fences or
+ * prose without us having to instruct them with `response_format`.
+ */
+function extractJsonObject(s: string): string {
+  const start = s.indexOf("{");
+  if (start < 0) return s;
+  let depth = 0;
+  let inStr = false;
+  let esc = false;
+  for (let i = start; i < s.length; i++) {
+    const ch = s[i]!;
+    if (inStr) {
+      if (esc) {
+        esc = false;
+      } else if (ch === "\\") {
+        esc = true;
+      } else if (ch === '"') {
+        inStr = false;
+      }
+      continue;
+    }
+    if (ch === '"') inStr = true;
+    else if (ch === "{") depth++;
+    else if (ch === "}") {
+      depth--;
+      if (depth === 0) return s.slice(start, i + 1);
+    }
+  }
+  return s.slice(start);
+}
+
+/* -------------------------------------------------------------------------- */
+/* analyze                                                                    */
+/* -------------------------------------------------------------------------- */
+
+export interface AnalyzeOpts {
+  readonly modelId: string;
+  readonly question?: string;
+  /** Per-column anomaly flags from `profileCsv` (used to seed `anomalies`). */
+  readonly columnFlags?: readonly ColumnFlags[];
+}
+
+export interface AnalyzeDeps {
+  readonly llm: LlmClient;
+  readonly now?: () => number;
+}
+
+export interface AnalyzeResult {
+  readonly markdown: string;
+  readonly report: AnalysisReport;
+}
+
+export async function analyze(
+  profile: DatasetProfile,
+  sample: DatasetSample,
+  opts: AnalyzeOpts,
+  deps: AnalyzeDeps,
+): Promise<AnalyzeResult> {
+  if (profile.columnCount === 0 || profile.rowCount === 0) {
+    throw new Error("data-analyze:planner:empty-dataset");
+  }
+
+  const llmReq: LlmRequest = {
+    profile,
+    sample,
+    modelId: opts.modelId,
+    ...(opts.question !== undefined ? { question: opts.question } : {}),
+  };
+  let report: AnalysisReport;
+  try {
+    report = await deps.llm.analyze(llmReq);
+  } catch (err) {
+    const msg = (err as Error).message;
+    if (
+      msg.startsWith("data-analyze:planner:llm-invalid") ||
+      msg.startsWith("data-analyze:planner:schema-mismatch") ||
+      msg.startsWith("data-analyze:planner:llm-timeout")
+    ) {
+      throw err;
+    }
+    throw new Error(`data-analyze:planner:llm-invalid: ${msg}`);
+  }
+  // Defensive re-validate (in case a fake llm returns a malformed shape).
+  const reparsed = zAnalysisReport.safeParse(report);
+  if (!reparsed.success) throw new Error("data-analyze:planner:schema-mismatch");
+  report = reparsed.data as AnalysisReport;
+
+  // Seed additional anomaly bullets from the local profiler flags so
+  // the rendered report includes them even when the LLM misses them.
+  const seeded = mergeAnomalies(report, profile.columns, opts.columnFlags ?? []);
+
+  const markdown = renderMarkdown(seeded, opts.question);
+  return { markdown, report: seeded };
+}
+
+function mergeAnomalies(
+  report: AnalysisReport,
+  columns: readonly ColumnProfile[],
+  flags: readonly ColumnFlags[],
+): AnalysisReport {
+  if (flags.length === 0) return report;
+  const extras: string[] = [];
+  for (let i = 0; i < flags.length; i++) {
+    const f = flags[i]!;
+    const c = columns[i];
+    if (!c) continue;
+    if (f.constant) extras.push(`Column \`${c.name}\` is constant.`);
+    else if (f.allDistinct)
+      extras.push(`Column \`${c.name}\` is all-distinct (likely an id).`);
+    if (f.highNullRate)
+      extras.push(`Column \`${c.name}\` has a null rate above 30%.`);
+    if (f.monotonic)
+      extras.push(`Column \`${c.name}\` is monotonic — possible row index.`);
+    if (f.outlierHeavy)
+      extras.push(`Column \`${c.name}\` has > 5% IQR outliers.`);
+  }
+  if (extras.length === 0) return report;
+  // Avoid duplicates — only append extras whose text isn't already present.
+  const existing = new Set(report.anomalies);
+  const merged = [...report.anomalies];
+  for (const e of extras) if (!existing.has(e)) merged.push(e);
+  return { ...report, anomalies: merged };
+}
+
+function renderMarkdown(report: AnalysisReport, question?: string): string {
+  const out: string[] = [];
+  out.push("# Data Analysis Report");
+  out.push("");
+  out.push("## Summary");
+  out.push(report.summary || "(no summary)");
+  out.push("");
+  out.push("## Findings");
+  for (const f of report.findings) out.push(`- ${f}`);
+  if (report.findings.length === 0) out.push("- (none)");
+  out.push("");
+  out.push("## Anomalies");
+  for (const a of report.anomalies) out.push(`- ${a}`);
+  if (report.anomalies.length === 0) out.push("- (none)");
+  out.push("");
+  out.push("## Suggested Questions");
+  for (const q of report.suggestedQuestions) out.push(`- ${q}`);
+  if (report.suggestedQuestions.length === 0) out.push("- (none)");
+  if (question !== undefined) {
+    out.push("");
+    out.push("## Answer");
+    out.push(report.answer ?? "(no answer)");
+  }
+  return out.join("\n");
+}
+
+export function sha256Hex(s: string): string {
+  return createHash("sha256").update(s, "utf8").digest("hex");
+}

--- a/keeper/bpps/data-analyze/source-loader.ts
+++ b/keeper/bpps/data-analyze/source-loader.ts
@@ -1,0 +1,182 @@
+/**
+ * CSV fetcher for the `data:analyze` BPP (FN-079).
+ *
+ * Resolves an `AnalyzeSource` to raw CSV/TSV text:
+ *  - `kind: "csv"`        — passthrough.
+ *  - `kind: "csvBase64"`  — base64-decode (validated) and decode utf-8.
+ *  - `kind: "url"`        — `fetch(url)` with a 30 s `AbortController`
+ *    timeout and a streaming-cap of `maxBytes` (default 16 MB);
+ *    accepts `text/csv`, `text/tab-separated-values`, `text/plain`,
+ *    `application/csv`. Non-2xx → `fetch_failed: <status>`. Oversized
+ *    → `source_too_large`.
+ *
+ * Side-effecting seams (`fetch`) are injected so the test suite can
+ * drive each branch with deterministic stubs.
+ */
+
+import type { AnalyzeSource } from "./types.js";
+
+/* -------------------------------------------------------------------------- */
+/* Constants                                                                  */
+/* -------------------------------------------------------------------------- */
+
+export const DEFAULT_FETCH_MAX_BYTES = 16 * 1024 * 1024;
+export const DEFAULT_FETCH_TIMEOUT_MS = 30_000;
+
+const ACCEPTED_CONTENT_TYPES = new Set([
+  "text/csv",
+  "text/tab-separated-values",
+  "text/plain",
+  "application/csv",
+  "application/octet-stream", // best-effort fallback
+]);
+
+/* -------------------------------------------------------------------------- */
+/* Types                                                                      */
+/* -------------------------------------------------------------------------- */
+
+export type FetchLike = (
+  url: string,
+  init?: { signal?: AbortSignal },
+) => Promise<FetchLikeResponse>;
+
+export interface FetchLikeResponse {
+  readonly ok: boolean;
+  readonly status: number;
+  readonly headers: { get(name: string): string | null };
+  arrayBuffer(): Promise<ArrayBuffer>;
+}
+
+export interface FetchCsvDeps {
+  readonly fetch: FetchLike;
+  readonly fetchTimeoutMs?: number;
+}
+
+export interface FetchedCsv {
+  readonly text: string;
+  readonly sourceBytes: number;
+  readonly contentType: string;
+}
+
+/* -------------------------------------------------------------------------- */
+/* fetchCsv                                                                   */
+/* -------------------------------------------------------------------------- */
+
+const BASE64_RE = /^[A-Za-z0-9+/=\s]+$/;
+
+export async function fetchCsv(
+  source: AnalyzeSource,
+  deps: FetchCsvDeps,
+): Promise<FetchedCsv> {
+  switch (source.kind) {
+    case "csv": {
+      if (!isUtf8Decodable(Buffer.from(source.text, "utf8"))) {
+        throw new Error("encoding_unsupported");
+      }
+      return {
+        text: source.text,
+        sourceBytes: Buffer.byteLength(source.text, "utf8"),
+        contentType: "text/csv",
+      };
+    }
+    case "csvBase64": {
+      const cleaned = source.data.replace(/\s+/g, "");
+      if (!BASE64_RE.test(source.data)) {
+        throw new Error("input_too_large: invalid base64");
+      }
+      let buf: Buffer;
+      try {
+        buf = Buffer.from(cleaned, "base64");
+      } catch {
+        throw new Error("input_too_large: invalid base64");
+      }
+      if (!isUtf8Decodable(buf)) {
+        throw new Error("encoding_unsupported");
+      }
+      return {
+        text: buf.toString("utf8"),
+        sourceBytes: buf.length,
+        contentType: "text/csv",
+      };
+    }
+    case "url":
+      return await fetchUrl(source.url, source.maxBytes, deps);
+  }
+}
+
+async function fetchUrl(
+  url: string,
+  maxBytesOpt: number | undefined,
+  deps: FetchCsvDeps,
+): Promise<FetchedCsv> {
+  const maxBytes = maxBytesOpt ?? DEFAULT_FETCH_MAX_BYTES;
+  const timeoutMs = deps.fetchTimeoutMs ?? DEFAULT_FETCH_TIMEOUT_MS;
+  const ctrl = new AbortController();
+  const timer = setTimeout(() => ctrl.abort(), timeoutMs);
+  let resp: FetchLikeResponse;
+  try {
+    resp = await deps.fetch(url, { signal: ctrl.signal });
+  } catch (err) {
+    clearTimeout(timer);
+    throw new Error(`fetch_failed: ${(err as Error).message}`);
+  }
+  clearTimeout(timer);
+
+  if (!resp.ok) {
+    throw new Error(`fetch_failed: ${resp.status}`);
+  }
+
+  const cl = resp.headers.get("content-length");
+  if (cl !== null) {
+    const declared = Number(cl);
+    if (Number.isFinite(declared) && declared > maxBytes) {
+      throw new Error("source_too_large");
+    }
+  }
+
+  const buf = Buffer.from(await resp.arrayBuffer());
+  if (buf.length > maxBytes) {
+    throw new Error("source_too_large");
+  }
+
+  const ctRaw = resp.headers.get("content-type") ?? "application/octet-stream";
+  const ct = ctRaw.split(";")[0]!.trim().toLowerCase();
+  if (!ACCEPTED_CONTENT_TYPES.has(ct) && !ct.startsWith("text/")) {
+    throw new Error(`unsupported_content_type: ${ct}`);
+  }
+
+  if (!isUtf8Decodable(buf)) {
+    throw new Error("encoding_unsupported");
+  }
+
+  return {
+    text: buf.toString("utf8"),
+    sourceBytes: buf.length,
+    contentType: ct,
+  };
+}
+
+/* -------------------------------------------------------------------------- */
+/* Utf-8 validation                                                           */
+/* -------------------------------------------------------------------------- */
+
+/**
+ * Validate that `buf` is well-formed UTF-8. Re-encodes after decoding
+ * and compares byte-length so invalid sequences (which Node would
+ * otherwise replace with U+FFFD silently) are detected.
+ *
+ * Permissive of pure-ASCII input (the common case), and rejects
+ * anything that contains a replacement character that wasn't already
+ * present in the source bytes.
+ */
+function isUtf8Decodable(buf: Buffer): boolean {
+  try {
+    const decoded = new TextDecoder("utf-8", { fatal: true }).decode(buf);
+    // Round-trip check — defensive belt + braces against runtimes that
+    // don't honour `fatal: true`.
+    const reencoded = Buffer.from(decoded, "utf8");
+    return reencoded.length === buf.length;
+  } catch {
+    return false;
+  }
+}

--- a/tests/unit/data-analyze-bpp.test.ts
+++ b/tests/unit/data-analyze-bpp.test.ts
@@ -815,7 +815,7 @@ describe("createDataAnalyzeHandler", () => {
     );
     expect(res.status).toBe("failure");
     if (res.status === "failure") {
-      expect(res.reason).toBe("empty_dataset");
+      expect(res.reason).toBe("data-analyze:planner:empty-dataset");
     }
   });
 });


### PR DESCRIPTION
## Summary
- Add `planner.ts` (canonical rename of `analyzer.ts`) with `data-analyze:planner:<phase>` error taxonomy (`llm-invalid`, `schema-mismatch`, `llm-timeout`, `empty-dataset`)
- Add `source-loader.ts` (canonical rename of `fetcher.ts`)
- Move profiler internals to `analyzers/profiler.ts` subdir per FN-201 acceptance layout
- Update `handler.ts` empty-dataset error code and `stableReason` KNOWN list to include new taxonomy prefix
- Original files kept for backward compat; new canonical files are the implementation

## Test plan
- [ ] `pnpm test tests/unit/data-analyze-bpp.test.ts` — 57 tests pass
- [ ] `tsc -p tsconfig.build.json --noEmit` — clean (exit 0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)