### PR TITLE
feat(FN-073): thread gateway callerPubkey onto BeckonInitEvent and TaskRequest

### DIFF
--- a/keeper/templates/bpp/runtime.ts
+++ b/keeper/templates/bpp/runtime.ts
@@ -200,6 +200,9 @@ async function dispatchOne<TInput, TOutput>(
     networkPubkey: event.networkPubkey,
     action: event.action,
     input: event.input,
+    // FN-073: thread gateway-verified caller pubkey through to the handler.
+    // Absent when the gateway could not verify a BAP signature.
+    ...(event.callerPubkey != null ? { callerPubkey: event.callerPubkey } : {}),
   };
   let result: TaskResult<TOutput>;
   try {

--- a/keeper/templates/bpp/types.ts
+++ b/keeper/templates/bpp/types.ts
@@ -133,6 +133,19 @@ export interface BeckonInitEvent<TInput = unknown> {
   readonly input: TInput;
   /** Unix seconds at which the event was observed. */
   readonly observedAt: number;
+  /**
+   * Gateway-verified BAP caller pubkey (FN-073).
+   *
+   * Set by the gateway layer when it has successfully verified the
+   * BAP-signature on the inbound Beckn request (Ed25519 over the request
+   * body, presented in the `Authorization` header). Absent / undefined when
+   * the gateway could not verify a signature — handlers MUST treat absence
+   * as `unauthorized_caller` for any money-binding capability.
+   *
+   * The value is the lowercase hex-encoded ed25519 public key of the BAP
+   * whose signature was verified.
+   */
+  readonly callerPubkey?: string;
 }
 
 /** Inbound task (mirror of BeckonInitEvent at the handler layer). */
@@ -143,6 +156,17 @@ export interface TaskRequest<TInput = unknown> {
   readonly networkPubkey: Pubkey;
   readonly action: string;
   readonly input: TInput;
+  /**
+   * Gateway-verified BAP caller pubkey (FN-073).
+   *
+   * Threaded from `BeckonInitEvent.callerPubkey` by the BPP runtime.
+   * Per-capability handlers use {@link extractCallerPubkey} (from
+   * `keeper/bpps/bank/handler.ts`) to read this field and `assertCallerEquals`
+   * (from `keeper/bpps/bank/auth.ts`) to bind it to the request subject.
+   * Absent / undefined means the gateway did not verify a caller — handlers
+   * MUST fail-closed with `unauthorized_caller` for any money-binding action.
+   */
+  readonly callerPubkey?: string;
 }
 
 /**


### PR DESCRIPTION
## Summary

- Adds optional `callerPubkey?: string` to `BeckonInitEvent<T>` and `TaskRequest<T>` in `keeper/templates/bpp/types.ts`
- Threads the field through `dispatchOne` in `keeper/templates/bpp/runtime.ts` so gateway-verified caller pubkeys reach per-capability handlers
- The bank BPP's existing `extractCallerPubkey(req)` and `assertCallerEquals` (FN-015) can now read a properly typed `callerPubkey` once the gateway populates it
- No breaking changes: field is optional; handlers that don't read it are unaffected

## Test plan

- [x] `bun run typecheck` — exit 0
- [x] `npx vitest run tests/unit/bank-bpp.test.ts` — 51 passed
- [x] `BeckonInitEvent.callerPubkey` documented with gateway-auth contract
- [x] `TaskRequest.callerPubkey` documented as the handler-layer view
- [x] `dispatchOne` spreads `callerPubkey` only when non-null

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for gateway-verified caller identity information to be propagated through the system runtime, enabling caller verification capabilities in downstream operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->