### PR TITLE
feat(FN-030): add signWithJose compact-JWS wrapper to audit-trail

### DIFF
--- a/.changeset/FN-064-memo.md
+++ b/.changeset/FN-064-memo.md
@@ -1,0 +1,5 @@
+---
+"@eto/mcp": minor
+---
+
+Added optional `memo` parameter to `buildTransferTx` (SPL Memo Program v2 instruction prepended). Backward compatible — calls without `memo` (or with an empty-string `memo`) produce byte-identical transactions to the prior 4-argument signature, so existing callers and on-chain signatures are unaffected. With a memo, two transfers that differ only in their memo string produce distinct transaction bytes (and therefore distinct signatures), which the `transfer` tools (single + batch) rely on for idempotency-safe parallel submissions.

--- a/.changeset/fn-020-claim-commitments-examples.md
+++ b/.changeset/fn-020-claim-commitments-examples.md
@@ -1,0 +1,74 @@
+# FN-020: Banking credential `claimCommitments` examples — consolidation
+
+## Summary
+
+Confirms and pins the §10.3.1 `claimCommitments` block in the four banking
+credential JSON-LD templates under `spec/banking/credentials/`. The structural
+schema additions and worked examples (with real Poseidon-2 hex) were
+originally landed by **FN-200**; the producer primitive
+`computeClaimCommitments` was landed by **FN-077** as
+`src/issuers/claim-commitments.ts`. This changeset records FN-020's
+verification pass and explicitly unblocks the downstream verification gates.
+
+## Affected templates
+
+- `spec/banking/credentials/account-checking.json`
+- `spec/banking/credentials/account-savings.json`
+- `spec/banking/credentials/card-debit.json`
+- `spec/banking/credentials/tax-1099.json`
+
+## Per-entry contract (§10.3.1)
+
+Each entry binds one leaf of `credentialSubject`:
+
+| Field            | Definition                                                                          |
+|------------------|-------------------------------------------------------------------------------------|
+| `fieldPath`      | Dot-separated leaf path under `credentialSubject` (e.g. `credentialSubject.holder`) |
+| `idx`            | 0-based position in the **byte-stable** lex sort of leaf `fieldPath`s               |
+| `commitment`     | 32-byte LE lowercase hex of `Poseidon2_t3([encodeFr(value), encodeSalt(salt), Fr(idx)])` |
+| `saltCommitment` | 32-byte LE lowercase hex of `Poseidon2_t3([encodeSalt(salt), 0, Fr(idx)])`          |
+
+`idx` MUST equal the `field_index` public input of
+`verify_credential_predicate`, so the lex-sort over leaf paths is the
+security-critical contract that lets selective-disclosure proofs match.
+
+## Example hex
+
+The `examples[0].claimCommitments` block in each schema contains **real
+Poseidon-2 outputs** (BN254 Fr, t=3) — never placeholders. They were
+originally produced by `eto-zk-cli commit` (FN-082) using deterministic test
+salts (byte `i+1` repeated 32 times for the i-th sorted entry). Production
+issuers MUST sample fresh CSPRNG salts per attribute (see
+`src/issuers/claim-commitments.ts` — FN-077).
+
+## Test coverage
+
+`tests/bank/credential-schemas.test.ts` is the round-trip + drift guard:
+
+1. Asserts each schema declares `claimCommitments` in `required` and that
+   `properties.claimCommitments.items.required` covers
+   `[fieldPath, idx, commitment, saltCommitment]`.
+2. Asserts every `commitment` and `saltCommitment` matches `/^[0-9a-f]{64}$/`
+   and that `claimCommitments[i].idx === i` with lex-sorted `fieldPath`s.
+3. Re-derives a fresh `claimCommitments` array via `computeClaimCommitments`
+   (FN-077) against `examples[0].credentialSubject`, swaps it into a
+   synthetic example, and asserts the synthetic example still validates
+   against the schema. This is the contract guarantee that the producer
+   primitive and the schema agree, even though CSPRNG salts make raw hex
+   non-deterministic.
+
+## Downstream
+
+This changeset unblocks the schema-validation gates filed as **FN-069**,
+**FN-076**, and **FN-086**, and confirms the consumer shape `computeClaimCommitments`
+(FN-077) emits matches the per-entry contract pinned here. Wiring of
+`computeClaimCommitments` into `src/issuers/bank.ts` and
+`keeper/bpps/bank/handlers/tax-1099-sketch.ts` remains FN-077 / FN-063 /
+FN-064 work and is intentionally out of scope here.
+
+## References
+
+- `spec/SINGULARITY-LAYER-1.md` §10.3.1 — canonical entry contract.
+- FN-082 — Poseidon-2 t=3 over BN254 (`src/crypto/poseidon2.ts`).
+- FN-077 — `src/issuers/claim-commitments.ts` (`computeClaimCommitments`).
+- FN-200 — original schema + example landing.

--- a/.changeset/fn-077-claim-commitments.md
+++ b/.changeset/fn-077-claim-commitments.md
@@ -1,0 +1,64 @@
+# FN-077: Issuers embed `claimCommitments` per §10.3.1
+
+## Summary
+
+All five reference issuer services now embed a per-leaf `claimCommitments`
+array into the off-chain VC body **before** computing
+`claim_hash = sha256(JCS(vcWithoutProof))`, per
+`spec/SINGULARITY-LAYER-1.md` §10.3.1 (ratified by FN-212, primitive landed
+by FN-082, and previously documented in the banking JSON-LD templates by
+FN-200).
+
+This is **additive** — no existing field is removed — but `claim_hash` for
+**newly issued** credentials now binds the per-attribute Poseidon-2
+commitments. Pre-FN-077 issued credentials are unaffected; their existing
+on-chain `claim_hash` continues to validate against their original
+(no-`claimCommitments`) JCS bytes.
+
+## What changed
+
+- **New shared utility** `src/issuers/claim-commitments.ts` exporting
+  `computeClaimCommitments(credentialSubject, opts?)` and the
+  `ClaimCommitment` type. Implements §10.3.1 byte-stable lex ordering of
+  `fieldPath`s, `idx = 0..n-1`, `commitment = Poseidon2_t3([value, salt, idx])`,
+  `saltCommitment = Poseidon2_t3([salt, 0, idx])`, 32-byte LE lowercase hex
+  (no `0x`). Salts are sourced from `globalThis.crypto.getRandomValues` by
+  default; tests inject deterministic CSPRNGs via the `randomBytes` hook.
+- Five reference issuers wired:
+  `src/issuers/worldcoin.ts`, `civic.ts`, `kyc-test.ts`, `skill-cert.ts`,
+  `bank-mock.ts`. Each builds its VC envelope, computes
+  `claimCommitments`, embeds the array on the envelope, and only then
+  computes `claim_hash` / pins / submits `IssueCredential`. Each issuer
+  exposes an optional `randomBytes` dep for test determinism.
+- `tests/issuers/claim-commitments.test.ts` (new) pins the §10.3.1 contract
+  end-to-end with KAT regressions against `poseidon2` + `encodeFr` +
+  `encodeSalt` + `bytesToHex32`.
+- Banking JSON-LD templates (`spec/banking/credentials/*.json`) already
+  declare the property courtesy of FN-200 — no template changes here.
+
+## What did NOT change
+
+- `src/issuers/bank.ts` (production banking issuer) is intentionally **not**
+  wired in this changeset. A follow-up task (filed via the Fusion board) will
+  bring `bank.ts` onto the same path so that production-issued banking
+  credentials commit to `claimCommitments`.
+- The `eto-zk` Rust crate, on-chain verifier VK, and Groth16 keys are
+  untouched. The TS port of Poseidon-2 lives in `src/crypto/poseidon2.ts`
+  and is the FN-212-ratified parameter set, KAT-locked against the Rust
+  reference.
+
+## Array-leaf encoding (v0)
+
+§10.3.1's encoding table does not enumerate arrays. As a v0 convention this
+implementation encodes array leaves via `encodeFr(JSON.stringify(arr))` —
+i.e. the string path with NFC + 31-byte truncation + length byte. A
+follow-up will be filed if §10.3.1 later mandates per-element encoding.
+
+## Compatibility
+
+- **On-chain:** semantics-additive. New issuances commit to a new
+  `claim_hash` value; old credentials still verify against their original
+  bytes.
+- **Off-chain consumers:** any consumer that re-derives `claim_hash` MUST
+  now include the issuer's `claimCommitments` array in its JCS input
+  (it is a top-level VC field).

--- a/.changeset/fn-200-claim-commitments.md
+++ b/.changeset/fn-200-claim-commitments.md
@@ -1,0 +1,51 @@
+# FN-200: claimCommitments block in banking credential JSON-LD templates
+
+## Summary
+
+Extends the four banking credential schemas in `spec/banking/credentials/` to
+include the §10.3.1 `claimCommitments` JSON-LD block ratified by FN-212 and
+implemented in FN-082.
+
+## Affected templates
+
+- `spec/banking/credentials/account-checking.json`
+- `spec/banking/credentials/account-savings.json`
+- `spec/banking/credentials/card-debit.json`
+- `spec/banking/credentials/tax-1099.json`
+
+## Changes
+
+Each schema now:
+
+1. Declares `claimCommitments` in `properties` and `required`.
+2. Pins the per-entry shape from §10.3.1: `{ fieldPath, idx, commitment, saltCommitment }`,
+   with `commitment` / `saltCommitment` constrained to 64-hex (32-byte LE).
+3. Ships a worked `examples[]` envelope whose `claimCommitments` array contains
+   **real Poseidon-2 outputs over BN254 `Fr`, `t=3`** produced by
+   `eto-zk-cli commit` (FN-082) — not placeholder hex.
+
+## Reproducibility
+
+Two helper scripts are checked in alongside the schemas:
+
+- `scripts/fn-200-build-commitments.mjs` — drives `eto-zk-cli commit` over the
+  example credentialSubject objects and emits the full claimCommitments arrays.
+- `scripts/fn-200-emit-schemas.mjs` — patches each schema with the
+  `claimCommitments` definition + worked example.
+
+Salts in the example envelopes are deterministic test salts (byte `i+1`
+repeated 32 times for the i-th sorted entry). Real issuers MUST sample salts
+from a CSPRNG and never reuse them.
+
+## Tests
+
+`tests/bank/credential-schemas.test.ts` (new) compiles each schema under
+ajv 2020-12 and asserts the embedded example validates, that
+`claimCommitments` covers every credentialSubject leaf, and that entries are
+sorted lexicographically by `fieldPath` with `idx` matching position.
+
+## Unblocks
+
+- FN-077 — selective-disclosure ZK proof embedding via `claim_commitment` slot 0.
+- Bank issuer flows that emit checking / savings / card / 1099 credentials now
+  have a concrete schema-of-record for the `claimCommitments` envelope.

--- a/README.md
+++ b/README.md
@@ -263,9 +263,10 @@ injectable `KytEventSource` and emits a deterministic JSON-LD audit
 feed shaped as a `VerifiableCredential` of type
 `["VerifiableCredential", "AuditTrailFeed"]`. Events are sorted by
 `(slot, txSignature)` for byte-stable output, and the
-`credentialSubject.summary` carries per-stage counters. v0 is
-**unsigned** (issuer DID `did:eto:indexer:audit-trail:v0` is a
-placeholder); the production source will subscribe to
+`credentialSubject.summary` carries per-stage counters. Signing is opt-in via the injected `VcSigner` (FN-084); the default
+`NoOpVcSigner` preserves the historical unsigned shape (no `proof`
+key, issuer DID `did:eto:indexer:audit-trail:v0`). The production
+source will subscribe to
 `singularity:kyt:*` and `singularity:revocation:root_updated` log
 lines via Solana JSON-RPC `logsSubscribe`. Consumed downstream by the
 1099 issuer (FN-132) and travel-rule generator (FN-133). Tests use the
@@ -304,8 +305,52 @@ are resolved via the injected `AmountResolver`. v0 ships the in-memory
 reference implementations (`InMemoryPartyDirectory`,
 `InMemoryAmountResolver`); production wiring (backed by the issuer
 registry and `EtoRpcClient` transaction lookups) is a follow-up task.
-v0 reports are **unsigned** (issuer DID `did:eto:indexer:travel-rule:v0`
-is a placeholder). Per spec §9.3: `parties[0]` (BAP) is the originator;
+Signing is opt-in via the injected `VcSigner` (FN-084); the default
+`NoOpVcSigner` preserves the historical unsigned shape (issuer DID
+`did:eto:indexer:travel-rule:v0`, no `proof` key on the document). Per
+spec §9.3: `parties[0]` (BAP) is the originator;
 `parties[1]` (BPP) is the beneficiary. Entries are sorted by
 `(slot, txSignature)` for byte-stable output; the injectable `clock`
 allows tests to pin `issuanceDate` for deterministic assertions.
+
+### Audit / travel-rule signing (`@eto/mcp` → `src/services/indexer/vc-signer.ts`)
+
+FN-084. Compliance-grade `Ed25519Signature2020` proof blocks for the
+audit-trail and travel-rule JSON-LD documents per the W3C VC Data
+Integrity 1.0 spec. Signing is **opt-in**: the default `NoOpVcSigner`
+emits the historical unsigned shape (no `proof` key, byte-stable
+against pre-FN-084 fixtures). To enable signing, set
+`AUDIT_SIGNING_KEY_PATH` and inject `createVcSignerFromEnv({ issuerDid })`
+into `AuditTrailIndexerDeps.signer` / `TravelRuleReportGeneratorDeps.signer`.
+
+**Env var.**
+
+- `AUDIT_SIGNING_KEY_PATH` — filesystem path to a 32-byte Ed25519 seed.
+  The file may be raw 32 bytes, hex (with or without `0x` prefix), or
+  base64 / base64url. Anything else throws `expected 32-byte Ed25519
+  seed`. The loaded secret is never logged or echoed back in error
+  messages.
+
+**Proof block shape.** Attached as `feed.proof` /
+`report.proof` when a non-NoOp signer is configured:
+
+```jsonc
+{
+  "type": "Ed25519Signature2020",
+  "created": "2026-05-02T12:34:56.000Z",
+  "verificationMethod": "did:eto:issuer:bank-prod#key-1",
+  "proofPurpose": "assertionMethod",
+  "proofValue": "<base64url(Ed25519(sha256(JCS(vcWithoutProof))))>"
+}
+```
+
+**Hash input (spec §11.4).** `claim_hash = sha256(JCS(vcWithoutProof))`.
+The `proof` block itself is **excluded** from the JCS preimage; the
+indexer wiring strips it before calling `signer.sign(...)` and only
+attaches the returned proof afterwards.
+
+**Backwards compatibility.** When `AUDIT_SIGNING_KEY_PATH` is unset (or
+no `signer` is injected), the default `NoOpVcSigner` returns a sentinel
+proof with `proofValue === ""`; the indexers detect this and OMIT the
+`proof` key entirely so output is byte-identical to v0. All existing
+fixture-based tests pass unchanged.

--- a/claude-mcp-config.md
+++ b/claude-mcp-config.md
@@ -47,7 +47,7 @@ Or add manually to `~/.claude/claude_desktop_config.json`:
 ### All Categories
 | Category | Tools | Count |
 |----------|-------|-------|
-| Query | get_balance, get_account, get_transaction, get_block, search, get_chain_stats, get_block_height, get_account_transactions | 8 |
+| Query | get_balance, get_account, get_transaction, get_block, search, get_chain_stats, get_block_height, get_account_transactions, query_memos | 9 |
 | Wallet | create_wallet, import_wallet, list_wallets, get_wallet, set_active_wallet, derive_address | 6 |
 | Transfer | transfer_native, batch_transfer, estimate_fee | 3 |
 | Token | create_token, mint_tokens, transfer_token, burn_tokens, get_token_info, get_token_balance, list_token_holdings, freeze_token_account | 8 |

--- a/docs/agent-identity-model.md
+++ b/docs/agent-identity-model.md
@@ -1,0 +1,310 @@
+# ETO Agent Identity Model — `human × model × environment`
+
+> Tracking issue: [etofdn/eto-mcp#11](https://github.com/etofdn/eto-mcp/issues/11)
+> Upstream task: **FN-058** (this spec).
+> Downstream: **FN-059** (authority-inheritance enforcement), **FN-060** (A2A coordination), **FN-061** (model-attestation research). Part of the **FN-054** A2A milestone.
+>
+> Status: **normative spec, no runtime wiring yet.** A reference TypeScript shape lives at [`src/models/agent-identity.ts`](../src/models/agent-identity.ts); no MCP tool currently emits or consumes it. FN-059 is the first task that will wire it into a request handler.
+
+---
+
+## §1 — Why a multi-axis identity
+
+Today's session model in `src/gateway/session.ts` answers a single question:
+*"Is this caller's bearer token validly signed for some `sub`?"* That binds a
+request to a **human authority** (the user behind `sub`) and to a bounded
+**session scope** (`exp`, `caps`, `wallet_id`). It is silent on two questions
+that A2A coordination ([FN-054](#)) forces us to answer:
+
+1. **Which AI model produced this action?** Two MCP sessions can share the same
+   `sub` while running on completely different model providers (Claude, GPT,
+   self-hosted Llama). Trust decisions about *autonomous-agent* behavior — rate
+   limits, capability gating, audit logs — need to attribute actions to a
+   model, not just a person.
+2. **Where is the agent executing?** "The same human" running ETO from the
+   stdio CLI on their laptop, from a hosted SSE deployment, and from a CI
+   runner is three different *execution surfaces*. The cryptographic anchor
+   (the wallet keys actually doing the signing) and the network-reachable
+   endpoint are surface-specific.
+
+The agent identity model therefore tuples four orthogonal axes:
+
+```
+AgentIdentity = {
+  human_authority,    // who authorized this agent
+  model_attestation,  // what AI is steering it
+  environment,        // where it's running + crypto anchor
+  session_scope,      // bounded MCP session window
+}
+```
+
+Each axis has its own source-of-truth, its own threat model, and its own
+verification roadmap. They compose: an A2A counterpart that wants to trust an
+incoming message MUST evaluate all four, and MAY make different trust
+decisions on each.
+
+---
+
+## §2 — The four fields
+
+### §2.1 — `human_authority`
+
+| | |
+|---|---|
+| **Definition** | The human (or human-controlled service account) that consented to this agent acting on their behalf. |
+| **Type (TS)** | `HumanAuthority` |
+| **Source-of-truth (today)** | `SessionPayload.sub` + `SessionPayload.auth_strategy` from `src/gateway/session.ts`, surfaced via `authenticate()` in `src/gateway/auth.ts`. |
+| **Concrete values today** | `sub` = thirdweb-issued wallet address (SIWE / inapp_email / inapp_oauth strategies), the literal `"dev-user"` (dev-bypass), or the synthetic `"__stdio__"` scope when running over stdio without auth. |
+| **Trust assumption** | The session token's HMAC signature attests that *some* trusted auth backend issued this `sub`. The strength of that attestation is a function of `auth_strategy`: `siwe` ≥ `inapp_oauth` ≥ `inapp_email` ≫ `dev`. `__stdio__` carries no human attestation at all and MUST be treated as local-only. |
+| **Threat model** | Compromise of `SESSION_SIGNING_KEY` lets an attacker forge any `sub`. Compromise of an upstream IdP (thirdweb) lets an attacker take over a single user's `sub`. Cross-tenant impersonation is out of scope for this spec (see [§7 Non-goals](#7-non-goals)). |
+
+### §2.2 — `model_attestation`
+
+| | |
+|---|---|
+| **Definition** | A claim about which AI model/provider produced the agent's tool calls, and whether that claim is cryptographically verified. |
+| **Type (TS)** | `ModelAttestation` with discriminator `attestation_status: "verified" \| "self_declared" \| "absent"`. |
+| **Source-of-truth (forward)** | A provider-signed JWT/JWS attesting `{ model_id, provider, issued_at, audience }`, verified against the provider's published JWKS. Tracked by **FN-061**. |
+| **Source-of-truth (today)** | None. The MCP server cannot today verify what model is on the other end of the protocol; the field is `attestation_status: "self_declared"` carrying whatever the agent advertises in a `User-Agent`-style header, or `attestation_status: "absent"` if nothing was sent. |
+| **Trust assumption** | When `attestation_status === "verified"`: trust the provider's JWKS. When `"self_declared"`: treat the model claim as a **hint for telemetry only**, never for capability gating. When `"absent"`: do not branch on model identity at all. |
+| **Threat model** | Self-declared values can be spoofed trivially. Verified values inherit the provider's KMS posture; signature replay across audiences is mitigated by `aud` binding to the MCP server's origin. |
+
+This is the axis that explicitly *does not work today*. The interim path
+(see [§5](#5-interim-implementation-works-today)) is to record the
+self-declared claim and propagate `attestation_status: "self_declared"` so
+downstream code can refuse to trust it.
+
+### §2.3 — `environment`
+
+| | |
+|---|---|
+| **Definition** | The execution surface the agent is running on, plus the cryptographic wallet anchor it controls. |
+| **Type (TS)** | `Environment` |
+| **Source-of-truth** | `currentScope()` from `src/signing/session-context.ts` (`__stdio__` / `__dev__` / thirdweb sub) for the surface; `localSignerFactory` (`src/signing/local-signer.ts`) for the SVM (Ed25519 base58) and EVM (secp256k1 0x-hex) addresses derived from the active wallet. |
+| **Concrete values** | `surface ∈ { "stdio", "sse", "dev" }`, `server_instance` = `last_restart_iso` from `session_info`, `wallet_anchor = { id, svm, evm }` from the active wallet. |
+| **Trust assumption** | The wallet anchor is the **strongest** signal in this entire model: anyone presenting a signature over a fresh challenge from `wallet_anchor.svm` or `wallet_anchor.evm` proves possession of the corresponding private key. A2A trust SHOULD prefer wallet-anchor proofs over `human_authority` claims when they disagree. |
+| **Threat model** | A surface label (`"sse"`) is unauthenticated metadata. A wallet address is authenticated metadata only after a fresh signature challenge — never trust a wallet address presented in a payload alone. |
+
+### §2.4 — `session_scope`
+
+| | |
+|---|---|
+| **Definition** | The bounded MCP session window inside which this identity is valid. |
+| **Type (TS)** | `SessionScope` |
+| **Source-of-truth** | `SessionPayload.{ jti, exp, caps }` plus the persistence-key `scope` string from `currentScope()`. |
+| **Concrete values** | `{ scope, jti, expires_at_iso, capabilities[] }`. |
+| **Trust assumption** | A token with `exp < now` is invalid regardless of how strong every other axis is. Capabilities (`caps[]`) are the authoritative authorization list; identity in this spec does NOT confer capability — it only attributes. |
+| **Threat model** | Token replay before `exp` is mitigated by HMAC binding + the `revoked_jtis` denylist in `src/gateway/session.ts`. Capability escalation is gated by `requireCapability()`, not by anything in this spec. |
+
+---
+
+## §3 — Authority inheritance rule
+
+> **Rule.** Two `AgentIdentity` values `A` and `B` MAY transitively trust each
+> other for the *intersection* of `A.session_scope.capabilities` and
+> `B.session_scope.capabilities`, **iff** all of the following hold:
+>
+> 1. `A.human_authority.sub === B.human_authority.sub`, AND
+> 2. Both `A.human_authority` and `B.human_authority` carry an
+>    `auth_strategy` other than `"dev"` and a scope other than `"__stdio__"`
+>    (i.e. both are anchored to a real human-authenticated backend), AND
+> 3. Neither `session_scope` is expired.
+>
+> The rule is **silent on `model_attestation`**: two agents inherit authority
+> across model providers, because the human is the same human. The rule is
+> **silent on `environment`**: a user can fan out work from their laptop to a
+> hosted runner under the same `sub`, and inheritance still holds.
+
+### §3.1 — Worked example
+
+Alice signs in with thirdweb SIWE on her laptop. The MCP server issues
+session token `T_laptop` with `sub = 0xAlice`, `auth_strategy = "siwe"`,
+`caps = [a2a:write, transfer:write, …]`. Her IDE runs Claude.
+
+Alice also has a hosted runner that authenticated as `0xAlice` through the
+same thirdweb provider; it holds session token `T_runner` with the same `sub`
+but `caps = [a2a:write, a2a:read]` only (narrowed by capability scoping at
+issuance). It runs GPT.
+
+A2A message flow: the runner agent (GPT) sends an A2A message to a counterpart
+that holds `T_laptop` (Claude). The receiver evaluates inheritance:
+
+- `sub` matches (`0xAlice` ↔ `0xAlice`) ✓
+- both `auth_strategy = "siwe"` ✓
+- both unexpired ✓
+
+→ The receiver MAY treat the message as Alice-authorized. The action it can
+ultimately *perform* is gated by **its own** `capabilities[]`, not the
+sender's: inheritance attributes intent, it does not lend caps. If the
+receiver only has `a2a:read`, it cannot turn an inherited request into a
+`transfer:write`.
+
+### §3.2 — When inheritance does NOT apply
+
+- `__stdio__` ↔ anything: stdio carries no human attestation, so it cannot
+  inherit from or to an authenticated session. Stdio agents are local trust
+  only.
+- `__dev__` / `auth_strategy = "dev"`: dev-bypass MUST NOT inherit into
+  production-strategy sessions even on a `sub` collision.
+- `model_attestation`-based gating: a counterpart MAY *additionally* require
+  `model_attestation.attestation_status === "verified"` for a specific
+  capability. That check is layered ON TOP of the rule above; it does not
+  weaken it.
+
+---
+
+## §4 — Verification roadmap for `model_attestation`
+
+The eventual flow ([FN-061](#) tracks the research):
+
+1. The agent runtime obtains a short-lived JWT from its model provider with
+   payload approximately:
+   ```json
+   {
+     "iss": "https://provider.example/v1",
+     "sub": "model:claude-3-7-sonnet-20250219",
+     "aud": "https://mcp.eto.example",
+     "iat": 1735689600,
+     "exp": 1735690200,
+     "model_id": "claude-3-7-sonnet-20250219",
+     "provider": "anthropic"
+   }
+   ```
+2. The agent attaches the JWT in an `X-Model-Attestation` header (or MCP
+   transport equivalent) on each outbound MCP request.
+3. The MCP server verifies the JWT against the provider's published JWKS
+   (cached, with rotation). `aud` MUST equal the server's canonical origin.
+4. On success: emit `ModelAttestation` with `attestation_status: "verified"`,
+   carrying `provider`, `model_id`, and the signature's `kid`.
+5. On any failure (signature, `aud`, `exp`, unknown provider): emit
+   `attestation_status: "absent"`. Do NOT downgrade to `"self_declared"` —
+   self-declared is for the case where there was *no* attestation attempted.
+
+**Open design questions** flagged for FN-061:
+
+- Signature algorithm — RFC 9458/9461 / JWS `EdDSA` vs. `ES256`.
+- Key discovery — direct JWKS URL vs. a registry like
+  [`oauth-for-ai-agents`](https://github.com/etofdn/eto-mcp/issues/11)-style
+  IdP federation.
+- Revocation — short `exp` (≤ 60 s) is the working assumption; explicit
+  revocation lists are deferred.
+- Tenant binding — whether `aud` alone is enough, or a per-deployment nonce
+  is required to defeat replay across ETO instances.
+
+---
+
+## §5 — Interim implementation (works today)
+
+Until FN-061 lands, every `AgentIdentity` we can construct has
+`model_attestation.attestation_status` of `"self_declared"` or `"absent"`.
+Construction reuses the existing `session_info` MCP tool's response shape
+*as data input only* — no new tool, no change to `session_info` itself
+(that's FN-059's job).
+
+A pure builder is exported as
+[`buildInterimAgentIdentity`](../src/models/agent-identity.ts) with this
+contract:
+
+```ts
+buildInterimAgentIdentity({
+  // session_info-shaped payload:
+  scope,                       // currentScope()
+  active_wallet_id,            // wallet.ts
+  wallets: [{ id, label, svm, evm }, ...],
+  auth_strategy,               // SessionPayload.auth_strategy | null
+  token_expires_at,            // ISO string | null
+  last_restart_iso,            // server boot ISO
+  // optional caller-provided hints:
+  declared_model?: { provider, model_id }, // becomes self_declared attestation
+  capabilities?: string[],     // SessionPayload.caps | undefined
+  jti?: string,                // SessionPayload.jti | undefined
+}): AgentIdentity
+```
+
+The builder:
+
+1. Maps `scope` + `auth_strategy` into `human_authority`, computing
+   `human_authority.kind` as `"thirdweb"` (real `sub`),
+   `"stdio"` (`scope === "__stdio__"`), `"dev"` (`auth_strategy === "dev"`
+   or `scope === "__dev__"`), or `"unknown"`.
+2. Maps the active wallet's `{svm, evm}` into `environment.wallet_anchor`,
+   and `last_restart_iso` into `environment.server_instance`. Surface is
+   inferred from `scope` (`"__stdio__"` → `"stdio"`, `"__dev__"` → `"dev"`,
+   anything else → `"sse"`).
+3. If `declared_model` is provided, emits
+   `attestation_status: "self_declared"` carrying it. Otherwise emits
+   `attestation_status: "absent"`.
+4. Maps `token_expires_at`, `capabilities`, `jti`, and `scope` into
+   `session_scope`.
+
+**The builder MUST throw** if `scope` is missing — there is no meaningful
+identity without a session-scope persistence key.
+
+**Trust degradation.** Any consumer of an interim `AgentIdentity` MUST
+treat `model_attestation` as untrusted telemetry. Specifically:
+
+- Authority inheritance ([§3](#3--authority-inheritance-rule)) is permitted
+  on `human_authority` alone, since that field is HMAC-attested today.
+- Capability gating MUST NOT branch on `model_attestation` until `verified`
+  is reachable.
+
+---
+
+## §6 — Type reference
+
+The canonical TS surface is in [`src/models/agent-identity.ts`](../src/models/agent-identity.ts).
+Field-level JSDoc cites the section numbers in this document.
+
+```ts
+interface AgentIdentity {
+  human_authority: HumanAuthority;     // §2.1
+  model_attestation: ModelAttestation; // §2.2
+  environment: Environment;            // §2.3
+  session_scope: SessionScope;         // §2.4
+}
+```
+
+---
+
+## §7 — Non-goals
+
+This spec deliberately does NOT cover:
+
+- **Revocation transport.** Token revocation lives in
+  `src/gateway/session.ts`'s `revokeJti` denylist and is independent of
+  this identity shape.
+- **Attestation transport.** How `X-Model-Attestation` arrives at the server
+  (HTTP header vs. MCP-protocol extension) is FN-061's call.
+- **Cross-tenant delegation.** "Alice's agent acts on behalf of Bob" is not a
+  case of authority inheritance; it requires a delegation credential and is
+  out of scope.
+- **A2A wire format.** How an `AgentIdentity` is serialized into an A2A
+  envelope is FN-060's call.
+- **MCP tool changes.** `session_info` and `SessionPayload` are unchanged.
+  FN-059 is the first task that will wire `AgentIdentity` into a handler.
+
+---
+
+## §8 — Open questions
+
+| # | Question | Resolved by |
+|---|---|---|
+| Q1 | Should `human_authority.kind === "stdio"` ever participate in inheritance with another stdio session on the same host? | FN-059 |
+| Q2 | What is the exact JWS algorithm and JWKS discovery story for `model_attestation`? | FN-061 |
+| Q3 | Does `environment.surface` need a fourth value (`"http-bridge"`) for the SSE-bridge variant? | FN-060 |
+| Q4 | Should `session_scope.capabilities` be re-projected into a coarser A2A capability vocabulary, or carried verbatim? | FN-060 |
+| Q5 | Is `wallet_anchor` allowed to carry multiple wallets (the user's full set), or must it be the single active wallet at issuance? | FN-059 |
+
+---
+
+## §9 — Cross-references
+
+- Upstream tracking issue: [etofdn/eto-mcp#11](https://github.com/etofdn/eto-mcp/issues/11)
+- A2A milestone: **FN-054**
+- Authority-inheritance enforcement: **FN-059** (consumes this spec)
+- A2A coordination wire format: **FN-060**
+- Model-attestation research: **FN-061**
+- Session and capability primitives: [`src/gateway/session.ts`](../src/gateway/session.ts), [`src/gateway/auth.ts`](../src/gateway/auth.ts)
+- Scope context: [`src/signing/session-context.ts`](../src/signing/session-context.ts)
+- Wallet anchor: [`src/signing/local-signer.ts`](../src/signing/local-signer.ts)
+- Today's identity-adjacent tool: [`src/tools/session.ts`](../src/tools/session.ts) (`session_info`)

--- a/docs/memo-schema-registry.md
+++ b/docs/memo-schema-registry.md
@@ -1,0 +1,225 @@
+# ETO Memo Schema Registry
+
+> Tracking issue: [etofdn/eto-mcp#11](https://github.com/etofdn/eto-mcp/issues/11) (item 4/10).
+> Companion to [`docs/schema-registry.md`](./schema-registry.md). This registry
+> covers **memo schemas** — typed JSON envelopes anchored in SPL Memo Program v2
+> instruction data — and is intentionally separate from the **credential schema
+> registry**, which catalogs W3C Verifiable Credential payloads gated on-chain
+> by `schema_hash`.
+
+## §1 — Why a typed memo layer
+
+Today `transfer_native` and the `batch` transfer tool accept a free-form
+`memo: string` (see `src/tools/transfer.ts`), which is wired straight into a
+single SPL Memo v2 instruction in the transfer transaction. The same memo is
+recoverable later via `query_memos` and `get_account_transactions`. This is
+sufficient for human-readable annotations but breaks down once agents start
+exchanging structured records on-chain:
+
+- **No type discrimination.** A consumer cannot tell an evaluation score from a
+  payment receipt from a coordination-log entry without ad-hoc string sniffing
+  ("does it start with `score:`?").
+- **No versioning.** Producers cannot evolve their record shape without
+  silently breaking older readers.
+- **No validation contract.** Each consumer re-implements its own parser, and
+  malformed entries surface as opaque errors instead of being skipped cleanly.
+
+This registry defines a small typed-envelope convention so that three concrete
+record kinds — and any future ones — can be produced and consumed safely:
+
+| Kind                | Purpose                                                                 |
+|---------------------|-------------------------------------------------------------------------|
+| `eval_score`        | One agent scoring another against a named metric (LLM-judge, oracle)   |
+| `payment`           | Structured payment metadata (purpose, invoice id, optional task ref)   |
+| `coordination_log`  | A2A coordination event (`task_offered`, `task_accepted`, …)            |
+
+The runtime implementation (validators, helper functions, tool wiring) is
+explicitly out of scope for this document; see the follow-up implementation
+task referenced from issue #11.
+
+## §2 — Envelope shape
+
+Every typed memo is a single UTF-8 JSON object with **no leading whitespace**
+and no trailing newline. The wire format is:
+
+```json
+{
+  "type": "eval_score",
+  "schema": "eto.memo.eval_score.v1",
+  "v": 1,
+  "ts": "2026-05-02T17:00:00Z",
+  "payload": { "...": "..." }
+}
+```
+
+Required top-level fields:
+
+| Field      | Type    | Notes                                                                   |
+|------------|---------|-------------------------------------------------------------------------|
+| `type`     | string  | Short kind discriminator. Must equal the `<type>` segment of `schema`. |
+| `schema`   | string  | Full registry label (see §3). Identifies the payload schema.            |
+| `v`        | integer | Major schema version, ≥ 1. Equals the `vN` suffix of `schema`.          |
+| `ts`       | string  | RFC 3339 / ISO 8601 UTC timestamp (e.g. `2026-05-02T17:00:00Z`).        |
+| `payload`  | object  | The typed body, validated by the schema named in `schema`.              |
+
+`additionalProperties` on the envelope is **false**; producers MUST NOT add
+extra top-level fields. Extensibility happens inside `payload` (per its own
+schema, additive within a major version).
+
+### Size budget
+
+A single SPL Memo v2 instruction in a typical SVM transfer transaction has
+roughly **566 bytes** of usable instruction data after accounting for the
+transfer instruction, signature, blockhash, and program ids. This budget
+shrinks further if multiple instructions are packed in the same tx.
+
+Guidance for producers:
+
+- Keep the full encoded envelope ≤ **400 bytes** to leave headroom for SDK
+  variations and future cosigner accounts.
+- For records that exceed the budget (e.g. eval evidence with logs attached),
+  store the bulk content off-chain (S3, IPFS, R2) and put a content digest +
+  pointer URI inside the payload. The on-chain memo then anchors integrity
+  without paying transaction-size for the whole record. v1 schemas already
+  reserve `evidence_uri` on `eval_score` for exactly this pattern.
+- Producers SHOULD reject oversize envelopes client-side rather than rely on
+  the validator to truncate.
+
+## §3 — Naming convention
+
+```
+eto.memo.<type>[.<sub>].v<N>
+```
+
+- `<type>` — required kind discriminator. Matches the envelope `type` field.
+- `<sub>` — optional refinement (reserved for future use, e.g.
+  `payment.escrow.v1`). v1 schemas in this registry do not use a sub-segment.
+- `<N>` — major version, integer ≥ 1. Additive changes within a major version
+  are non-breaking; breaking changes mint `v(N+1)`.
+
+The `eto.memo.*` prefix is **deliberately distinct** from `eto.beckn.schema.*`
+used by the credential registry (`docs/schema-registry.md`) to prevent label
+collision. Memo schemas are **not** hashed onto chain; they are identified by
+label string only. If hash-binding is desired later, see §8.
+
+Pre-image strings are case-sensitive ASCII.
+
+## §4 — Registered schemas (v1)
+
+| Label                            | Producer                                  | Consumer                                    | Schema file                                       |
+|----------------------------------|-------------------------------------------|---------------------------------------------|---------------------------------------------------|
+| `eto.memo.eval_score.v1`         | evaluator agent (LLM-judge / oracle)      | reputation aggregator, dashboards           | [`spec/memo-schemas/eval_score.v1.json`](../spec/memo-schemas/eval_score.v1.json) |
+| `eto.memo.payment.v1`            | wallet UX, escrow agent, A2A SDK          | accounting, invoice reconciliation          | [`spec/memo-schemas/payment.v1.json`](../spec/memo-schemas/payment.v1.json)       |
+| `eto.memo.coordination_log.v1`   | A2A SDK coordination layer                | orchestration UI, audit trail               | [`spec/memo-schemas/coordination_log.v1.json`](../spec/memo-schemas/coordination_log.v1.json) |
+
+## §5 — Validation approach
+
+Validation uses [Ajv](https://ajv.js.org/) (already a project dependency in
+`package.json`, `^8.20.0`) compiled against JSON Schema **Draft 2020-12**, with
+`ajv-formats` providing `date-time` validation for the `ts` field.
+
+Two-stage validation:
+
+1. **Envelope** — validate top-level shape (`type`, `schema`, `v`, `ts`,
+   `payload`) against a single shared envelope schema.
+2. **Payload** — look up the per-schema validator by the envelope's `schema`
+   label and validate `payload` against the schema file under
+   `spec/memo-schemas/`.
+
+Producer/consumer contract:
+
+- **Producers MUST validate before submission.** A failing validation aborts
+  the transfer; it does not silently strip the memo.
+- **Consumers MUST validate on read** and MUST treat invalid records as
+  opaque. A malformed memo, an unknown `schema`, or a future-version memo
+  must never throw out of the entire `query_memos` call — it returns alongside
+  valid records with a `{ ok: false, reason }` shape.
+
+Suggested TypeScript helper signatures (runtime task will implement):
+
+```ts
+export interface MemoEnvelope<T = unknown> {
+  type: string;
+  schema: string;
+  v: number;
+  ts: string; // RFC 3339 UTC
+  payload: T;
+}
+
+export function encodeMemo<T>(
+  type: string,
+  payload: T,
+  opts?: { schema?: string; v?: number; ts?: string },
+): string;
+
+export type DecodeResult =
+  | { ok: true; envelope: MemoEnvelope }
+  | { ok: false; reason: string; raw: string };
+
+export function decodeMemo(raw: string): DecodeResult;
+```
+
+`encodeMemo` is the single sanctioned way for SDK callers to produce typed
+memos; it MUST run Ajv against both envelope and payload before returning the
+serialized string. `decodeMemo` MUST never throw — all parse/validate failures
+land in the `{ ok: false }` branch.
+
+## §6 — Versioning rules
+
+- **Additive within a major version.** New optional fields can be added to a
+  payload schema's `properties` without bumping `vN`. Required fields, type
+  changes, and removed fields are breaking and require `v(N+1)`.
+- **One major version per file.** Each `vN` lives in its own
+  `<type>.v<N>.json` file under `spec/memo-schemas/`. Older versions remain
+  in the repo so historical memos remain decodable.
+- **Consumer compatibility.** A consumer that knows versions up to `vK`
+  SHOULD accept any envelope with `v ≤ K` and SHOULD ignore (treat as opaque)
+  envelopes with `v > K`. Consumers MUST NOT crash on unknown future versions.
+- **Label immutability.** Once published, a label like `eto.memo.eval_score.v1`
+  is frozen. Never reuse the label for a different shape.
+
+## §7 — Adding a new schema
+
+1. Pick a `type` discriminator and label per §3 (e.g. `eto.memo.attestation.v1`).
+2. Add a JSON Schema Draft 2020-12 file at
+   `spec/memo-schemas/<type>.v<N>.json` validating the **payload only** (the
+   envelope is validated separately). Set `$schema`, `$id`, `title`,
+   `type: "object"`, `required`, and `additionalProperties: false`.
+3. Add a row to §4 (Producer / Consumer / Schema file).
+4. Add a one-line description to `spec/memo-schemas/README.md`.
+5. Verify the schema compiles under Ajv 2020 in strict mode (see Step 4 of
+   FN-057 for the exact one-liner).
+6. If breaking an existing schema, mint `v(N+1)` rather than mutating the
+   existing file.
+7. Open a PR; CI re-runs the Ajv compile check.
+
+## §8 — Open questions / out of scope for v1
+
+- **Cryptographic schema commitments.** v1 identifies schemas by label string
+  only. We do not bind a `sha256(canonical-JSON-of-schema)` digest into the
+  envelope or anchor it on-chain. If a future BPP wants strong schema
+  integrity (analogous to the credential registry's on-chain `schema_hash`),
+  add a `schema_digest` field to the envelope and define canonicalization
+  rules (likely RFC 8785 JCS).
+- **Cross-program memo discovery.** Today only `query_memos` /
+  `get_account_transactions` surface memos, scoped to a single SVM account.
+  Cross-program indexing (e.g. tying a `coordination_log` memo on one wallet
+  to a `payment` memo on another) is left to higher-level orchestration.
+- **Bridging to the credential registry.** A `payment` memo that doubles as a
+  receipt VC will need a defined mapping from `eto.memo.payment.v1` →
+  `eto.beckn.schema.<receipt>.v1`. The two registries deliberately do not
+  share a namespace, but a runtime adapter could project one into the other.
+- **Compression / binary framing.** All v1 envelopes are uncompressed UTF-8
+  JSON. If size pressure grows, candidates include CBOR (RFC 8949) or simple
+  field aliasing; both would mint `v2` or a sibling envelope kind.
+- **Multi-instruction memos.** v1 assumes one envelope per memo instruction.
+  Splitting a large record across multiple memo instructions in a single tx
+  is left to a future spec.
+
+## See also
+
+- [`docs/schema-registry.md`](./schema-registry.md) — Beckn **credential**
+  schema registry. Credential schemas are W3C VC payload shapes gated on-chain
+  by `schema_hash = SHA-256(label)` and consumed by the IssuerNetwork. Memo
+  schemas (this document) live in SPL Memo instruction data and are validated
+  off-chain only.

--- a/docs/schema-registry.md
+++ b/docs/schema-registry.md
@@ -2,6 +2,8 @@
 
 > Tracking issue: [etofdn/eto-mcp#11](https://github.com/etofdn/eto-mcp/issues/11)
 > Closes: FN-179, FN-193, FN-203 (FN-057 follow-through).
+>
+> **See also:** [`docs/memo-schema-registry.md`](./memo-schema-registry.md) catalogs the disjoint **memo schema** registry (`eto.memo.*`) used to type SPL Memo v2 records anchored by `transfer_native` / `batch` and surfaced via `query_memos`. This document covers **credential schemas** (`eto.beckn.schema.*`), which are W3C VC payloads gated on-chain by `schema_hash = SHA-256(label)`. The two registries share a versioning philosophy but live under disjoint namespaces and have different identity / validation models (on-chain hash gating vs off-chain Ajv validation).
 
 This document catalogs every Beckn-mapped credential schema referenced by the
 eto-mcp codebase, their pre-image label (the string that hashes into the on-chain

--- a/docs/schema-registry.md
+++ b/docs/schema-registry.md
@@ -3,6 +3,8 @@
 > Tracking issue: [etofdn/eto-mcp#11](https://github.com/etofdn/eto-mcp/issues/11)
 > Closes: FN-179, FN-193, FN-203 (FN-057 follow-through).
 >
+> **See also:** [`docs/agent-identity-model.md`](./agent-identity-model.md) — the agent identity model (`human × model × environment × session_scope`) that downstream A2A trust decisions evaluate. Disjoint from this credential registry.
+>
 > **See also:** [`docs/memo-schema-registry.md`](./memo-schema-registry.md) catalogs the disjoint **memo schema** registry (`eto.memo.*`) used to type SPL Memo v2 records anchored by `transfer_native` / `batch` and surfaced via `query_memos`. This document covers **credential schemas** (`eto.beckn.schema.*`), which are W3C VC payloads gated on-chain by `schema_hash = SHA-256(label)`. The two registries share a versioning philosophy but live under disjoint namespaces and have different identity / validation models (on-chain hash gating vs off-chain Ajv validation).
 
 This document catalogs every Beckn-mapped credential schema referenced by the

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,0 +1,1829 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+
+  .:
+    dependencies:
+      '@noble/curves':
+        specifier: ^1.4.0
+        version: 1.9.7
+      '@noble/ed25519':
+        specifier: ^2.0.0
+        version: 2.3.0
+      '@noble/hashes':
+        specifier: ^1.4.0
+        version: 1.8.0
+      ajv:
+        specifier: ^8.20.0
+        version: 8.20.0
+      ajv-formats:
+        specifier: ^3.0.1
+        version: 3.0.1(ajv@8.20.0)
+      express:
+        specifier: ^5.2.1
+        version: 5.2.1
+      zod:
+        specifier: ^3.25.76
+        version: 3.25.76
+    devDependencies:
+      '@types/express':
+        specifier: ^5.0.0
+        version: 5.0.6
+      '@types/node':
+        specifier: ^20.12.0
+        version: 20.19.39
+      bs58:
+        specifier: ^6.0.0
+        version: 6.0.0
+      typescript:
+        specifier: ^5.4.0
+        version: 5.9.3
+      vitest:
+        specifier: ^1.6.0
+        version: 1.6.1(@types/node@20.19.39)
+
+packages:
+
+  '@esbuild/aix-ppc64@0.21.5':
+    resolution: {integrity: sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==}
+    engines: {node: '>=12'}
+    cpu: [ppc64]
+    os: [aix]
+
+  '@esbuild/android-arm64@0.21.5':
+    resolution: {integrity: sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm@0.21.5':
+    resolution: {integrity: sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==}
+    engines: {node: '>=12'}
+    cpu: [arm]
+    os: [android]
+
+  '@esbuild/android-x64@0.21.5':
+    resolution: {integrity: sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [android]
+
+  '@esbuild/darwin-arm64@0.21.5':
+    resolution: {integrity: sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.21.5':
+    resolution: {integrity: sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@esbuild/freebsd-arm64@0.21.5':
+    resolution: {integrity: sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.21.5':
+    resolution: {integrity: sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@esbuild/linux-arm64@0.21.5':
+    resolution: {integrity: sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.21.5':
+    resolution: {integrity: sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==}
+    engines: {node: '>=12'}
+    cpu: [arm]
+    os: [linux]
+
+  '@esbuild/linux-ia32@0.21.5':
+    resolution: {integrity: sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==}
+    engines: {node: '>=12'}
+    cpu: [ia32]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.21.5':
+    resolution: {integrity: sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==}
+    engines: {node: '>=12'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@esbuild/linux-mips64el@0.21.5':
+    resolution: {integrity: sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==}
+    engines: {node: '>=12'}
+    cpu: [mips64el]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.21.5':
+    resolution: {integrity: sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==}
+    engines: {node: '>=12'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@esbuild/linux-riscv64@0.21.5':
+    resolution: {integrity: sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==}
+    engines: {node: '>=12'}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.21.5':
+    resolution: {integrity: sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==}
+    engines: {node: '>=12'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@esbuild/linux-x64@0.21.5':
+    resolution: {integrity: sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [linux]
+
+  '@esbuild/netbsd-x64@0.21.5':
+    resolution: {integrity: sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [netbsd]
+
+  '@esbuild/openbsd-x64@0.21.5':
+    resolution: {integrity: sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@esbuild/sunos-x64@0.21.5':
+    resolution: {integrity: sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [sunos]
+
+  '@esbuild/win32-arm64@0.21.5':
+    resolution: {integrity: sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@esbuild/win32-ia32@0.21.5':
+    resolution: {integrity: sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==}
+    engines: {node: '>=12'}
+    cpu: [ia32]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.21.5':
+    resolution: {integrity: sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [win32]
+
+  '@jest/schemas@29.6.3':
+    resolution: {integrity: sha512-mo5j5X+jIZmJQveBKeS/clAueipV7KgiX1vMgCxam1RNYiqE1w62n0/tJJnHtjW8ZHcQco5gY85jA3mi0L+nSA==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+
+  '@jridgewell/sourcemap-codec@1.5.5':
+    resolution: {integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==}
+
+  '@noble/curves@1.9.7':
+    resolution: {integrity: sha512-gbKGcRUYIjA3/zCCNaWDciTMFI0dCkvou3TL8Zmy5Nc7sJ47a0jtOeZoTaMxkuqRo9cRhjOdZJXegxYE5FN/xw==}
+    engines: {node: ^14.21.3 || >=16}
+
+  '@noble/ed25519@2.3.0':
+    resolution: {integrity: sha512-M7dvXL2B92/M7dw9+gzuydL8qn/jiqNHaoR3Q+cb1q1GHV7uwE17WCyFMG+Y+TZb5izcaXk5TdJRrDUxHXL78A==}
+
+  '@noble/hashes@1.8.0':
+    resolution: {integrity: sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==}
+    engines: {node: ^14.21.3 || >=16}
+
+  '@rollup/rollup-android-arm-eabi@4.60.2':
+    resolution: {integrity: sha512-dnlp69efPPg6Uaw2dVqzWRfAWRnYVb1XJ8CyyhIbZeaq4CA5/mLeZ1IEt9QqQxmbdvagjLIm2ZL8BxXv5lH4Yw==}
+    cpu: [arm]
+    os: [android]
+
+  '@rollup/rollup-android-arm64@4.60.2':
+    resolution: {integrity: sha512-OqZTwDRDchGRHHm/hwLOL7uVPB9aUvI0am/eQuWMNyFHf5PSEQmyEeYYheA0EPPKUO/l0uigCp+iaTjoLjVoHg==}
+    cpu: [arm64]
+    os: [android]
+
+  '@rollup/rollup-darwin-arm64@4.60.2':
+    resolution: {integrity: sha512-UwRE7CGpvSVEQS8gUMBe1uADWjNnVgP3Iusyda1nSRwNDCsRjnGc7w6El6WLQsXmZTbLZx9cecegumcitNfpmA==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@rollup/rollup-darwin-x64@4.60.2':
+    resolution: {integrity: sha512-gjEtURKLCC5VXm1I+2i1u9OhxFsKAQJKTVB8WvDAHF+oZlq0GTVFOlTlO1q3AlCTE/DF32c16ESvfgqR7343/g==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@rollup/rollup-freebsd-arm64@4.60.2':
+    resolution: {integrity: sha512-Bcl6CYDeAgE70cqZaMojOi/eK63h5Me97ZqAQoh77VPjMysA/4ORQBRGo3rRy45x4MzVlU9uZxs8Uwy7ZaKnBw==}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@rollup/rollup-freebsd-x64@4.60.2':
+    resolution: {integrity: sha512-LU+TPda3mAE2QB0/Hp5VyeKJivpC6+tlOXd1VMoXV/YFMvk/MNk5iXeBfB4MQGRWyOYVJ01625vjkr0Az98OJQ==}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@rollup/rollup-linux-arm-gnueabihf@4.60.2':
+    resolution: {integrity: sha512-2QxQrM+KQ7DAW4o22j+XZ6RKdxjLD7BOWTP0Bv0tmjdyhXSsr2Ul1oJDQqh9Zf5qOwTuTc7Ek83mOFaKnodPjg==}
+    cpu: [arm]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-arm-musleabihf@4.60.2':
+    resolution: {integrity: sha512-TbziEu2DVsTEOPif2mKWkMeDMLoYjx95oESa9fkQQK7r/Orta0gnkcDpzwufEcAO2BLBsD7mZkXGFqEdMRRwfw==}
+    cpu: [arm]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-linux-arm64-gnu@4.60.2':
+    resolution: {integrity: sha512-bO/rVDiDUuM2YfuCUwZ1t1cP+/yqjqz+Xf2VtkdppefuOFS2OSeAfgafaHNkFn0t02hEyXngZkxtGqXcXwO8Rg==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-arm64-musl@4.60.2':
+    resolution: {integrity: sha512-hr26p7e93Rl0Za+JwW7EAnwAvKkehh12BU1Llm9Ykiibg4uIr2rbpxG9WCf56GuvidlTG9KiiQT/TXT1yAWxTA==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-linux-loong64-gnu@4.60.2':
+    resolution: {integrity: sha512-pOjB/uSIyDt+ow3k/RcLvUAOGpysT2phDn7TTUB3n75SlIgZzM6NKAqlErPhoFU+npgY3/n+2HYIQVbF70P9/A==}
+    cpu: [loong64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-loong64-musl@4.60.2':
+    resolution: {integrity: sha512-2/w+q8jszv9Ww1c+6uJT3OwqhdmGP2/4T17cu8WuwyUuuaCDDJ2ojdyYwZzCxx0GcsZBhzi3HmH+J5pZNXnd+Q==}
+    cpu: [loong64]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-linux-ppc64-gnu@4.60.2':
+    resolution: {integrity: sha512-11+aL5vKheYgczxtPVVRhdptAM2H7fcDR5Gw4/bTcteuZBlH4oP9f5s9zYO9aGZvoGeBpqXI/9TZZihZ609wKw==}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-ppc64-musl@4.60.2':
+    resolution: {integrity: sha512-i16fokAGK46IVZuV8LIIwMdtqhin9hfYkCh8pf8iC3QU3LpwL+1FSFGej+O7l3E/AoknL6Dclh2oTdnRMpTzFQ==}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-linux-riscv64-gnu@4.60.2':
+    resolution: {integrity: sha512-49FkKS6RGQoriDSK/6E2GkAsAuU5kETFCh7pG4yD/ylj9rKhTmO3elsnmBvRD4PgJPds5W2PkhC82aVwmUcJ7A==}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-riscv64-musl@4.60.2':
+    resolution: {integrity: sha512-mjYNkHPfGpUR00DuM1ZZIgs64Hpf4bWcz9Z41+4Q+pgDx73UwWdAYyf6EG/lRFldmdHHzgrYyge5akFUW0D3mQ==}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-linux-s390x-gnu@4.60.2':
+    resolution: {integrity: sha512-ALyvJz965BQk8E9Al/JDKKDLH2kfKFLTGMlgkAbbYtZuJt9LU8DW3ZoDMCtQpXAltZxwBHevXz5u+gf0yA0YoA==}
+    cpu: [s390x]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-x64-gnu@4.60.2':
+    resolution: {integrity: sha512-UQjrkIdWrKI626Du8lCQ6MJp/6V1LAo2bOK9OTu4mSn8GGXIkPXk/Vsp4bLHCd9Z9Iz2OTEaokUE90VweJgIYQ==}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-x64-musl@4.60.2':
+    resolution: {integrity: sha512-bTsRGj6VlSdn/XD4CGyzMnzaBs9bsRxy79eTqTCBsA8TMIEky7qg48aPkvJvFe1HyzQ5oMZdg7AnVlWQSKLTnw==}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-openbsd-x64@4.60.2':
+    resolution: {integrity: sha512-6d4Z3534xitaA1FcMWP7mQPq5zGwBmGbhphh2DwaA1aNIXUu3KTOfwrWpbwI4/Gr0uANo7NTtaykFyO2hPuFLg==}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@rollup/rollup-openharmony-arm64@4.60.2':
+    resolution: {integrity: sha512-NetAg5iO2uN7eB8zE5qrZ3CSil+7IJt4WDFLcC75Ymywq1VZVD6qJ6EvNLjZ3rEm6gB7XW5JdT60c6MN35Z85Q==}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@rollup/rollup-win32-arm64-msvc@4.60.2':
+    resolution: {integrity: sha512-NCYhOotpgWZ5kdxCZsv6Iudx0wX8980Q/oW4pNFNihpBKsDbEA1zpkfxJGC0yugsUuyDZ7gL37dbzwhR0VI7pQ==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@rollup/rollup-win32-ia32-msvc@4.60.2':
+    resolution: {integrity: sha512-RXsaOqXxfoUBQoOgvmmijVxJnW2IGB0eoMO7F8FAjaj0UTywUO/luSqimWBJn04WNgUkeNhh7fs7pESXajWmkg==}
+    cpu: [ia32]
+    os: [win32]
+
+  '@rollup/rollup-win32-x64-gnu@4.60.2':
+    resolution: {integrity: sha512-qdAzEULD+/hzObedtmV6iBpdL5TIbKVztGiK7O3/KYSf+HIzU257+MX1EXJcyIiDbMAqmbwaufcYPvyRryeZtA==}
+    cpu: [x64]
+    os: [win32]
+
+  '@rollup/rollup-win32-x64-msvc@4.60.2':
+    resolution: {integrity: sha512-Nd/SgG27WoA9e+/TdK74KnHz852TLa94ovOYySo/yMPuTmpckK/jIF2jSwS3g7ELSKXK13/cVdmg1Z/DaCWKxA==}
+    cpu: [x64]
+    os: [win32]
+
+  '@sinclair/typebox@0.27.10':
+    resolution: {integrity: sha512-MTBk/3jGLNB2tVxv6uLlFh1iu64iYOQ2PbdOSK3NW8JZsmlaOh2q6sdtKowBhfw8QFLmYNzTW4/oK4uATIi6ZA==}
+
+  '@types/body-parser@1.19.6':
+    resolution: {integrity: sha512-HLFeCYgz89uk22N5Qg3dvGvsv46B8GLvKKo1zKG4NybA8U2DiEO3w9lqGg29t/tfLRJpJ6iQxnVw4OnB7MoM9g==}
+
+  '@types/connect@3.4.38':
+    resolution: {integrity: sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==}
+
+  '@types/estree@1.0.8':
+    resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
+
+  '@types/express-serve-static-core@5.1.1':
+    resolution: {integrity: sha512-v4zIMr/cX7/d2BpAEX3KNKL/JrT1s43s96lLvvdTmza1oEvDudCqK9aF/djc/SWgy8Yh0h30TZx5VpzqFCxk5A==}
+
+  '@types/express@5.0.6':
+    resolution: {integrity: sha512-sKYVuV7Sv9fbPIt/442koC7+IIwK5olP1KWeD88e/idgoJqDm3JV/YUiPwkoKK92ylff2MGxSz1CSjsXelx0YA==}
+
+  '@types/http-errors@2.0.5':
+    resolution: {integrity: sha512-r8Tayk8HJnX0FztbZN7oVqGccWgw98T/0neJphO91KkmOzug1KkofZURD4UaD5uH8AqcFLfdPErnBod0u71/qg==}
+
+  '@types/node@20.19.39':
+    resolution: {integrity: sha512-orrrD74MBUyK8jOAD/r0+lfa1I2MO6I+vAkmAWzMYbCcgrN4lCrmK52gRFQq/JRxfYPfonkr4b0jcY7Olqdqbw==}
+
+  '@types/qs@6.15.0':
+    resolution: {integrity: sha512-JawvT8iBVWpzTrz3EGw9BTQFg3BQNmwERdKE22vlTxawwtbyUSlMppvZYKLZzB5zgACXdXxbD3m1bXaMqP/9ow==}
+
+  '@types/range-parser@1.2.7':
+    resolution: {integrity: sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ==}
+
+  '@types/send@1.2.1':
+    resolution: {integrity: sha512-arsCikDvlU99zl1g69TcAB3mzZPpxgw0UQnaHeC1Nwb015xp8bknZv5rIfri9xTOcMuaVgvabfIRA7PSZVuZIQ==}
+
+  '@types/serve-static@2.2.0':
+    resolution: {integrity: sha512-8mam4H1NHLtu7nmtalF7eyBH14QyOASmcxHhSfEoRyr0nP/YdoesEtU+uSRvMe96TW/HPTtkoKqQLl53N7UXMQ==}
+
+  '@vitest/expect@1.6.1':
+    resolution: {integrity: sha512-jXL+9+ZNIJKruofqXuuTClf44eSpcHlgj3CiuNihUF3Ioujtmc0zIa3UJOW5RjDK1YLBJZnWBlPuqhYycLioog==}
+
+  '@vitest/runner@1.6.1':
+    resolution: {integrity: sha512-3nSnYXkVkf3mXFfE7vVyPmi3Sazhb/2cfZGGs0JRzFsPFvAMBEcrweV1V1GsrstdXeKCTXlJbvnQwGWgEIHmOA==}
+
+  '@vitest/snapshot@1.6.1':
+    resolution: {integrity: sha512-WvidQuWAzU2p95u8GAKlRMqMyN1yOJkGHnx3M1PL9Raf7AQ1kwLKg04ADlCa3+OXUZE7BceOhVZiuWAbzCKcUQ==}
+
+  '@vitest/spy@1.6.1':
+    resolution: {integrity: sha512-MGcMmpGkZebsMZhbQKkAf9CX5zGvjkBTqf8Zx3ApYWXr3wG+QvEu2eXWfnIIWYSJExIp4V9FCKDEeygzkYrXMw==}
+
+  '@vitest/utils@1.6.1':
+    resolution: {integrity: sha512-jOrrUvXM4Av9ZWiG1EajNto0u96kWAhJ1LmPmJhXXQx/32MecEKd10pOLYgS2BQx1TgkGhloPU1ArDW2vvaY6g==}
+
+  accepts@2.0.0:
+    resolution: {integrity: sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==}
+    engines: {node: '>= 0.6'}
+
+  acorn-walk@8.3.5:
+    resolution: {integrity: sha512-HEHNfbars9v4pgpW6SO1KSPkfoS0xVOM/9UzkJltjlsHZmJasxg8aXkuZa7SMf8vKGIBhpUsPluQSqhJFCqebw==}
+    engines: {node: '>=0.4.0'}
+
+  acorn@8.16.0:
+    resolution: {integrity: sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==}
+    engines: {node: '>=0.4.0'}
+    hasBin: true
+
+  ajv-formats@3.0.1:
+    resolution: {integrity: sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==}
+    peerDependencies:
+      ajv: ^8.0.0
+    peerDependenciesMeta:
+      ajv:
+        optional: true
+
+  ajv@8.20.0:
+    resolution: {integrity: sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==}
+
+  ansi-styles@5.2.0:
+    resolution: {integrity: sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==}
+    engines: {node: '>=10'}
+
+  assertion-error@1.1.0:
+    resolution: {integrity: sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==}
+
+  base-x@5.0.1:
+    resolution: {integrity: sha512-M7uio8Zt++eg3jPj+rHMfCC+IuygQHHCOU+IYsVtik6FWjuYpVt/+MRKcgsAMHh8mMFAwnB+Bs+mTrFiXjMzKg==}
+
+  body-parser@2.2.2:
+    resolution: {integrity: sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==}
+    engines: {node: '>=18'}
+
+  bs58@6.0.0:
+    resolution: {integrity: sha512-PD0wEnEYg6ijszw/u8s+iI3H17cTymlrwkKhDhPZq+Sokl3AU4htyBFTjAeNAlCCmg0f53g6ih3jATyCKftTfw==}
+
+  bytes@3.1.2:
+    resolution: {integrity: sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==}
+    engines: {node: '>= 0.8'}
+
+  cac@6.7.14:
+    resolution: {integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==}
+    engines: {node: '>=8'}
+
+  call-bind-apply-helpers@1.0.2:
+    resolution: {integrity: sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==}
+    engines: {node: '>= 0.4'}
+
+  call-bound@1.0.4:
+    resolution: {integrity: sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==}
+    engines: {node: '>= 0.4'}
+
+  chai@4.5.0:
+    resolution: {integrity: sha512-RITGBfijLkBddZvnn8jdqoTypxvqbOLYQkGGxXzeFjVHvudaPw0HNFD9x928/eUwYWd2dPCugVqspGALTZZQKw==}
+    engines: {node: '>=4'}
+
+  check-error@1.0.3:
+    resolution: {integrity: sha512-iKEoDYaRmd1mxM90a2OEfWhjsjPpYPuQ+lMYsoxB126+t8fw7ySEO48nmDg5COTjxDI65/Y2OWpeEHk3ZOe8zg==}
+
+  confbox@0.1.8:
+    resolution: {integrity: sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w==}
+
+  content-disposition@1.1.0:
+    resolution: {integrity: sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==}
+    engines: {node: '>=18'}
+
+  content-type@1.0.5:
+    resolution: {integrity: sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==}
+    engines: {node: '>= 0.6'}
+
+  cookie-signature@1.2.2:
+    resolution: {integrity: sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==}
+    engines: {node: '>=6.6.0'}
+
+  cookie@0.7.2:
+    resolution: {integrity: sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==}
+    engines: {node: '>= 0.6'}
+
+  cross-spawn@7.0.6:
+    resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
+    engines: {node: '>= 8'}
+
+  debug@4.4.3:
+    resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
+    engines: {node: '>=6.0'}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
+
+  deep-eql@4.1.4:
+    resolution: {integrity: sha512-SUwdGfqdKOwxCPeVYjwSyRpJ7Z+fhpwIAtmCUdZIWZ/YP5R9WAsyuSgpLVDi9bjWoN2LXHNss/dk3urXtdQxGg==}
+    engines: {node: '>=6'}
+
+  depd@2.0.0:
+    resolution: {integrity: sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==}
+    engines: {node: '>= 0.8'}
+
+  diff-sequences@29.6.3:
+    resolution: {integrity: sha512-EjePK1srD3P08o2j4f0ExnylqRs5B9tJjcp9t1krH2qRi8CCdsYfwe9JgSLurFBWwq4uOlipzfk5fHNvwFKr8Q==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+
+  dunder-proto@1.0.1:
+    resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
+    engines: {node: '>= 0.4'}
+
+  ee-first@1.1.1:
+    resolution: {integrity: sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==}
+
+  encodeurl@2.0.0:
+    resolution: {integrity: sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==}
+    engines: {node: '>= 0.8'}
+
+  es-define-property@1.0.1:
+    resolution: {integrity: sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==}
+    engines: {node: '>= 0.4'}
+
+  es-errors@1.3.0:
+    resolution: {integrity: sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==}
+    engines: {node: '>= 0.4'}
+
+  es-object-atoms@1.1.1:
+    resolution: {integrity: sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==}
+    engines: {node: '>= 0.4'}
+
+  esbuild@0.21.5:
+    resolution: {integrity: sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==}
+    engines: {node: '>=12'}
+    hasBin: true
+
+  escape-html@1.0.3:
+    resolution: {integrity: sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==}
+
+  estree-walker@3.0.3:
+    resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
+
+  etag@1.8.1:
+    resolution: {integrity: sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==}
+    engines: {node: '>= 0.6'}
+
+  execa@8.0.1:
+    resolution: {integrity: sha512-VyhnebXciFV2DESc+p6B+y0LjSm0krU4OgJN44qFAhBY0TJ+1V61tYD2+wHusZ6F9n5K+vl8k0sTy7PEfV4qpg==}
+    engines: {node: '>=16.17'}
+
+  express@5.2.1:
+    resolution: {integrity: sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==}
+    engines: {node: '>= 18'}
+
+  fast-deep-equal@3.1.3:
+    resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
+
+  fast-uri@3.1.0:
+    resolution: {integrity: sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==}
+
+  finalhandler@2.1.1:
+    resolution: {integrity: sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==}
+    engines: {node: '>= 18.0.0'}
+
+  forwarded@0.2.0:
+    resolution: {integrity: sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==}
+    engines: {node: '>= 0.6'}
+
+  fresh@2.0.0:
+    resolution: {integrity: sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==}
+    engines: {node: '>= 0.8'}
+
+  fsevents@2.3.3:
+    resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
+  function-bind@1.1.2:
+    resolution: {integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==}
+
+  get-func-name@2.0.2:
+    resolution: {integrity: sha512-8vXOvuE167CtIc3OyItco7N/dpRtBbYOsPsXCz7X/PMnlGjYjSGuZJgM1Y7mmew7BKf9BqvLX2tnOVy1BBUsxQ==}
+
+  get-intrinsic@1.3.0:
+    resolution: {integrity: sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==}
+    engines: {node: '>= 0.4'}
+
+  get-proto@1.0.1:
+    resolution: {integrity: sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==}
+    engines: {node: '>= 0.4'}
+
+  get-stream@8.0.1:
+    resolution: {integrity: sha512-VaUJspBffn/LMCJVoMvSAdmscJyS1auj5Zulnn5UoYcY531UWmdwhRWkcGKnGU93m5HSXP9LP2usOryrBtQowA==}
+    engines: {node: '>=16'}
+
+  gopd@1.2.0:
+    resolution: {integrity: sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==}
+    engines: {node: '>= 0.4'}
+
+  has-symbols@1.1.0:
+    resolution: {integrity: sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==}
+    engines: {node: '>= 0.4'}
+
+  hasown@2.0.3:
+    resolution: {integrity: sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==}
+    engines: {node: '>= 0.4'}
+
+  http-errors@2.0.1:
+    resolution: {integrity: sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==}
+    engines: {node: '>= 0.8'}
+
+  human-signals@5.0.0:
+    resolution: {integrity: sha512-AXcZb6vzzrFAUE61HnN4mpLqd/cSIwNQjtNWR0euPm6y0iqx3G4gOXaIDdtdDwZmhwe82LA6+zinmW4UBWVePQ==}
+    engines: {node: '>=16.17.0'}
+
+  iconv-lite@0.7.2:
+    resolution: {integrity: sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==}
+    engines: {node: '>=0.10.0'}
+
+  inherits@2.0.4:
+    resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
+
+  ipaddr.js@1.9.1:
+    resolution: {integrity: sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==}
+    engines: {node: '>= 0.10'}
+
+  is-promise@4.0.0:
+    resolution: {integrity: sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==}
+
+  is-stream@3.0.0:
+    resolution: {integrity: sha512-LnQR4bZ9IADDRSkvpqMGvt/tEJWclzklNgSw48V5EAaAeDd6qGvN8ei6k5p0tvxSR171VmGyHuTiAOfxAbr8kA==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+
+  isexe@2.0.0:
+    resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
+
+  js-tokens@9.0.1:
+    resolution: {integrity: sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==}
+
+  json-schema-traverse@1.0.0:
+    resolution: {integrity: sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==}
+
+  local-pkg@0.5.1:
+    resolution: {integrity: sha512-9rrA30MRRP3gBD3HTGnC6cDFpaE1kVDWxWgqWJUN0RvDNAo+Nz/9GxB+nHOH0ifbVFy0hSA1V6vFDvnx54lTEQ==}
+    engines: {node: '>=14'}
+
+  loupe@2.3.7:
+    resolution: {integrity: sha512-zSMINGVYkdpYSOBmLi0D1Uo7JU9nVdQKrHxC8eYlV+9YKK9WePqAlL7lSlorG/U2Fw1w0hTBmaa/jrQ3UbPHtA==}
+
+  magic-string@0.30.21:
+    resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
+
+  math-intrinsics@1.1.0:
+    resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
+    engines: {node: '>= 0.4'}
+
+  media-typer@1.1.0:
+    resolution: {integrity: sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==}
+    engines: {node: '>= 0.8'}
+
+  merge-descriptors@2.0.0:
+    resolution: {integrity: sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==}
+    engines: {node: '>=18'}
+
+  merge-stream@2.0.0:
+    resolution: {integrity: sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==}
+
+  mime-db@1.54.0:
+    resolution: {integrity: sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==}
+    engines: {node: '>= 0.6'}
+
+  mime-types@3.0.2:
+    resolution: {integrity: sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==}
+    engines: {node: '>=18'}
+
+  mimic-fn@4.0.0:
+    resolution: {integrity: sha512-vqiC06CuhBTUdZH+RYl8sFrL096vA45Ok5ISO6sE/Mr1jRbGH4Csnhi8f3wKVl7x8mO4Au7Ir9D3Oyv1VYMFJw==}
+    engines: {node: '>=12'}
+
+  mlly@1.8.2:
+    resolution: {integrity: sha512-d+ObxMQFmbt10sretNDytwt85VrbkhhUA/JBGm1MPaWJ65Cl4wOgLaB1NYvJSZ0Ef03MMEU/0xpPMXUIQ29UfA==}
+
+  ms@2.1.3:
+    resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
+
+  nanoid@3.3.12:
+    resolution: {integrity: sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==}
+    engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
+    hasBin: true
+
+  negotiator@1.0.0:
+    resolution: {integrity: sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==}
+    engines: {node: '>= 0.6'}
+
+  npm-run-path@5.3.0:
+    resolution: {integrity: sha512-ppwTtiJZq0O/ai0z7yfudtBpWIoxM8yE6nHi1X47eFR2EWORqfbu6CnPlNsjeN683eT0qG6H/Pyf9fCcvjnnnQ==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+
+  object-inspect@1.13.4:
+    resolution: {integrity: sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==}
+    engines: {node: '>= 0.4'}
+
+  on-finished@2.4.1:
+    resolution: {integrity: sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==}
+    engines: {node: '>= 0.8'}
+
+  once@1.4.0:
+    resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
+
+  onetime@6.0.0:
+    resolution: {integrity: sha512-1FlR+gjXK7X+AsAHso35MnyN5KqGwJRi/31ft6x0M194ht7S+rWAvd7PHss9xSKMzE0asv1pyIHaJYq+BbacAQ==}
+    engines: {node: '>=12'}
+
+  p-limit@5.0.0:
+    resolution: {integrity: sha512-/Eaoq+QyLSiXQ4lyYV23f14mZRQcXnxfHrN0vCai+ak9G0pp9iEQukIIZq5NccEvwRB8PUnZT0KsOoDCINS1qQ==}
+    engines: {node: '>=18'}
+
+  parseurl@1.3.3:
+    resolution: {integrity: sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==}
+    engines: {node: '>= 0.8'}
+
+  path-key@3.1.1:
+    resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
+    engines: {node: '>=8'}
+
+  path-key@4.0.0:
+    resolution: {integrity: sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==}
+    engines: {node: '>=12'}
+
+  path-to-regexp@8.4.2:
+    resolution: {integrity: sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==}
+
+  pathe@1.1.2:
+    resolution: {integrity: sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==}
+
+  pathe@2.0.3:
+    resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
+
+  pathval@1.1.1:
+    resolution: {integrity: sha512-Dp6zGqpTdETdR63lehJYPeIOqpiNBNtc7BpWSLrOje7UaIsE5aY92r/AunQA7rsXvet3lrJ3JnZX29UPTKXyKQ==}
+
+  picocolors@1.1.1:
+    resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
+
+  pkg-types@1.3.1:
+    resolution: {integrity: sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ==}
+
+  postcss@8.5.13:
+    resolution: {integrity: sha512-qif0+jGGZoLWdHey3UFHHWP0H7Gbmsk8T5VEqyYFbWqPr1XqvLGBbk/sl8V5exGmcYJklJOhOQq1pV9IcsiFag==}
+    engines: {node: ^10 || ^12 || >=14}
+
+  pretty-format@29.7.0:
+    resolution: {integrity: sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+
+  proxy-addr@2.0.7:
+    resolution: {integrity: sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==}
+    engines: {node: '>= 0.10'}
+
+  qs@6.15.1:
+    resolution: {integrity: sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg==}
+    engines: {node: '>=0.6'}
+
+  range-parser@1.2.1:
+    resolution: {integrity: sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==}
+    engines: {node: '>= 0.6'}
+
+  raw-body@3.0.2:
+    resolution: {integrity: sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==}
+    engines: {node: '>= 0.10'}
+
+  react-is@18.3.1:
+    resolution: {integrity: sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==}
+
+  require-from-string@2.0.2:
+    resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
+    engines: {node: '>=0.10.0'}
+
+  rollup@4.60.2:
+    resolution: {integrity: sha512-J9qZyW++QK/09NyN/zeO0dG/1GdGfyp9lV8ajHnRVLfo/uFsbji5mHnDgn/qYdUHyCkM2N+8VyspgZclfAh0eQ==}
+    engines: {node: '>=18.0.0', npm: '>=8.0.0'}
+    hasBin: true
+
+  router@2.2.0:
+    resolution: {integrity: sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==}
+    engines: {node: '>= 18'}
+
+  safer-buffer@2.1.2:
+    resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
+
+  send@1.2.1:
+    resolution: {integrity: sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==}
+    engines: {node: '>= 18'}
+
+  serve-static@2.2.1:
+    resolution: {integrity: sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==}
+    engines: {node: '>= 18'}
+
+  setprototypeof@1.2.0:
+    resolution: {integrity: sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==}
+
+  shebang-command@2.0.0:
+    resolution: {integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==}
+    engines: {node: '>=8'}
+
+  shebang-regex@3.0.0:
+    resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
+    engines: {node: '>=8'}
+
+  side-channel-list@1.0.1:
+    resolution: {integrity: sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==}
+    engines: {node: '>= 0.4'}
+
+  side-channel-map@1.0.1:
+    resolution: {integrity: sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==}
+    engines: {node: '>= 0.4'}
+
+  side-channel-weakmap@1.0.2:
+    resolution: {integrity: sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==}
+    engines: {node: '>= 0.4'}
+
+  side-channel@1.1.0:
+    resolution: {integrity: sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==}
+    engines: {node: '>= 0.4'}
+
+  siginfo@2.0.0:
+    resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
+
+  signal-exit@4.1.0:
+    resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
+    engines: {node: '>=14'}
+
+  source-map-js@1.2.1:
+    resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
+    engines: {node: '>=0.10.0'}
+
+  stackback@0.0.2:
+    resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+
+  statuses@2.0.2:
+    resolution: {integrity: sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==}
+    engines: {node: '>= 0.8'}
+
+  std-env@3.10.0:
+    resolution: {integrity: sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==}
+
+  strip-final-newline@3.0.0:
+    resolution: {integrity: sha512-dOESqjYr96iWYylGObzd39EuNTa5VJxyvVAEm5Jnh7KGo75V43Hk1odPQkNDyXNmUR6k+gEiDVXnjB8HJ3crXw==}
+    engines: {node: '>=12'}
+
+  strip-literal@2.1.1:
+    resolution: {integrity: sha512-631UJ6O00eNGfMiWG78ck80dfBab8X6IVFB51jZK5Icd7XAs60Z5y7QdSd/wGIklnWvRbUNloVzhOKKmutxQ6Q==}
+
+  tinybench@2.9.0:
+    resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
+
+  tinypool@0.8.4:
+    resolution: {integrity: sha512-i11VH5gS6IFeLY3gMBQ00/MmLncVP7JLXOw1vlgkytLmJK7QnEr7NXf0LBdxfmNPAeyetukOk0bOYrJrFGjYJQ==}
+    engines: {node: '>=14.0.0'}
+
+  tinyspy@2.2.1:
+    resolution: {integrity: sha512-KYad6Vy5VDWV4GH3fjpseMQ/XU2BhIYP7Vzd0LG44qRWm/Yt2WCOTicFdvmgo6gWaqooMQCawTtILVQJupKu7A==}
+    engines: {node: '>=14.0.0'}
+
+  toidentifier@1.0.1:
+    resolution: {integrity: sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==}
+    engines: {node: '>=0.6'}
+
+  type-detect@4.1.0:
+    resolution: {integrity: sha512-Acylog8/luQ8L7il+geoSxhEkazvkslg7PSNKOX59mbB9cOveP5aq9h74Y7YU8yDpJwetzQQrfIwtf4Wp4LKcw==}
+    engines: {node: '>=4'}
+
+  type-is@2.0.1:
+    resolution: {integrity: sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==}
+    engines: {node: '>= 0.6'}
+
+  typescript@5.9.3:
+    resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
+    engines: {node: '>=14.17'}
+    hasBin: true
+
+  ufo@1.6.4:
+    resolution: {integrity: sha512-JFNbkD1Svwe0KvGi8GOeLcP4kAWQ609twvCdcHxq1oSL8svv39ZuSvajcD8B+5D0eL4+s1Is2D/O6KN3qcTeRA==}
+
+  undici-types@6.21.0:
+    resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
+
+  unpipe@1.0.0:
+    resolution: {integrity: sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==}
+    engines: {node: '>= 0.8'}
+
+  vary@1.1.2:
+    resolution: {integrity: sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==}
+    engines: {node: '>= 0.8'}
+
+  vite-node@1.6.1:
+    resolution: {integrity: sha512-YAXkfvGtuTzwWbDSACdJSg4A4DZiAqckWe90Zapc/sEX3XvHcw1NdurM/6od8J207tSDqNbSsgdCacBgvJKFuA==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+    hasBin: true
+
+  vite@5.4.21:
+    resolution: {integrity: sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+    hasBin: true
+    peerDependencies:
+      '@types/node': ^18.0.0 || >=20.0.0
+      less: '*'
+      lightningcss: ^1.21.0
+      sass: '*'
+      sass-embedded: '*'
+      stylus: '*'
+      sugarss: '*'
+      terser: ^5.4.0
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      less:
+        optional: true
+      lightningcss:
+        optional: true
+      sass:
+        optional: true
+      sass-embedded:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      terser:
+        optional: true
+
+  vitest@1.6.1:
+    resolution: {integrity: sha512-Ljb1cnSJSivGN0LqXd/zmDbWEM0RNNg2t1QW/XUhYl/qPqyu7CsqeWtqQXHVaJsecLPuDoak2oJcZN2QoRIOag==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@types/node': ^18.0.0 || >=20.0.0
+      '@vitest/browser': 1.6.1
+      '@vitest/ui': 1.6.1
+      happy-dom: '*'
+      jsdom: '*'
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+
+  which@2.0.2:
+    resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
+    engines: {node: '>= 8'}
+    hasBin: true
+
+  why-is-node-running@2.3.0:
+    resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
+    engines: {node: '>=8'}
+    hasBin: true
+
+  wrappy@1.0.2:
+    resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
+
+  yocto-queue@1.2.2:
+    resolution: {integrity: sha512-4LCcse/U2MHZ63HAJVE+v71o7yOdIe4cZ70Wpf8D/IyjDKYQLV5GD46B+hSTjJsvV5PztjvHoU580EftxjDZFQ==}
+    engines: {node: '>=12.20'}
+
+  zod@3.25.76:
+    resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
+
+snapshots:
+
+  '@esbuild/aix-ppc64@0.21.5':
+    optional: true
+
+  '@esbuild/android-arm64@0.21.5':
+    optional: true
+
+  '@esbuild/android-arm@0.21.5':
+    optional: true
+
+  '@esbuild/android-x64@0.21.5':
+    optional: true
+
+  '@esbuild/darwin-arm64@0.21.5':
+    optional: true
+
+  '@esbuild/darwin-x64@0.21.5':
+    optional: true
+
+  '@esbuild/freebsd-arm64@0.21.5':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.21.5':
+    optional: true
+
+  '@esbuild/linux-arm64@0.21.5':
+    optional: true
+
+  '@esbuild/linux-arm@0.21.5':
+    optional: true
+
+  '@esbuild/linux-ia32@0.21.5':
+    optional: true
+
+  '@esbuild/linux-loong64@0.21.5':
+    optional: true
+
+  '@esbuild/linux-mips64el@0.21.5':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.21.5':
+    optional: true
+
+  '@esbuild/linux-riscv64@0.21.5':
+    optional: true
+
+  '@esbuild/linux-s390x@0.21.5':
+    optional: true
+
+  '@esbuild/linux-x64@0.21.5':
+    optional: true
+
+  '@esbuild/netbsd-x64@0.21.5':
+    optional: true
+
+  '@esbuild/openbsd-x64@0.21.5':
+    optional: true
+
+  '@esbuild/sunos-x64@0.21.5':
+    optional: true
+
+  '@esbuild/win32-arm64@0.21.5':
+    optional: true
+
+  '@esbuild/win32-ia32@0.21.5':
+    optional: true
+
+  '@esbuild/win32-x64@0.21.5':
+    optional: true
+
+  '@jest/schemas@29.6.3':
+    dependencies:
+      '@sinclair/typebox': 0.27.10
+
+  '@jridgewell/sourcemap-codec@1.5.5': {}
+
+  '@noble/curves@1.9.7':
+    dependencies:
+      '@noble/hashes': 1.8.0
+
+  '@noble/ed25519@2.3.0': {}
+
+  '@noble/hashes@1.8.0': {}
+
+  '@rollup/rollup-android-arm-eabi@4.60.2':
+    optional: true
+
+  '@rollup/rollup-android-arm64@4.60.2':
+    optional: true
+
+  '@rollup/rollup-darwin-arm64@4.60.2':
+    optional: true
+
+  '@rollup/rollup-darwin-x64@4.60.2':
+    optional: true
+
+  '@rollup/rollup-freebsd-arm64@4.60.2':
+    optional: true
+
+  '@rollup/rollup-freebsd-x64@4.60.2':
+    optional: true
+
+  '@rollup/rollup-linux-arm-gnueabihf@4.60.2':
+    optional: true
+
+  '@rollup/rollup-linux-arm-musleabihf@4.60.2':
+    optional: true
+
+  '@rollup/rollup-linux-arm64-gnu@4.60.2':
+    optional: true
+
+  '@rollup/rollup-linux-arm64-musl@4.60.2':
+    optional: true
+
+  '@rollup/rollup-linux-loong64-gnu@4.60.2':
+    optional: true
+
+  '@rollup/rollup-linux-loong64-musl@4.60.2':
+    optional: true
+
+  '@rollup/rollup-linux-ppc64-gnu@4.60.2':
+    optional: true
+
+  '@rollup/rollup-linux-ppc64-musl@4.60.2':
+    optional: true
+
+  '@rollup/rollup-linux-riscv64-gnu@4.60.2':
+    optional: true
+
+  '@rollup/rollup-linux-riscv64-musl@4.60.2':
+    optional: true
+
+  '@rollup/rollup-linux-s390x-gnu@4.60.2':
+    optional: true
+
+  '@rollup/rollup-linux-x64-gnu@4.60.2':
+    optional: true
+
+  '@rollup/rollup-linux-x64-musl@4.60.2':
+    optional: true
+
+  '@rollup/rollup-openbsd-x64@4.60.2':
+    optional: true
+
+  '@rollup/rollup-openharmony-arm64@4.60.2':
+    optional: true
+
+  '@rollup/rollup-win32-arm64-msvc@4.60.2':
+    optional: true
+
+  '@rollup/rollup-win32-ia32-msvc@4.60.2':
+    optional: true
+
+  '@rollup/rollup-win32-x64-gnu@4.60.2':
+    optional: true
+
+  '@rollup/rollup-win32-x64-msvc@4.60.2':
+    optional: true
+
+  '@sinclair/typebox@0.27.10': {}
+
+  '@types/body-parser@1.19.6':
+    dependencies:
+      '@types/connect': 3.4.38
+      '@types/node': 20.19.39
+
+  '@types/connect@3.4.38':
+    dependencies:
+      '@types/node': 20.19.39
+
+  '@types/estree@1.0.8': {}
+
+  '@types/express-serve-static-core@5.1.1':
+    dependencies:
+      '@types/node': 20.19.39
+      '@types/qs': 6.15.0
+      '@types/range-parser': 1.2.7
+      '@types/send': 1.2.1
+
+  '@types/express@5.0.6':
+    dependencies:
+      '@types/body-parser': 1.19.6
+      '@types/express-serve-static-core': 5.1.1
+      '@types/serve-static': 2.2.0
+
+  '@types/http-errors@2.0.5': {}
+
+  '@types/node@20.19.39':
+    dependencies:
+      undici-types: 6.21.0
+
+  '@types/qs@6.15.0': {}
+
+  '@types/range-parser@1.2.7': {}
+
+  '@types/send@1.2.1':
+    dependencies:
+      '@types/node': 20.19.39
+
+  '@types/serve-static@2.2.0':
+    dependencies:
+      '@types/http-errors': 2.0.5
+      '@types/node': 20.19.39
+
+  '@vitest/expect@1.6.1':
+    dependencies:
+      '@vitest/spy': 1.6.1
+      '@vitest/utils': 1.6.1
+      chai: 4.5.0
+
+  '@vitest/runner@1.6.1':
+    dependencies:
+      '@vitest/utils': 1.6.1
+      p-limit: 5.0.0
+      pathe: 1.1.2
+
+  '@vitest/snapshot@1.6.1':
+    dependencies:
+      magic-string: 0.30.21
+      pathe: 1.1.2
+      pretty-format: 29.7.0
+
+  '@vitest/spy@1.6.1':
+    dependencies:
+      tinyspy: 2.2.1
+
+  '@vitest/utils@1.6.1':
+    dependencies:
+      diff-sequences: 29.6.3
+      estree-walker: 3.0.3
+      loupe: 2.3.7
+      pretty-format: 29.7.0
+
+  accepts@2.0.0:
+    dependencies:
+      mime-types: 3.0.2
+      negotiator: 1.0.0
+
+  acorn-walk@8.3.5:
+    dependencies:
+      acorn: 8.16.0
+
+  acorn@8.16.0: {}
+
+  ajv-formats@3.0.1(ajv@8.20.0):
+    optionalDependencies:
+      ajv: 8.20.0
+
+  ajv@8.20.0:
+    dependencies:
+      fast-deep-equal: 3.1.3
+      fast-uri: 3.1.0
+      json-schema-traverse: 1.0.0
+      require-from-string: 2.0.2
+
+  ansi-styles@5.2.0: {}
+
+  assertion-error@1.1.0: {}
+
+  base-x@5.0.1: {}
+
+  body-parser@2.2.2:
+    dependencies:
+      bytes: 3.1.2
+      content-type: 1.0.5
+      debug: 4.4.3
+      http-errors: 2.0.1
+      iconv-lite: 0.7.2
+      on-finished: 2.4.1
+      qs: 6.15.1
+      raw-body: 3.0.2
+      type-is: 2.0.1
+    transitivePeerDependencies:
+      - supports-color
+
+  bs58@6.0.0:
+    dependencies:
+      base-x: 5.0.1
+
+  bytes@3.1.2: {}
+
+  cac@6.7.14: {}
+
+  call-bind-apply-helpers@1.0.2:
+    dependencies:
+      es-errors: 1.3.0
+      function-bind: 1.1.2
+
+  call-bound@1.0.4:
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      get-intrinsic: 1.3.0
+
+  chai@4.5.0:
+    dependencies:
+      assertion-error: 1.1.0
+      check-error: 1.0.3
+      deep-eql: 4.1.4
+      get-func-name: 2.0.2
+      loupe: 2.3.7
+      pathval: 1.1.1
+      type-detect: 4.1.0
+
+  check-error@1.0.3:
+    dependencies:
+      get-func-name: 2.0.2
+
+  confbox@0.1.8: {}
+
+  content-disposition@1.1.0: {}
+
+  content-type@1.0.5: {}
+
+  cookie-signature@1.2.2: {}
+
+  cookie@0.7.2: {}
+
+  cross-spawn@7.0.6:
+    dependencies:
+      path-key: 3.1.1
+      shebang-command: 2.0.0
+      which: 2.0.2
+
+  debug@4.4.3:
+    dependencies:
+      ms: 2.1.3
+
+  deep-eql@4.1.4:
+    dependencies:
+      type-detect: 4.1.0
+
+  depd@2.0.0: {}
+
+  diff-sequences@29.6.3: {}
+
+  dunder-proto@1.0.1:
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      es-errors: 1.3.0
+      gopd: 1.2.0
+
+  ee-first@1.1.1: {}
+
+  encodeurl@2.0.0: {}
+
+  es-define-property@1.0.1: {}
+
+  es-errors@1.3.0: {}
+
+  es-object-atoms@1.1.1:
+    dependencies:
+      es-errors: 1.3.0
+
+  esbuild@0.21.5:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.21.5
+      '@esbuild/android-arm': 0.21.5
+      '@esbuild/android-arm64': 0.21.5
+      '@esbuild/android-x64': 0.21.5
+      '@esbuild/darwin-arm64': 0.21.5
+      '@esbuild/darwin-x64': 0.21.5
+      '@esbuild/freebsd-arm64': 0.21.5
+      '@esbuild/freebsd-x64': 0.21.5
+      '@esbuild/linux-arm': 0.21.5
+      '@esbuild/linux-arm64': 0.21.5
+      '@esbuild/linux-ia32': 0.21.5
+      '@esbuild/linux-loong64': 0.21.5
+      '@esbuild/linux-mips64el': 0.21.5
+      '@esbuild/linux-ppc64': 0.21.5
+      '@esbuild/linux-riscv64': 0.21.5
+      '@esbuild/linux-s390x': 0.21.5
+      '@esbuild/linux-x64': 0.21.5
+      '@esbuild/netbsd-x64': 0.21.5
+      '@esbuild/openbsd-x64': 0.21.5
+      '@esbuild/sunos-x64': 0.21.5
+      '@esbuild/win32-arm64': 0.21.5
+      '@esbuild/win32-ia32': 0.21.5
+      '@esbuild/win32-x64': 0.21.5
+
+  escape-html@1.0.3: {}
+
+  estree-walker@3.0.3:
+    dependencies:
+      '@types/estree': 1.0.8
+
+  etag@1.8.1: {}
+
+  execa@8.0.1:
+    dependencies:
+      cross-spawn: 7.0.6
+      get-stream: 8.0.1
+      human-signals: 5.0.0
+      is-stream: 3.0.0
+      merge-stream: 2.0.0
+      npm-run-path: 5.3.0
+      onetime: 6.0.0
+      signal-exit: 4.1.0
+      strip-final-newline: 3.0.0
+
+  express@5.2.1:
+    dependencies:
+      accepts: 2.0.0
+      body-parser: 2.2.2
+      content-disposition: 1.1.0
+      content-type: 1.0.5
+      cookie: 0.7.2
+      cookie-signature: 1.2.2
+      debug: 4.4.3
+      depd: 2.0.0
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      etag: 1.8.1
+      finalhandler: 2.1.1
+      fresh: 2.0.0
+      http-errors: 2.0.1
+      merge-descriptors: 2.0.0
+      mime-types: 3.0.2
+      on-finished: 2.4.1
+      once: 1.4.0
+      parseurl: 1.3.3
+      proxy-addr: 2.0.7
+      qs: 6.15.1
+      range-parser: 1.2.1
+      router: 2.2.0
+      send: 1.2.1
+      serve-static: 2.2.1
+      statuses: 2.0.2
+      type-is: 2.0.1
+      vary: 1.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  fast-deep-equal@3.1.3: {}
+
+  fast-uri@3.1.0: {}
+
+  finalhandler@2.1.1:
+    dependencies:
+      debug: 4.4.3
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      on-finished: 2.4.1
+      parseurl: 1.3.3
+      statuses: 2.0.2
+    transitivePeerDependencies:
+      - supports-color
+
+  forwarded@0.2.0: {}
+
+  fresh@2.0.0: {}
+
+  fsevents@2.3.3:
+    optional: true
+
+  function-bind@1.1.2: {}
+
+  get-func-name@2.0.2: {}
+
+  get-intrinsic@1.3.0:
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      es-define-property: 1.0.1
+      es-errors: 1.3.0
+      es-object-atoms: 1.1.1
+      function-bind: 1.1.2
+      get-proto: 1.0.1
+      gopd: 1.2.0
+      has-symbols: 1.1.0
+      hasown: 2.0.3
+      math-intrinsics: 1.1.0
+
+  get-proto@1.0.1:
+    dependencies:
+      dunder-proto: 1.0.1
+      es-object-atoms: 1.1.1
+
+  get-stream@8.0.1: {}
+
+  gopd@1.2.0: {}
+
+  has-symbols@1.1.0: {}
+
+  hasown@2.0.3:
+    dependencies:
+      function-bind: 1.1.2
+
+  http-errors@2.0.1:
+    dependencies:
+      depd: 2.0.0
+      inherits: 2.0.4
+      setprototypeof: 1.2.0
+      statuses: 2.0.2
+      toidentifier: 1.0.1
+
+  human-signals@5.0.0: {}
+
+  iconv-lite@0.7.2:
+    dependencies:
+      safer-buffer: 2.1.2
+
+  inherits@2.0.4: {}
+
+  ipaddr.js@1.9.1: {}
+
+  is-promise@4.0.0: {}
+
+  is-stream@3.0.0: {}
+
+  isexe@2.0.0: {}
+
+  js-tokens@9.0.1: {}
+
+  json-schema-traverse@1.0.0: {}
+
+  local-pkg@0.5.1:
+    dependencies:
+      mlly: 1.8.2
+      pkg-types: 1.3.1
+
+  loupe@2.3.7:
+    dependencies:
+      get-func-name: 2.0.2
+
+  magic-string@0.30.21:
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.5
+
+  math-intrinsics@1.1.0: {}
+
+  media-typer@1.1.0: {}
+
+  merge-descriptors@2.0.0: {}
+
+  merge-stream@2.0.0: {}
+
+  mime-db@1.54.0: {}
+
+  mime-types@3.0.2:
+    dependencies:
+      mime-db: 1.54.0
+
+  mimic-fn@4.0.0: {}
+
+  mlly@1.8.2:
+    dependencies:
+      acorn: 8.16.0
+      pathe: 2.0.3
+      pkg-types: 1.3.1
+      ufo: 1.6.4
+
+  ms@2.1.3: {}
+
+  nanoid@3.3.12: {}
+
+  negotiator@1.0.0: {}
+
+  npm-run-path@5.3.0:
+    dependencies:
+      path-key: 4.0.0
+
+  object-inspect@1.13.4: {}
+
+  on-finished@2.4.1:
+    dependencies:
+      ee-first: 1.1.1
+
+  once@1.4.0:
+    dependencies:
+      wrappy: 1.0.2
+
+  onetime@6.0.0:
+    dependencies:
+      mimic-fn: 4.0.0
+
+  p-limit@5.0.0:
+    dependencies:
+      yocto-queue: 1.2.2
+
+  parseurl@1.3.3: {}
+
+  path-key@3.1.1: {}
+
+  path-key@4.0.0: {}
+
+  path-to-regexp@8.4.2: {}
+
+  pathe@1.1.2: {}
+
+  pathe@2.0.3: {}
+
+  pathval@1.1.1: {}
+
+  picocolors@1.1.1: {}
+
+  pkg-types@1.3.1:
+    dependencies:
+      confbox: 0.1.8
+      mlly: 1.8.2
+      pathe: 2.0.3
+
+  postcss@8.5.13:
+    dependencies:
+      nanoid: 3.3.12
+      picocolors: 1.1.1
+      source-map-js: 1.2.1
+
+  pretty-format@29.7.0:
+    dependencies:
+      '@jest/schemas': 29.6.3
+      ansi-styles: 5.2.0
+      react-is: 18.3.1
+
+  proxy-addr@2.0.7:
+    dependencies:
+      forwarded: 0.2.0
+      ipaddr.js: 1.9.1
+
+  qs@6.15.1:
+    dependencies:
+      side-channel: 1.1.0
+
+  range-parser@1.2.1: {}
+
+  raw-body@3.0.2:
+    dependencies:
+      bytes: 3.1.2
+      http-errors: 2.0.1
+      iconv-lite: 0.7.2
+      unpipe: 1.0.0
+
+  react-is@18.3.1: {}
+
+  require-from-string@2.0.2: {}
+
+  rollup@4.60.2:
+    dependencies:
+      '@types/estree': 1.0.8
+    optionalDependencies:
+      '@rollup/rollup-android-arm-eabi': 4.60.2
+      '@rollup/rollup-android-arm64': 4.60.2
+      '@rollup/rollup-darwin-arm64': 4.60.2
+      '@rollup/rollup-darwin-x64': 4.60.2
+      '@rollup/rollup-freebsd-arm64': 4.60.2
+      '@rollup/rollup-freebsd-x64': 4.60.2
+      '@rollup/rollup-linux-arm-gnueabihf': 4.60.2
+      '@rollup/rollup-linux-arm-musleabihf': 4.60.2
+      '@rollup/rollup-linux-arm64-gnu': 4.60.2
+      '@rollup/rollup-linux-arm64-musl': 4.60.2
+      '@rollup/rollup-linux-loong64-gnu': 4.60.2
+      '@rollup/rollup-linux-loong64-musl': 4.60.2
+      '@rollup/rollup-linux-ppc64-gnu': 4.60.2
+      '@rollup/rollup-linux-ppc64-musl': 4.60.2
+      '@rollup/rollup-linux-riscv64-gnu': 4.60.2
+      '@rollup/rollup-linux-riscv64-musl': 4.60.2
+      '@rollup/rollup-linux-s390x-gnu': 4.60.2
+      '@rollup/rollup-linux-x64-gnu': 4.60.2
+      '@rollup/rollup-linux-x64-musl': 4.60.2
+      '@rollup/rollup-openbsd-x64': 4.60.2
+      '@rollup/rollup-openharmony-arm64': 4.60.2
+      '@rollup/rollup-win32-arm64-msvc': 4.60.2
+      '@rollup/rollup-win32-ia32-msvc': 4.60.2
+      '@rollup/rollup-win32-x64-gnu': 4.60.2
+      '@rollup/rollup-win32-x64-msvc': 4.60.2
+      fsevents: 2.3.3
+
+  router@2.2.0:
+    dependencies:
+      debug: 4.4.3
+      depd: 2.0.0
+      is-promise: 4.0.0
+      parseurl: 1.3.3
+      path-to-regexp: 8.4.2
+    transitivePeerDependencies:
+      - supports-color
+
+  safer-buffer@2.1.2: {}
+
+  send@1.2.1:
+    dependencies:
+      debug: 4.4.3
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      etag: 1.8.1
+      fresh: 2.0.0
+      http-errors: 2.0.1
+      mime-types: 3.0.2
+      ms: 2.1.3
+      on-finished: 2.4.1
+      range-parser: 1.2.1
+      statuses: 2.0.2
+    transitivePeerDependencies:
+      - supports-color
+
+  serve-static@2.2.1:
+    dependencies:
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      parseurl: 1.3.3
+      send: 1.2.1
+    transitivePeerDependencies:
+      - supports-color
+
+  setprototypeof@1.2.0: {}
+
+  shebang-command@2.0.0:
+    dependencies:
+      shebang-regex: 3.0.0
+
+  shebang-regex@3.0.0: {}
+
+  side-channel-list@1.0.1:
+    dependencies:
+      es-errors: 1.3.0
+      object-inspect: 1.13.4
+
+  side-channel-map@1.0.1:
+    dependencies:
+      call-bound: 1.0.4
+      es-errors: 1.3.0
+      get-intrinsic: 1.3.0
+      object-inspect: 1.13.4
+
+  side-channel-weakmap@1.0.2:
+    dependencies:
+      call-bound: 1.0.4
+      es-errors: 1.3.0
+      get-intrinsic: 1.3.0
+      object-inspect: 1.13.4
+      side-channel-map: 1.0.1
+
+  side-channel@1.1.0:
+    dependencies:
+      es-errors: 1.3.0
+      object-inspect: 1.13.4
+      side-channel-list: 1.0.1
+      side-channel-map: 1.0.1
+      side-channel-weakmap: 1.0.2
+
+  siginfo@2.0.0: {}
+
+  signal-exit@4.1.0: {}
+
+  source-map-js@1.2.1: {}
+
+  stackback@0.0.2: {}
+
+  statuses@2.0.2: {}
+
+  std-env@3.10.0: {}
+
+  strip-final-newline@3.0.0: {}
+
+  strip-literal@2.1.1:
+    dependencies:
+      js-tokens: 9.0.1
+
+  tinybench@2.9.0: {}
+
+  tinypool@0.8.4: {}
+
+  tinyspy@2.2.1: {}
+
+  toidentifier@1.0.1: {}
+
+  type-detect@4.1.0: {}
+
+  type-is@2.0.1:
+    dependencies:
+      content-type: 1.0.5
+      media-typer: 1.1.0
+      mime-types: 3.0.2
+
+  typescript@5.9.3: {}
+
+  ufo@1.6.4: {}
+
+  undici-types@6.21.0: {}
+
+  unpipe@1.0.0: {}
+
+  vary@1.1.2: {}
+
+  vite-node@1.6.1(@types/node@20.19.39):
+    dependencies:
+      cac: 6.7.14
+      debug: 4.4.3
+      pathe: 1.1.2
+      picocolors: 1.1.1
+      vite: 5.4.21(@types/node@20.19.39)
+    transitivePeerDependencies:
+      - '@types/node'
+      - less
+      - lightningcss
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+
+  vite@5.4.21(@types/node@20.19.39):
+    dependencies:
+      esbuild: 0.21.5
+      postcss: 8.5.13
+      rollup: 4.60.2
+    optionalDependencies:
+      '@types/node': 20.19.39
+      fsevents: 2.3.3
+
+  vitest@1.6.1(@types/node@20.19.39):
+    dependencies:
+      '@vitest/expect': 1.6.1
+      '@vitest/runner': 1.6.1
+      '@vitest/snapshot': 1.6.1
+      '@vitest/spy': 1.6.1
+      '@vitest/utils': 1.6.1
+      acorn-walk: 8.3.5
+      chai: 4.5.0
+      debug: 4.4.3
+      execa: 8.0.1
+      local-pkg: 0.5.1
+      magic-string: 0.30.21
+      pathe: 1.1.2
+      picocolors: 1.1.1
+      std-env: 3.10.0
+      strip-literal: 2.1.1
+      tinybench: 2.9.0
+      tinypool: 0.8.4
+      vite: 5.4.21(@types/node@20.19.39)
+      vite-node: 1.6.1(@types/node@20.19.39)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/node': 20.19.39
+    transitivePeerDependencies:
+      - less
+      - lightningcss
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+
+  which@2.0.2:
+    dependencies:
+      isexe: 2.0.0
+
+  why-is-node-running@2.3.0:
+    dependencies:
+      siginfo: 2.0.0
+      stackback: 0.0.2
+
+  wrappy@1.0.2: {}
+
+  yocto-queue@1.2.2: {}
+
+  zod@3.25.76: {}

--- a/scripts/fn-200-build-commitments.mjs
+++ b/scripts/fn-200-build-commitments.mjs
@@ -1,0 +1,99 @@
+#!/usr/bin/env node
+// FN-200: build example claimCommitments arrays for each banking credential
+// schema by invoking the FN-082 eto-zk-cli (Poseidon-2 over BN254 Fr, t=3).
+//
+// Output: writes JSON to stdout with shape:
+//   { [credName]: { example: <vc body>, claimCommitments: [...entries] } }
+//
+// Salts are deterministic test salts of the form `byte(i+1) repeated 32x`,
+// where i is the lexicographic index of the field. Real issuers MUST sample
+// salts from a CSPRNG and never reuse them.
+
+import { execFileSync } from "node:child_process";
+
+const CLI = process.env.ETO_ZK_CLI ?? "/home/naman/eto/target/release/eto-zk-cli";
+
+// Example credentialSubject objects. These mirror the schema-required fields
+// and use obviously-fake test values. Numeric fields are Number, strings are
+// strings — value-encoding auto-detect in `eto-zk-cli commit` handles both.
+const examples = {
+  "account-checking": {
+    id: "did:eto:agentcard:0000000000000000000000000000000000000000000000000000000000000001",
+    account_pda: "cafef00dcafef00dcafef00dcafef00dcafef00dcafef00dcafef00dcafef00d",
+    holder: "deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef",
+    opened_slot: 1234567,
+    currency: "eUSD",
+    opening_balance: 1000000000,
+  },
+  "account-savings": {
+    id: "did:eto:agentcard:0000000000000000000000000000000000000000000000000000000000000002",
+    account_pda: "feedfacefeedfacefeedfacefeedfacefeedfacefeedfacefeedfacefeedface",
+    holder: "deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef",
+    opened_slot: 1234567,
+    currency: "eUSD",
+    opening_balance: 5000000000,
+    apy_bps: 400,
+  },
+  "card-debit": {
+    id: "did:eto:agentcard:0000000000000000000000000000000000000000000000000000000000000003",
+    card_id_hash: "0102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f20",
+    holder: "deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef",
+    linked_account_pda: "cafef00dcafef00dcafef00dcafef00dcafef00dcafef00dcafef00dcafef00d",
+    jurisdiction: "us",
+    issued_slot: 1234567,
+    spending_limit_per_day: 5000000000,
+    network_brand: "visa",
+    tier: "standard",
+  },
+  "tax-1099": {
+    id: "did:eto:agentcard:0000000000000000000000000000000000000000000000000000000000000004",
+    year: 2026,
+    interest_income_atomic: 123456789,
+    fees_atomic: 4200,
+    withholding_atomic: 0,
+    currency: "eUSD",
+  },
+};
+
+// Sort leaf field paths lexicographically (UTF-8 byte order — JS default `<`
+// on strings already does this for ASCII paths).
+function sortedPaths(subject) {
+  return Object.keys(subject)
+    .map((k) => `credentialSubject.${k}`)
+    .sort();
+}
+
+function saltFor(idx) {
+  // 32 bytes of (idx+1) — deterministic + obviously test-only
+  const byte = ((idx + 1) & 0xff).toString(16).padStart(2, "0");
+  return byte.repeat(32);
+}
+
+function commit({ fieldPath, value, idx, salt }) {
+  // Strip "credentialSubject." prefix for the --field arg label, but the
+  // §10.3.1 ABI uses the full dotted path. The CLI only emits this label
+  // verbatim back as `fieldPath`, so we pass the full path.
+  const out = execFileSync(CLI, [
+    "commit",
+    "--field", fieldPath,
+    "--value", String(value),
+    "--idx", String(idx),
+    "--salt", salt,
+  ], { encoding: "utf8" });
+  return JSON.parse(out);
+}
+
+const result = {};
+for (const [name, subject] of Object.entries(examples)) {
+  const paths = sortedPaths(subject);
+  const claimCommitments = paths.map((fieldPath, idx) => {
+    const key = fieldPath.replace(/^credentialSubject\./, "");
+    const value = subject[key];
+    const salt = saltFor(idx);
+    const out = commit({ fieldPath, value, idx, salt });
+    return out;
+  });
+  result[name] = { subject, claimCommitments };
+}
+
+process.stdout.write(JSON.stringify(result, null, 2) + "\n");

--- a/scripts/fn-200-emit-schemas.mjs
+++ b/scripts/fn-200-emit-schemas.mjs
@@ -1,0 +1,129 @@
+#!/usr/bin/env node
+// FN-200: rewrite spec/banking/credentials/*.json to add the §10.3.1
+// `claimCommitments` block (schema + worked example) using real Poseidon-2
+// outputs from FN-082's eto-zk-cli.
+import fs from "node:fs";
+import path from "node:path";
+
+const ROOT = path.resolve(new URL("..", import.meta.url).pathname);
+const fixtures = JSON.parse(
+  fs.readFileSync(path.join(ROOT, "spec/banking/credentials/_fixtures.json"), "utf8")
+);
+
+const META = {
+  "account-checking": {
+    typeName: "CheckingAccountCredential",
+    issuer: "did:eto:bank:eto-reference",
+    issuanceDate: "2026-04-30T00:00:00.000Z",
+    contextV1: "https://schema.eto.dev/banking/account-checking/v1",
+  },
+  "account-savings": {
+    typeName: "SavingsAccountCredential",
+    issuer: "did:eto:bank:eto-reference",
+    issuanceDate: "2026-04-30T00:00:00.000Z",
+    contextV1: "https://schema.eto.dev/banking/account-savings/v1",
+  },
+  "card-debit": {
+    typeName: "CardDebitCredential",
+    issuer: "did:eto:bank:eto-reference",
+    issuanceDate: "2026-04-30T00:00:00.000Z",
+    contextV1: "https://schema.eto.dev/banking/card-debit/v1",
+  },
+  "tax-1099": {
+    typeName: "Tax1099Credential",
+    issuer: "did:eto:bank:eto-reference",
+    issuanceDate: "2027-01-31T00:00:00.000Z",
+    contextV1: "https://schema.eto.dev/banking/tax-1099/v1",
+  },
+};
+
+// Stable, ETO-issuer-shaped 32-byte hex placeholders for the example envelope.
+const EXAMPLE_ISSUER_AUTHORITY =
+  "abadcafeabadcafeabadcafeabadcafeabadcafeabadcafeabadcafeabadcafe";
+const EXAMPLE_CLAIM_HASH =
+  "0badc0de0badc0de0badc0de0badc0de0badc0de0badc0de0badc0de0badc0de";
+
+const claimCommitmentsSchema = {
+  type: "array",
+  description:
+    "Per-attribute Poseidon-2 commitments over every leaf field of credentialSubject, per spec/SINGULARITY-LAYER-1.md §10.3.1. Issuers MUST emit one entry for every leaf field (sorted lexicographically by fieldPath) before computing claim_hash. Required by FN-077 (selective-disclosure ZK proofs); produced by FN-082's `eto-zk-cli commit`.",
+  minItems: 1,
+  items: {
+    type: "object",
+    required: ["fieldPath", "idx", "commitment", "saltCommitment"],
+    additionalProperties: false,
+    properties: {
+      fieldPath: {
+        type: "string",
+        description:
+          "Dot-separated JSON path from the VC root, e.g. 'credentialSubject.account_pda'. Leaf fields only.",
+        pattern: "^credentialSubject\\.",
+      },
+      idx: {
+        type: "integer",
+        minimum: 0,
+        description:
+          "Zero-based position of this fieldPath in the lexicographically sorted leaf-path list. MUST equal the field_index public input (slot 6) when constructing a verify_credential_predicate proof for this attribute.",
+      },
+      commitment: {
+        type: "string",
+        pattern: "^[0-9a-fA-F]{64}$",
+        description:
+          "Poseidon2_t3([value_field, salt_field, idx_field])[0] — 32-byte little-endian hex.",
+      },
+      saltCommitment: {
+        type: "string",
+        pattern: "^[0-9a-fA-F]{64}$",
+        description:
+          "Poseidon2_t3([salt_field, Fr::ZERO, idx_field])[0] — 32-byte little-endian hex. Pins the salt domain without revealing salt.",
+      },
+    },
+  },
+};
+
+function buildExample(name) {
+  const meta = META[name];
+  const fx = fixtures[name];
+  return {
+    "@context": [
+      "https://www.w3.org/2018/credentials/v1",
+      meta.contextV1,
+    ],
+    type: ["VerifiableCredential", meta.typeName],
+    issuer: meta.issuer,
+    issuanceDate: meta.issuanceDate,
+    credentialSubject: fx.subject,
+    issuerAuthority: EXAMPLE_ISSUER_AUTHORITY,
+    claimCommitments: fx.claimCommitments,
+    claim_hash: EXAMPLE_CLAIM_HASH,
+  };
+}
+
+for (const [name] of Object.entries(META)) {
+  const file = path.join(ROOT, "spec/banking/credentials", `${name}.json`);
+  const schema = JSON.parse(fs.readFileSync(file, "utf8"));
+
+  // Inject claimCommitments into properties + required.
+  schema.properties.claimCommitments = claimCommitmentsSchema;
+  if (!schema.required.includes("claimCommitments")) {
+    // Insert before claim_hash so claim_hash sits at the end of required.
+    const idx = schema.required.indexOf("issuerAuthority");
+    if (idx >= 0) {
+      schema.required.splice(idx + 1, 0, "claimCommitments");
+    } else {
+      schema.required.push("claimCommitments");
+    }
+  }
+
+  // Update $comment to mention FN-200 / FN-082.
+  if (typeof schema.$comment === "string" && !schema.$comment.includes("FN-200")) {
+    schema.$comment +=
+      " FN-200 added the §10.3.1 `claimCommitments` block; example commitments computed via FN-082's eto-zk-cli (Poseidon-2 over BN254 Fr, t=3).";
+  }
+
+  // Replace examples with the worked envelope.
+  schema.examples = [buildExample(name)];
+
+  fs.writeFileSync(file, JSON.stringify(schema, null, 2) + "\n");
+  console.log(`wrote ${file}`);
+}

--- a/spec/banking/credentials/account-checking.json
+++ b/spec/banking/credentials/account-checking.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://schema.eto.dev/banking/account-checking/v1",
-  "$comment": "FN-190 — JSON-LD VC template for an eUSD checking account credential. Mirrors src/issuers/bank.ts:buildAccountCheckingVc and SINGULARITY-LAYER-1.md §10.3.1.",
+  "$comment": "FN-190 — JSON-LD VC template for an eUSD checking account credential. Mirrors src/issuers/bank.ts:buildAccountCheckingVc and SINGULARITY-LAYER-1.md §10.3.1. FN-200 added the §10.3.1 `claimCommitments` block; example commitments computed via FN-082's eto-zk-cli (Poseidon-2 over BN254 Fr, t=3).",
   "title": "CheckingAccountCredential",
   "type": "object",
   "required": [
@@ -10,13 +10,16 @@
     "issuer",
     "issuanceDate",
     "credentialSubject",
-    "issuerAuthority"
+    "issuerAuthority",
+    "claimCommitments"
   ],
   "properties": {
     "@context": {
       "type": "array",
       "minItems": 2,
-      "items": { "type": "string" },
+      "items": {
+        "type": "string"
+      },
       "default": [
         "https://www.w3.org/2018/credentials/v1",
         "https://schema.eto.dev/banking/account-checking/v1"
@@ -24,9 +27,16 @@
     },
     "type": {
       "type": "array",
-      "items": { "type": "string" },
-      "contains": { "const": "VerifiableCredential" },
-      "default": ["VerifiableCredential", "CheckingAccountCredential"]
+      "items": {
+        "type": "string"
+      },
+      "contains": {
+        "const": "VerifiableCredential"
+      },
+      "default": [
+        "VerifiableCredential",
+        "CheckingAccountCredential"
+      ]
     },
     "issuer": {
       "type": "string",
@@ -39,7 +49,14 @@
     },
     "credentialSubject": {
       "type": "object",
-      "required": ["id", "account_pda", "holder", "opened_slot", "currency", "opening_balance"],
+      "required": [
+        "id",
+        "account_pda",
+        "holder",
+        "opened_slot",
+        "currency",
+        "opening_balance"
+      ],
       "additionalProperties": false,
       "properties": {
         "id": {
@@ -58,7 +75,9 @@
           "type": "integer",
           "minimum": 0
         },
-        "currency": { "const": "eUSD" },
+        "currency": {
+          "const": "eUSD"
+        },
         "opening_balance": {
           "type": "integer",
           "minimum": 0,
@@ -75,6 +94,105 @@
       "type": "string",
       "pattern": "^[0-9a-fA-F]{64}$",
       "description": "SHA-256 over the JCS-canonicalized credentialSubject (set at issuance, optional in the template)."
+    },
+    "claimCommitments": {
+      "type": "array",
+      "description": "Per-attribute Poseidon-2 commitments over every leaf field of credentialSubject, per spec/SINGULARITY-LAYER-1.md §10.3.1. Issuers MUST emit one entry for every leaf field (sorted lexicographically by fieldPath) before computing claim_hash. Required by FN-077 (selective-disclosure ZK proofs); produced by FN-082's `eto-zk-cli commit`.",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "required": [
+          "fieldPath",
+          "idx",
+          "commitment",
+          "saltCommitment"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "fieldPath": {
+            "type": "string",
+            "description": "Dot-separated JSON path from the VC root, e.g. 'credentialSubject.account_pda'. Leaf fields only.",
+            "pattern": "^credentialSubject\\."
+          },
+          "idx": {
+            "type": "integer",
+            "minimum": 0,
+            "description": "Zero-based position of this fieldPath in the lexicographically sorted leaf-path list. MUST equal the field_index public input (slot 6) when constructing a verify_credential_predicate proof for this attribute."
+          },
+          "commitment": {
+            "type": "string",
+            "pattern": "^[0-9a-fA-F]{64}$",
+            "description": "Poseidon2_t3([value_field, salt_field, idx_field])[0] — 32-byte little-endian hex."
+          },
+          "saltCommitment": {
+            "type": "string",
+            "pattern": "^[0-9a-fA-F]{64}$",
+            "description": "Poseidon2_t3([salt_field, Fr::ZERO, idx_field])[0] — 32-byte little-endian hex. Pins the salt domain without revealing salt."
+          }
+        }
+      }
     }
-  }
+  },
+  "examples": [
+    {
+      "@context": [
+        "https://www.w3.org/2018/credentials/v1",
+        "https://schema.eto.dev/banking/account-checking/v1"
+      ],
+      "type": [
+        "VerifiableCredential",
+        "CheckingAccountCredential"
+      ],
+      "issuer": "did:eto:bank:eto-reference",
+      "issuanceDate": "2026-04-30T00:00:00.000Z",
+      "credentialSubject": {
+        "id": "did:eto:agentcard:0000000000000000000000000000000000000000000000000000000000000001",
+        "account_pda": "cafef00dcafef00dcafef00dcafef00dcafef00dcafef00dcafef00dcafef00d",
+        "holder": "deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef",
+        "opened_slot": 1234567,
+        "currency": "eUSD",
+        "opening_balance": 1000000000
+      },
+      "issuerAuthority": "abadcafeabadcafeabadcafeabadcafeabadcafeabadcafeabadcafeabadcafe",
+      "claimCommitments": [
+        {
+          "fieldPath": "credentialSubject.account_pda",
+          "idx": 0,
+          "commitment": "37fd5959c5b80255ffadead85f46f3277b4227e948ba6acf141fec8ee1a66118",
+          "saltCommitment": "83efd9326266a623972b58129f336b6b83e82bf7129809e77a4022e7a7ef182d"
+        },
+        {
+          "fieldPath": "credentialSubject.currency",
+          "idx": 1,
+          "commitment": "f39dee1310787b6e4fd748cec27b64635289806a1812ca6a5d1631a5ca73532f",
+          "saltCommitment": "3906158ac1901abfefcffca6983c7b1ee09e7333610089e18121caa6bf52042d"
+        },
+        {
+          "fieldPath": "credentialSubject.holder",
+          "idx": 2,
+          "commitment": "56eeb18da268d13abb1064dba12a1066899d0b589099054f6a0b68e04b0fed26",
+          "saltCommitment": "95ea817fce300c0defec532f119e5dc7981372ec960a889f8d0dfb76e5c9cb2e"
+        },
+        {
+          "fieldPath": "credentialSubject.id",
+          "idx": 3,
+          "commitment": "b537007ea92acc4b11545cfc66fd85818e480f7c9e08a8de68c45ebe3a3afb19",
+          "saltCommitment": "38daf6c319b49a993138388bd3263a4ef099212c914cf0ae2f96fadb928b4c24"
+        },
+        {
+          "fieldPath": "credentialSubject.opened_slot",
+          "idx": 4,
+          "commitment": "215021c05d4cb737c974c8bb46c9ad2bf4ce27098028b7e1dca1e26df704a82c",
+          "saltCommitment": "2ea0a3aad16daf93ea5d3414010b7d5308a0777c8e0e66e2ee2484b60247bd0e"
+        },
+        {
+          "fieldPath": "credentialSubject.opening_balance",
+          "idx": 5,
+          "commitment": "1f1ba14e4d824886ad02498f917c8728dce322868af05e85f106b3cffac8fb18",
+          "saltCommitment": "b6b6b21969b663f348bd48aef998835d2f9abd2d1ecf7ba7d404b08b8f964823"
+        }
+      ],
+      "claim_hash": "0badc0de0badc0de0badc0de0badc0de0badc0de0badc0de0badc0de0badc0de"
+    }
+  ]
 }

--- a/spec/banking/credentials/account-savings.json
+++ b/spec/banking/credentials/account-savings.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://schema.eto.dev/banking/account-savings/v1",
-  "$comment": "FN-190 — JSON-LD VC template for an eUSD savings account credential. Mirrors src/issuers/bank.ts:buildAccountSavingsVc.",
+  "$comment": "FN-190 — JSON-LD VC template for an eUSD savings account credential. Mirrors src/issuers/bank.ts:buildAccountSavingsVc. FN-200 added the §10.3.1 `claimCommitments` block; example commitments computed via FN-082's eto-zk-cli (Poseidon-2 over BN254 Fr, t=3).",
   "title": "SavingsAccountCredential",
   "type": "object",
   "required": [
@@ -10,13 +10,16 @@
     "issuer",
     "issuanceDate",
     "credentialSubject",
-    "issuerAuthority"
+    "issuerAuthority",
+    "claimCommitments"
   ],
   "properties": {
     "@context": {
       "type": "array",
       "minItems": 2,
-      "items": { "type": "string" },
+      "items": {
+        "type": "string"
+      },
       "default": [
         "https://www.w3.org/2018/credentials/v1",
         "https://schema.eto.dev/banking/account-savings/v1"
@@ -24,9 +27,16 @@
     },
     "type": {
       "type": "array",
-      "items": { "type": "string" },
-      "contains": { "const": "VerifiableCredential" },
-      "default": ["VerifiableCredential", "SavingsAccountCredential"]
+      "items": {
+        "type": "string"
+      },
+      "contains": {
+        "const": "VerifiableCredential"
+      },
+      "default": [
+        "VerifiableCredential",
+        "SavingsAccountCredential"
+      ]
     },
     "issuer": {
       "type": "string",
@@ -65,7 +75,9 @@
           "type": "integer",
           "minimum": 0
         },
-        "currency": { "const": "eUSD" },
+        "currency": {
+          "const": "eUSD"
+        },
         "opening_balance": {
           "type": "integer",
           "minimum": 0,
@@ -86,6 +98,112 @@
     "claim_hash": {
       "type": "string",
       "pattern": "^[0-9a-fA-F]{64}$"
+    },
+    "claimCommitments": {
+      "type": "array",
+      "description": "Per-attribute Poseidon-2 commitments over every leaf field of credentialSubject, per spec/SINGULARITY-LAYER-1.md §10.3.1. Issuers MUST emit one entry for every leaf field (sorted lexicographically by fieldPath) before computing claim_hash. Required by FN-077 (selective-disclosure ZK proofs); produced by FN-082's `eto-zk-cli commit`.",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "required": [
+          "fieldPath",
+          "idx",
+          "commitment",
+          "saltCommitment"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "fieldPath": {
+            "type": "string",
+            "description": "Dot-separated JSON path from the VC root, e.g. 'credentialSubject.account_pda'. Leaf fields only.",
+            "pattern": "^credentialSubject\\."
+          },
+          "idx": {
+            "type": "integer",
+            "minimum": 0,
+            "description": "Zero-based position of this fieldPath in the lexicographically sorted leaf-path list. MUST equal the field_index public input (slot 6) when constructing a verify_credential_predicate proof for this attribute."
+          },
+          "commitment": {
+            "type": "string",
+            "pattern": "^[0-9a-fA-F]{64}$",
+            "description": "Poseidon2_t3([value_field, salt_field, idx_field])[0] — 32-byte little-endian hex."
+          },
+          "saltCommitment": {
+            "type": "string",
+            "pattern": "^[0-9a-fA-F]{64}$",
+            "description": "Poseidon2_t3([salt_field, Fr::ZERO, idx_field])[0] — 32-byte little-endian hex. Pins the salt domain without revealing salt."
+          }
+        }
+      }
     }
-  }
+  },
+  "examples": [
+    {
+      "@context": [
+        "https://www.w3.org/2018/credentials/v1",
+        "https://schema.eto.dev/banking/account-savings/v1"
+      ],
+      "type": [
+        "VerifiableCredential",
+        "SavingsAccountCredential"
+      ],
+      "issuer": "did:eto:bank:eto-reference",
+      "issuanceDate": "2026-04-30T00:00:00.000Z",
+      "credentialSubject": {
+        "id": "did:eto:agentcard:0000000000000000000000000000000000000000000000000000000000000002",
+        "account_pda": "feedfacefeedfacefeedfacefeedfacefeedfacefeedfacefeedfacefeedface",
+        "holder": "deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef",
+        "opened_slot": 1234567,
+        "currency": "eUSD",
+        "opening_balance": 5000000000,
+        "apy_bps": 400
+      },
+      "issuerAuthority": "abadcafeabadcafeabadcafeabadcafeabadcafeabadcafeabadcafeabadcafe",
+      "claimCommitments": [
+        {
+          "fieldPath": "credentialSubject.account_pda",
+          "idx": 0,
+          "commitment": "d73f1ebdaf16e0c67955630b31e2e398c81b05289fa7702284615715f880c21e",
+          "saltCommitment": "83efd9326266a623972b58129f336b6b83e82bf7129809e77a4022e7a7ef182d"
+        },
+        {
+          "fieldPath": "credentialSubject.apy_bps",
+          "idx": 1,
+          "commitment": "3ac881f88d3ea615cbf1b342e598ee4e68a59216433b299c4910efadc4da4528",
+          "saltCommitment": "3906158ac1901abfefcffca6983c7b1ee09e7333610089e18121caa6bf52042d"
+        },
+        {
+          "fieldPath": "credentialSubject.currency",
+          "idx": 2,
+          "commitment": "023a6a18a933488f01b21cfb8d7cfe4ef5bb7ddf9be4164e20eb767d30a57a2f",
+          "saltCommitment": "95ea817fce300c0defec532f119e5dc7981372ec960a889f8d0dfb76e5c9cb2e"
+        },
+        {
+          "fieldPath": "credentialSubject.holder",
+          "idx": 3,
+          "commitment": "f499599ddb86fd739cd815e3781703367f3f944362ee5fe1e3a92e4ff7babc2f",
+          "saltCommitment": "38daf6c319b49a993138388bd3263a4ef099212c914cf0ae2f96fadb928b4c24"
+        },
+        {
+          "fieldPath": "credentialSubject.id",
+          "idx": 4,
+          "commitment": "04976443555178d9148e33cccf0529f2a80edc91c749a2679d18fa3927801b2e",
+          "saltCommitment": "2ea0a3aad16daf93ea5d3414010b7d5308a0777c8e0e66e2ee2484b60247bd0e"
+        },
+        {
+          "fieldPath": "credentialSubject.opened_slot",
+          "idx": 5,
+          "commitment": "f58fcbee1f8ff3abb3ddf7ff32ca3b2ff47e3f571d2a32e5374c4bf38e734d12",
+          "saltCommitment": "b6b6b21969b663f348bd48aef998835d2f9abd2d1ecf7ba7d404b08b8f964823"
+        },
+        {
+          "fieldPath": "credentialSubject.opening_balance",
+          "idx": 6,
+          "commitment": "08d0eb0dd662be921c9e9c750447368752b9c95699ffe0d34bba004e13df5408",
+          "saltCommitment": "a45c6791a9e5ca35b4efaa0a69b751cf4d3a2314c300d5bd7a2771203b3ceb2f"
+        }
+      ],
+      "claim_hash": "0badc0de0badc0de0badc0de0badc0de0badc0de0badc0de0badc0de0badc0de"
+    }
+  ]
 }

--- a/spec/banking/credentials/card-debit.json
+++ b/spec/banking/credentials/card-debit.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://schema.eto.dev/banking/card-debit/v1",
-  "$comment": "FN-190 — JSON-LD VC template for a debit-card credential. Mirrors src/issuers/bank.ts:buildCardDebitVc and the keeper handler in keeper/bpps/bank/handlers/issue-card.ts. merchant_category_blocklist added in FN-103.",
+  "$comment": "FN-190 — JSON-LD VC template for a debit-card credential. Mirrors src/issuers/bank.ts:buildCardDebitVc and the keeper handler in keeper/bpps/bank/handlers/issue-card.ts. merchant_category_blocklist added in FN-103. FN-200 added the §10.3.1 `claimCommitments` block; example commitments computed via FN-082's eto-zk-cli (Poseidon-2 over BN254 Fr, t=3).",
   "title": "CardDebitCredential",
   "type": "object",
   "required": [
@@ -10,13 +10,16 @@
     "issuer",
     "issuanceDate",
     "credentialSubject",
-    "issuerAuthority"
+    "issuerAuthority",
+    "claimCommitments"
   ],
   "properties": {
     "@context": {
       "type": "array",
       "minItems": 2,
-      "items": { "type": "string" },
+      "items": {
+        "type": "string"
+      },
       "default": [
         "https://www.w3.org/2018/credentials/v1",
         "https://schema.eto.dev/banking/card-debit/v1"
@@ -24,9 +27,16 @@
     },
     "type": {
       "type": "array",
-      "items": { "type": "string" },
-      "contains": { "const": "VerifiableCredential" },
-      "default": ["VerifiableCredential", "CardDebitCredential"]
+      "items": {
+        "type": "string"
+      },
+      "contains": {
+        "const": "VerifiableCredential"
+      },
+      "default": [
+        "VerifiableCredential",
+        "CardDebitCredential"
+      ]
     },
     "issuer": {
       "type": "string",
@@ -92,10 +102,19 @@
           "minimum": 0
         },
         "network_brand": {
-          "enum": ["visa", "mastercard", "amex", "internal"]
+          "enum": [
+            "visa",
+            "mastercard",
+            "amex",
+            "internal"
+          ]
         },
         "tier": {
-          "enum": ["standard", "premium", "metal"]
+          "enum": [
+            "standard",
+            "premium",
+            "metal"
+          ]
         },
         "merchant_category_blocklist": {
           "type": "array",
@@ -115,6 +134,126 @@
     "claim_hash": {
       "type": "string",
       "pattern": "^[0-9a-fA-F]{64}$"
+    },
+    "claimCommitments": {
+      "type": "array",
+      "description": "Per-attribute Poseidon-2 commitments over every leaf field of credentialSubject, per spec/SINGULARITY-LAYER-1.md §10.3.1. Issuers MUST emit one entry for every leaf field (sorted lexicographically by fieldPath) before computing claim_hash. Required by FN-077 (selective-disclosure ZK proofs); produced by FN-082's `eto-zk-cli commit`.",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "required": [
+          "fieldPath",
+          "idx",
+          "commitment",
+          "saltCommitment"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "fieldPath": {
+            "type": "string",
+            "description": "Dot-separated JSON path from the VC root, e.g. 'credentialSubject.account_pda'. Leaf fields only.",
+            "pattern": "^credentialSubject\\."
+          },
+          "idx": {
+            "type": "integer",
+            "minimum": 0,
+            "description": "Zero-based position of this fieldPath in the lexicographically sorted leaf-path list. MUST equal the field_index public input (slot 6) when constructing a verify_credential_predicate proof for this attribute."
+          },
+          "commitment": {
+            "type": "string",
+            "pattern": "^[0-9a-fA-F]{64}$",
+            "description": "Poseidon2_t3([value_field, salt_field, idx_field])[0] — 32-byte little-endian hex."
+          },
+          "saltCommitment": {
+            "type": "string",
+            "pattern": "^[0-9a-fA-F]{64}$",
+            "description": "Poseidon2_t3([salt_field, Fr::ZERO, idx_field])[0] — 32-byte little-endian hex. Pins the salt domain without revealing salt."
+          }
+        }
+      }
     }
-  }
+  },
+  "examples": [
+    {
+      "@context": [
+        "https://www.w3.org/2018/credentials/v1",
+        "https://schema.eto.dev/banking/card-debit/v1"
+      ],
+      "type": [
+        "VerifiableCredential",
+        "CardDebitCredential"
+      ],
+      "issuer": "did:eto:bank:eto-reference",
+      "issuanceDate": "2026-04-30T00:00:00.000Z",
+      "credentialSubject": {
+        "id": "did:eto:agentcard:0000000000000000000000000000000000000000000000000000000000000003",
+        "card_id_hash": "0102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f20",
+        "holder": "deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef",
+        "linked_account_pda": "cafef00dcafef00dcafef00dcafef00dcafef00dcafef00dcafef00dcafef00d",
+        "jurisdiction": "us",
+        "issued_slot": 1234567,
+        "spending_limit_per_day": 5000000000,
+        "network_brand": "visa",
+        "tier": "standard"
+      },
+      "issuerAuthority": "abadcafeabadcafeabadcafeabadcafeabadcafeabadcafeabadcafeabadcafe",
+      "claimCommitments": [
+        {
+          "fieldPath": "credentialSubject.card_id_hash",
+          "idx": 0,
+          "commitment": "194c662cdb5795d888b08bf78f3d869d2bee7cb18056f6249c213ffbe036ff27",
+          "saltCommitment": "83efd9326266a623972b58129f336b6b83e82bf7129809e77a4022e7a7ef182d"
+        },
+        {
+          "fieldPath": "credentialSubject.holder",
+          "idx": 1,
+          "commitment": "4f6e0eb51cfee7436684047bb38b0d77e3333ff274bafb7c3d3f7761f71e0b2a",
+          "saltCommitment": "3906158ac1901abfefcffca6983c7b1ee09e7333610089e18121caa6bf52042d"
+        },
+        {
+          "fieldPath": "credentialSubject.id",
+          "idx": 2,
+          "commitment": "d976cb709811f2598bd716a8611ee0b1b38778015d37ff4bc35c3877aff12406",
+          "saltCommitment": "95ea817fce300c0defec532f119e5dc7981372ec960a889f8d0dfb76e5c9cb2e"
+        },
+        {
+          "fieldPath": "credentialSubject.issued_slot",
+          "idx": 3,
+          "commitment": "4b2631566796dce9280f9d0295b3a4a557a8aa262b0301aa8d20d937cbfe262c",
+          "saltCommitment": "38daf6c319b49a993138388bd3263a4ef099212c914cf0ae2f96fadb928b4c24"
+        },
+        {
+          "fieldPath": "credentialSubject.jurisdiction",
+          "idx": 4,
+          "commitment": "75f047a5f17d40c12ff4fc4ef8bec90ab2ce4946b5f5650b5453b3e55b9aab14",
+          "saltCommitment": "2ea0a3aad16daf93ea5d3414010b7d5308a0777c8e0e66e2ee2484b60247bd0e"
+        },
+        {
+          "fieldPath": "credentialSubject.linked_account_pda",
+          "idx": 5,
+          "commitment": "2bf780be5472f7d092289e3f26ccad7726f8d041c085b550a0b78be72265af21",
+          "saltCommitment": "b6b6b21969b663f348bd48aef998835d2f9abd2d1ecf7ba7d404b08b8f964823"
+        },
+        {
+          "fieldPath": "credentialSubject.network_brand",
+          "idx": 6,
+          "commitment": "0c0edb87435a2955301fd66698e5b68302d8ed5cb93ce334f220c1ecb5453816",
+          "saltCommitment": "a45c6791a9e5ca35b4efaa0a69b751cf4d3a2314c300d5bd7a2771203b3ceb2f"
+        },
+        {
+          "fieldPath": "credentialSubject.spending_limit_per_day",
+          "idx": 7,
+          "commitment": "085a1e062a7124bd2c2731d4dd047c0132649d8eaec17c1d854e4fdc03f1221d",
+          "saltCommitment": "7d1b401729f3b2d3a0a129f21dd682e87dbee4c3ba3326232ce0057db6ceaf04"
+        },
+        {
+          "fieldPath": "credentialSubject.tier",
+          "idx": 8,
+          "commitment": "294e9e5640f330a90ee8f858cd785bd423406586b415113f2192abb258378d11",
+          "saltCommitment": "879a15ec39a9dc6061adfa7ee007a54df0d9be78b910278629cec9a5b2cd2d08"
+        }
+      ],
+      "claim_hash": "0badc0de0badc0de0badc0de0badc0de0badc0de0badc0de0badc0de0badc0de"
+    }
+  ]
 }

--- a/spec/banking/credentials/tax-1099.json
+++ b/spec/banking/credentials/tax-1099.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://schema.eto.dev/banking/tax-1099/v1",
-  "$comment": "FN-190 — JSON-LD VC template for an annual 1099 tax credential. No runtime emitter yet (lands with FN-3.13.1.x); this template establishes the field shape so the eventual issuer mirrors it.",
+  "$comment": "FN-190 — JSON-LD VC template for an annual 1099 tax credential. No runtime emitter yet (lands with FN-3.13.1.x); this template establishes the field shape so the eventual issuer mirrors it. FN-200 added the §10.3.1 `claimCommitments` block; example commitments computed via FN-082's eto-zk-cli (Poseidon-2 over BN254 Fr, t=3).",
   "title": "Tax1099Credential",
   "type": "object",
   "required": [
@@ -10,13 +10,16 @@
     "issuer",
     "issuanceDate",
     "credentialSubject",
-    "issuerAuthority"
+    "issuerAuthority",
+    "claimCommitments"
   ],
   "properties": {
     "@context": {
       "type": "array",
       "minItems": 2,
-      "items": { "type": "string" },
+      "items": {
+        "type": "string"
+      },
       "default": [
         "https://www.w3.org/2018/credentials/v1",
         "https://schema.eto.dev/banking/tax-1099/v1"
@@ -24,9 +27,16 @@
     },
     "type": {
       "type": "array",
-      "items": { "type": "string" },
-      "contains": { "const": "VerifiableCredential" },
-      "default": ["VerifiableCredential", "Tax1099Credential"]
+      "items": {
+        "type": "string"
+      },
+      "contains": {
+        "const": "VerifiableCredential"
+      },
+      "default": [
+        "VerifiableCredential",
+        "Tax1099Credential"
+      ]
     },
     "issuer": {
       "type": "string",
@@ -73,7 +83,9 @@
           "minimum": 0,
           "description": "Federal withholding (if any). Atomic eUSD. Box 4 equivalent."
         },
-        "currency": { "const": "eUSD" },
+        "currency": {
+          "const": "eUSD"
+        },
         "linked_account_pdas": {
           "type": "array",
           "items": {
@@ -96,6 +108,105 @@
     "claim_hash": {
       "type": "string",
       "pattern": "^[0-9a-fA-F]{64}$"
+    },
+    "claimCommitments": {
+      "type": "array",
+      "description": "Per-attribute Poseidon-2 commitments over every leaf field of credentialSubject, per spec/SINGULARITY-LAYER-1.md §10.3.1. Issuers MUST emit one entry for every leaf field (sorted lexicographically by fieldPath) before computing claim_hash. Required by FN-077 (selective-disclosure ZK proofs); produced by FN-082's `eto-zk-cli commit`.",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "required": [
+          "fieldPath",
+          "idx",
+          "commitment",
+          "saltCommitment"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "fieldPath": {
+            "type": "string",
+            "description": "Dot-separated JSON path from the VC root, e.g. 'credentialSubject.account_pda'. Leaf fields only.",
+            "pattern": "^credentialSubject\\."
+          },
+          "idx": {
+            "type": "integer",
+            "minimum": 0,
+            "description": "Zero-based position of this fieldPath in the lexicographically sorted leaf-path list. MUST equal the field_index public input (slot 6) when constructing a verify_credential_predicate proof for this attribute."
+          },
+          "commitment": {
+            "type": "string",
+            "pattern": "^[0-9a-fA-F]{64}$",
+            "description": "Poseidon2_t3([value_field, salt_field, idx_field])[0] — 32-byte little-endian hex."
+          },
+          "saltCommitment": {
+            "type": "string",
+            "pattern": "^[0-9a-fA-F]{64}$",
+            "description": "Poseidon2_t3([salt_field, Fr::ZERO, idx_field])[0] — 32-byte little-endian hex. Pins the salt domain without revealing salt."
+          }
+        }
+      }
     }
-  }
+  },
+  "examples": [
+    {
+      "@context": [
+        "https://www.w3.org/2018/credentials/v1",
+        "https://schema.eto.dev/banking/tax-1099/v1"
+      ],
+      "type": [
+        "VerifiableCredential",
+        "Tax1099Credential"
+      ],
+      "issuer": "did:eto:bank:eto-reference",
+      "issuanceDate": "2027-01-31T00:00:00.000Z",
+      "credentialSubject": {
+        "id": "did:eto:agentcard:0000000000000000000000000000000000000000000000000000000000000004",
+        "year": 2026,
+        "interest_income_atomic": 123456789,
+        "fees_atomic": 4200,
+        "withholding_atomic": 0,
+        "currency": "eUSD"
+      },
+      "issuerAuthority": "abadcafeabadcafeabadcafeabadcafeabadcafeabadcafeabadcafeabadcafe",
+      "claimCommitments": [
+        {
+          "fieldPath": "credentialSubject.currency",
+          "idx": 0,
+          "commitment": "3d5547d31a988c48ed086f1bf24ad19e94111177fe6d2cb0f722e7179a4f7c07",
+          "saltCommitment": "83efd9326266a623972b58129f336b6b83e82bf7129809e77a4022e7a7ef182d"
+        },
+        {
+          "fieldPath": "credentialSubject.fees_atomic",
+          "idx": 1,
+          "commitment": "ab217409d3393623d6fb452a3b254e7edaa18034f632042befb44614a446fb14",
+          "saltCommitment": "3906158ac1901abfefcffca6983c7b1ee09e7333610089e18121caa6bf52042d"
+        },
+        {
+          "fieldPath": "credentialSubject.id",
+          "idx": 2,
+          "commitment": "d976cb709811f2598bd716a8611ee0b1b38778015d37ff4bc35c3877aff12406",
+          "saltCommitment": "95ea817fce300c0defec532f119e5dc7981372ec960a889f8d0dfb76e5c9cb2e"
+        },
+        {
+          "fieldPath": "credentialSubject.interest_income_atomic",
+          "idx": 3,
+          "commitment": "cf962070df9ac9cd4d3cebc6902ed06f7fa247de4e39dde3005b8541dc6b0030",
+          "saltCommitment": "38daf6c319b49a993138388bd3263a4ef099212c914cf0ae2f96fadb928b4c24"
+        },
+        {
+          "fieldPath": "credentialSubject.withholding_atomic",
+          "idx": 4,
+          "commitment": "846bd5d0792e238e3df966dcf7ad82aafb3de5e34461d0141c350e59b79e801f",
+          "saltCommitment": "2ea0a3aad16daf93ea5d3414010b7d5308a0777c8e0e66e2ee2484b60247bd0e"
+        },
+        {
+          "fieldPath": "credentialSubject.year",
+          "idx": 5,
+          "commitment": "c03b129740b53c481e3e3f318195f3a25a37e3d980708f0a33e5528a4cef9921",
+          "saltCommitment": "b6b6b21969b663f348bd48aef998835d2f9abd2d1ecf7ba7d404b08b8f964823"
+        }
+      ],
+      "claim_hash": "0badc0de0badc0de0badc0de0badc0de0badc0de0badc0de0badc0de0badc0de"
+    }
+  ]
 }

--- a/spec/memo-schemas/README.md
+++ b/spec/memo-schemas/README.md
@@ -1,0 +1,19 @@
+# Memo schema examples
+
+Example JSON Schema (Draft 2020-12) files for the v1 memo schemas registered
+in [`docs/memo-schema-registry.md`](../../docs/memo-schema-registry.md).
+
+Each file validates the **payload** portion of a memo envelope; the envelope
+shape itself (`type`, `schema`, `v`, `ts`, `payload`) is described in §2 of the
+registry document and will be implemented as a separate shared schema by the
+runtime follow-up task.
+
+| File                          | Label                            | Description                                                          |
+|-------------------------------|----------------------------------|----------------------------------------------------------------------|
+| `eval_score.v1.json`          | `eto.memo.eval_score.v1`         | Score one agent against a named metric (LLM-judge, oracle).          |
+| `payment.v1.json`             | `eto.memo.payment.v1`            | Structured payment metadata (purpose, invoice id, optional task ref).|
+| `coordination_log.v1.json`    | `eto.memo.coordination_log.v1`   | A2A coordination lifecycle event (offered/accepted/completed/…).     |
+
+See [`docs/memo-schema-registry.md`](../../docs/memo-schema-registry.md) for
+naming conventions, validation rules, versioning policy, and the procedure for
+adding new schemas.

--- a/spec/memo-schemas/coordination_log.v1.json
+++ b/spec/memo-schemas/coordination_log.v1.json
@@ -1,0 +1,40 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://eto.fdn/spec/memo-schemas/coordination_log.v1.json",
+  "title": "eto.memo.coordination_log.v1",
+  "description": "Payload schema for an A2A coordination log memo. Validates the `payload` portion of an eto.memo.coordination_log.v1 envelope; envelope shape is defined in docs/memo-schema-registry.md §2.",
+  "type": "object",
+  "required": ["event", "task_id", "actor"],
+  "additionalProperties": false,
+  "properties": {
+    "event": {
+      "type": "string",
+      "enum": ["task_offered", "task_accepted", "task_completed", "task_cancelled"],
+      "description": "Lifecycle event type."
+    },
+    "task_id": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 128,
+      "description": "Stable identifier of the coordinated task."
+    },
+    "actor": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 128,
+      "description": "Agent emitting the event (DID or address)."
+    },
+    "peer": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 128,
+      "description": "Optional counterparty agent."
+    },
+    "parent_event": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 128,
+      "description": "Optional reference to a prior coordination_log event (e.g. tx signature or content digest) that this event responds to."
+    }
+  }
+}

--- a/spec/memo-schemas/eval_score.v1.json
+++ b/spec/memo-schemas/eval_score.v1.json
@@ -1,0 +1,46 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://eto.fdn/spec/memo-schemas/eval_score.v1.json",
+  "title": "eto.memo.eval_score.v1",
+  "description": "Payload schema for an evaluation score memo: one agent or oracle scoring a subject against a named metric. Validates the `payload` portion of an eto.memo.eval_score.v1 envelope; envelope shape is defined in docs/memo-schema-registry.md §2.",
+  "type": "object",
+  "required": ["subject", "metric", "score", "evaluator"],
+  "additionalProperties": false,
+  "properties": {
+    "subject": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 128,
+      "description": "Agent under evaluation. Either a DID (e.g. did:eto:...) or an SVM/EVM address."
+    },
+    "metric": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 64,
+      "description": "Short metric identifier, e.g. 'helpfulness', 'latency_p95', 'task_success'."
+    },
+    "score": {
+      "type": "number",
+      "minimum": 0,
+      "maximum": 1,
+      "description": "Normalized score in [0, 1]. Producers are responsible for any per-metric scaling."
+    },
+    "evaluator": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 128,
+      "description": "Identity of the evaluator (DID or address)."
+    },
+    "evidence_uri": {
+      "type": "string",
+      "format": "uri",
+      "maxLength": 256,
+      "description": "Optional pointer to off-chain evidence (logs, transcripts) for records that exceed the on-chain memo size budget."
+    },
+    "notes": {
+      "type": "string",
+      "maxLength": 280,
+      "description": "Optional free-form note (≤ 280 chars)."
+    }
+  }
+}

--- a/spec/memo-schemas/payment.v1.json
+++ b/spec/memo-schemas/payment.v1.json
@@ -1,0 +1,38 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://eto.fdn/spec/memo-schemas/payment.v1.json",
+  "title": "eto.memo.payment.v1",
+  "description": "Payload schema for a structured payment memo. Validates the `payload` portion of an eto.memo.payment.v1 envelope; envelope shape is defined in docs/memo-schema-registry.md §2.",
+  "type": "object",
+  "required": ["purpose", "invoice_id"],
+  "additionalProperties": false,
+  "properties": {
+    "purpose": {
+      "type": "string",
+      "enum": ["service", "escrow", "refund", "tip"],
+      "description": "What this payment is for."
+    },
+    "invoice_id": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 128,
+      "description": "Producer-issued invoice identifier; unique per producer."
+    },
+    "task_id": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 128,
+      "description": "Optional reference to a coordination_log task this payment fulfills."
+    },
+    "unit_price_lamports": {
+      "type": "integer",
+      "minimum": 0,
+      "description": "Optional per-unit price in lamports."
+    },
+    "quantity": {
+      "type": "integer",
+      "minimum": 1,
+      "description": "Optional unit count; total = unit_price_lamports * quantity."
+    }
+  }
+}

--- a/src/crypto/poseidon2.ts
+++ b/src/crypto/poseidon2.ts
@@ -84,7 +84,7 @@ function sbox(x: bigint): bigint {
 function fromLeBytesModOrder(bytes: Uint8Array): bigint {
   let val = 0n;
   for (let i = 0; i < bytes.length; i++) {
-    val |= BigInt(bytes[i]) << BigInt(8 * i);
+    val |= BigInt(bytes[i]!) << BigInt(8 * i);
   }
   return val % P;
 }
@@ -96,7 +96,7 @@ function fromLeBytesModOrder(bytes: Uint8Array): bigint {
 function fromBeBytesModOrder(bytes: Uint8Array): bigint {
   let val = 0n;
   for (let i = 0; i < bytes.length; i++) {
-    val = (val << 8n) | BigInt(bytes[i]);
+    val = (val << 8n) | BigInt(bytes[i]!);
   }
   return val % P;
 }
@@ -118,7 +118,7 @@ function fromBeBytesModOrder(bytes: Uint8Array): bigint {
  * State bit layout after initialization (before warm-up):
  *   [0]     = 0
  *   [1]     = 1   (prime field indicator)
- *   [2..5]  = S-box bits (state[5]=1 iff inverse S-box; else all 0)
+ *   [2..5]  = S-box bits (state[5] =1 iff inverse S-box; else all 0)
  *   [6..17] = n (prime_num_bits) in 12 bits, LSB at index 17
  *   [18..29]= t (state_len) in 12 bits, LSB at index 29
  *   [30..39]= R_F in 10 bits, LSB at index 39
@@ -207,12 +207,12 @@ class GrainLFSR {
   private _update(): number {
     const h = this.head;
     const newBit =
-      this.state[h] ^
-      this.state[(h + 13) % 80] ^
-      this.state[(h + 23) % 80] ^
-      this.state[(h + 38) % 80] ^
-      this.state[(h + 51) % 80] ^
-      this.state[(h + 62) % 80];
+      this.state[h]! ^
+      this.state[(h + 13) % 80]! ^
+      this.state[(h + 23) % 80]! ^
+      this.state[(h + 38) % 80]! ^
+      this.state[(h + 51) % 80]! ^
+      this.state[(h + 62) % 80]!;
     this.state[h] = newBit;
     this.head = (h + 1) % 80;
     return newBit;
@@ -260,10 +260,10 @@ class GrainLFSR {
     while (res.length < numElems) {
       const bits = this.getBits(this.primeNumBits);
       bits.reverse(); // match arkworks bits.reverse() before from_bits_le
-      // from_bits_le semantics: bits[0] is coefficient of 2^0 (LSB)
+      // from_bits_le semantics: bits[0]! is coefficient of 2^0 (LSB)
       let val = 0n;
       for (let i = 0; i < bits.length; i++) {
-        if (bits[i]) val |= 1n << BigInt(i);
+        if (bits[i]!!) val |= 1n << BigInt(i);
       }
       if (val < P) {
         res.push(val);
@@ -290,11 +290,11 @@ class GrainLFSR {
     for (let k = 0; k < numElems; k++) {
       const bits = this.getBits(this.primeNumBits);
       bits.reverse(); // MSB-first (matches arkworks)
-      // Pack into bytes: bits[i] → byte[i>>3] bit (i&7)
+      // Pack into bytes: bits[i]! → byte[i>>3] bit (i&7)
       const bytes = new Uint8Array(Math.ceil(this.primeNumBits / 8));
       for (let i = 0; i < bits.length; i++) {
-        if (bits[i]) {
-          bytes[i >> 3] |= 1 << (i & 7);
+        if (bits[i]!) {
+          bytes[i >> 3]! |= 1 << (i & 7);
         }
       }
       res.push(fromLeBytesModOrder(bytes));
@@ -346,12 +346,12 @@ function buildParams(): PoseidonParams {
   const xs = lfsr.getFieldElementsModP(T);
   const ys = lfsr.getFieldElementsModP(T);
 
-  // Cauchy matrix: mds[i][j] = (xs[i] + ys[j])^{-1}
+  // Cauchy matrix: mds[i][j] = (xs[i]! + ys[j]!)^{-1}
   const mds: bigint[][] = [];
   for (let i = 0; i < T; i++) {
     const row: bigint[] = [];
     for (let j = 0; j < T; j++) {
-      const sum = addMod(xs[i], ys[j]);
+      const sum = addMod(xs[i]!!, ys[j]!!);
       row.push(modInv(sum));
     }
     mds.push(row);
@@ -379,11 +379,11 @@ function getParams(): PoseidonParams {
  *
  * Round structure (matches `PoseidonSponge::permute` in arkworks 0.5.0):
  *   - 4 full rounds  (all 3 elements get S-box)
- *   - 56 partial rounds (only state[0] gets S-box)
+ *   - 56 partial rounds (only state[0]! gets S-box)
  *   - 4 full rounds
  *
  * The permutation acts on ALL t=3 state elements including the capacity
- * element at state[0].
+ * element at state[0]!.
  */
 function poseidonPermute(state: bigint[]): void {
   const { ark, mds } = getParams();
@@ -396,39 +396,39 @@ function poseidonPermute(state: bigint[]): void {
   // First half: full rounds
   for (let r = 0; r < FULL_HALF; r++, roundIdx++) {
     // ARK
-    for (let j = 0; j < T; j++) state[j] = addMod(state[j], ark[roundIdx][j]);
+    for (let j = 0; j < T; j++) state[j] = addMod(state[j]!, ark[roundIdx]![j]!);
     // S-box (all elements)
-    for (let j = 0; j < T; j++) state[j] = sbox(state[j]);
-    // MDS: new_state[i] = sum_j mds[i][j] * state[j]
-    const tmp0 = addMod(addMod(mulMod(mds[0][0], state[0]), mulMod(mds[0][1], state[1])), mulMod(mds[0][2], state[2]));
-    const tmp1 = addMod(addMod(mulMod(mds[1][0], state[0]), mulMod(mds[1][1], state[1])), mulMod(mds[1][2], state[2]));
-    const tmp2 = addMod(addMod(mulMod(mds[2][0], state[0]), mulMod(mds[2][1], state[1])), mulMod(mds[2][2], state[2]));
+    for (let j = 0; j < T; j++) state[j] = sbox(state[j]!);
+    // MDS: new_state[i] = sum_j mds[i][j] * state[j]!
+    const tmp0 = addMod(addMod(mulMod(mds[0]![0]!, state[0]!), mulMod(mds[0]![1]!, state[1]!)), mulMod(mds[0]![2]!, state[2]!));
+    const tmp1 = addMod(addMod(mulMod(mds[1]![0]!, state[0]!), mulMod(mds[1]![1]!, state[1]!)), mulMod(mds[1]![2]!, state[2]!));
+    const tmp2 = addMod(addMod(mulMod(mds[2]![0]!, state[0]!), mulMod(mds[2]![1]!, state[1]!)), mulMod(mds[2]![2]!, state[2]!));
     state[0] = tmp0; state[1] = tmp1; state[2] = tmp2;
   }
 
   // Partial rounds
   for (let r = 0; r < PARTIAL; r++, roundIdx++) {
     // ARK
-    for (let j = 0; j < T; j++) state[j] = addMod(state[j], ark[roundIdx][j]);
+    for (let j = 0; j < T; j++) state[j] = addMod(state[j]!, ark[roundIdx]![j]!);
     // S-box (first element only)
-    state[0] = sbox(state[0]);
+    state[0] = sbox(state[0]!);
     // MDS
-    const tmp0 = addMod(addMod(mulMod(mds[0][0], state[0]), mulMod(mds[0][1], state[1])), mulMod(mds[0][2], state[2]));
-    const tmp1 = addMod(addMod(mulMod(mds[1][0], state[0]), mulMod(mds[1][1], state[1])), mulMod(mds[1][2], state[2]));
-    const tmp2 = addMod(addMod(mulMod(mds[2][0], state[0]), mulMod(mds[2][1], state[1])), mulMod(mds[2][2], state[2]));
+    const tmp0 = addMod(addMod(mulMod(mds[0]![0]!, state[0]!), mulMod(mds[0]![1]!, state[1]!)), mulMod(mds[0]![2]!, state[2]!));
+    const tmp1 = addMod(addMod(mulMod(mds[1]![0]!, state[0]!), mulMod(mds[1]![1]!, state[1]!)), mulMod(mds[1]![2]!, state[2]!));
+    const tmp2 = addMod(addMod(mulMod(mds[2]![0]!, state[0]!), mulMod(mds[2]![1]!, state[1]!)), mulMod(mds[2]![2]!, state[2]!));
     state[0] = tmp0; state[1] = tmp1; state[2] = tmp2;
   }
 
   // Second half: full rounds
   for (let r = 0; r < FULL_HALF; r++, roundIdx++) {
     // ARK
-    for (let j = 0; j < T; j++) state[j] = addMod(state[j], ark[roundIdx][j]);
+    for (let j = 0; j < T; j++) state[j] = addMod(state[j]!, ark[roundIdx]![j]!);
     // S-box (all elements)
-    for (let j = 0; j < T; j++) state[j] = sbox(state[j]);
+    for (let j = 0; j < T; j++) state[j] = sbox(state[j]!);
     // MDS
-    const tmp0 = addMod(addMod(mulMod(mds[0][0], state[0]), mulMod(mds[0][1], state[1])), mulMod(mds[0][2], state[2]));
-    const tmp1 = addMod(addMod(mulMod(mds[1][0], state[0]), mulMod(mds[1][1], state[1])), mulMod(mds[1][2], state[2]));
-    const tmp2 = addMod(addMod(mulMod(mds[2][0], state[0]), mulMod(mds[2][1], state[1])), mulMod(mds[2][2], state[2]));
+    const tmp0 = addMod(addMod(mulMod(mds[0]![0]!, state[0]!), mulMod(mds[0]![1]!, state[1]!)), mulMod(mds[0]![2]!, state[2]!));
+    const tmp1 = addMod(addMod(mulMod(mds[1]![0]!, state[0]!), mulMod(mds[1]![1]!, state[1]!)), mulMod(mds[1]![2]!, state[2]!));
+    const tmp2 = addMod(addMod(mulMod(mds[2]![0]!, state[0]!), mulMod(mds[2]![1]!, state[1]!)), mulMod(mds[2]![2]!, state[2]!));
     state[0] = tmp0; state[1] = tmp1; state[2] = tmp2;
   }
 }
@@ -443,15 +443,15 @@ function poseidonPermute(state: bigint[]): void {
  * Absorbs three field elements and returns the first squeezed element.
  * Matches `hash_t3` in `crates/eto-zk/src/poseidon.rs`.
  *
- * State layout: [capacity(state[0]), rate_0(state[1]), rate_1(state[2])]
+ * State layout: [capacity(state[0]!), rate_0(state[1]!), rate_1(state[2]!)]
  *
  * Sponge construction (rate=2, capacity=1):
  *  1. state = [0, 0, 0]
- *  2. state[1] += inputs[0]; state[2] += inputs[1]  (absorb to rate portion)
+ *  2. state[1]! += inputs[0]!; state[2]! += inputs[1]!  (absorb to rate portion)
  *  3. Permute                                         (rate full)
- *  4. state[1] += inputs[2]                          (absorb remainder)
+ *  4. state[1]! += inputs[2]!                          (absorb remainder)
  *  5. Permute                                         (before squeeze)
- *  6. return state[1]                                 (first rate element)
+ *  6. return state[1]!                                 (first rate element)
  *
  * @param inputs Three BN254 Fr field elements (bigints in [0, P)).
  * @returns First output field element of the sponge.
@@ -461,23 +461,23 @@ export function poseidon2(inputs: [bigint, bigint, bigint]): bigint {
     if (x < 0n || x >= P) throw new RangeError(`poseidon2: input out of range: ${x}`);
   }
 
-  // State layout: [capacity=state[0], rate_0=state[1], rate_1=state[2]]
+  // State layout: [capacity=state[0]!, rate_0=state[1]!, rate_1=state[2]!]
   const state: bigint[] = [0n, 0n, 0n];
 
   // Absorb rate elements: state[capacity + i] += inputs[i]
-  // capacity=1, so state[1] and state[2] are the rate portion
-  state[1] = addMod(state[1], inputs[0]); // state[capacity + 0]
-  state[2] = addMod(state[2], inputs[1]); // state[capacity + 1]
+  // capacity=1, so state[1]! and state[2]! are the rate portion
+  state[1] = addMod(state[1]!, inputs[0]!); // state[capacity + 0]
+  state[2] = addMod(state[2]!, inputs[1]!); // state[capacity + 1]
   // Rate is now full → permute
   poseidonPermute(state);
 
   // Absorb remaining input
-  state[1] = addMod(state[1], inputs[2]); // state[capacity + 0]
+  state[1] = addMod(state[1]!, inputs[2]!); // state[capacity + 0]
 
-  // Squeeze: permute, then return state[capacity + 0] = state[1]
+  // Squeeze: permute, then return state[capacity + 0] = state[1]!
   poseidonPermute(state);
 
-  return state[1];
+  return state[1]!;
 }
 
 // ---------------------------------------------------------------------------

--- a/src/gateway/beckn.ts
+++ b/src/gateway/beckn.ts
@@ -16,7 +16,12 @@
  *    larger app; `createBecknApp()` returns a self-contained Express app
  *    that tests and the conformance suite (FN-092) can boot directly.
  */
-import express, { type Request, type Response, type Router } from "express";
+import express, {
+  type NextFunction,
+  type Request,
+  type Response,
+  type Router,
+} from "express";
 import { z } from "zod";
 
 // ---------- Beckn envelope types ----------
@@ -160,6 +165,53 @@ function makeHandler(expected: BecknAction) {
   };
 }
 
+// ---------- Error middleware ----------
+
+/**
+ * Express error-handling middleware that maps body-parser
+ * `PayloadTooLargeError` (the 413 thrown when a request body exceeds the
+ * per-route `express.json({ limit: "1mb" })` cap) into the canonical Beckn
+ * NACK envelope. Without this, Express's default error handler responds
+ * with its built-in HTML/plain-text 413 body, which deviates from the
+ * `{message:{ack:{status:"NACK"}}, error:{code,message}}` shape every
+ * other failure path on this router returns.
+ *
+ * Detection is deliberately broad — body-parser versions vary on which
+ * field they set (`err.type === "entity.too.large"`, `err.statusCode`,
+ * `err.status`, or `err.name === "PayloadTooLargeError"`) — so we match
+ * any of them. Unrelated errors are forwarded via `next(err)` so Express's
+ * default handler still applies.
+ */
+export function becknPayloadTooLargeMiddleware(
+  err: unknown,
+  _req: Request,
+  res: Response,
+  next: NextFunction,
+): void {
+  const e = err as {
+    type?: string;
+    status?: number;
+    statusCode?: number;
+    name?: string;
+  } | null;
+  const isOversized =
+    !!e &&
+    (e.type === "entity.too.large" ||
+      e.statusCode === 413 ||
+      e.status === 413 ||
+      (err instanceof Error && err.name === "PayloadTooLargeError"));
+  if (!isOversized) {
+    next(err);
+    return;
+  }
+  const { status, body } = becknError(
+    "PAYLOAD_TOO_LARGE",
+    "Request body exceeds 1 MiB limit",
+    413,
+  );
+  res.status(status).json(body);
+}
+
 // ---------- Router ----------
 
 /**
@@ -205,5 +257,9 @@ export function createBecknApp(): express.Express {
   });
 
   app.use(becknRouter);
+  // Global error handler for body-parser PayloadTooLargeError on any of the
+  // four action routes. Must be mounted AFTER `becknRouter` so it catches
+  // errors thrown by the per-route `express.json({ limit: "1mb" })` parser.
+  app.use(becknPayloadTooLargeMiddleware);
   return app;
 }

--- a/src/gateway/chain-client.ts
+++ b/src/gateway/chain-client.ts
@@ -1,0 +1,141 @@
+/**
+ * FN-091 — Beckn gateway chain client.
+ *
+ * Replaces the inline `stubSubmit` in `inbound-bap.ts` / `inbound-bpp.ts`
+ * with a swappable `ChainClient` so the bridge can submit real on-chain
+ * `BecknProgram::{Search,Select,Init,Confirm}` instructions when an
+ * `ETO_RPC_ENDPOINT` is configured.
+ *
+ * Default behaviour (no env): `StubChainClient` returns deterministic
+ * `stub-<hex>` signatures so existing tests stay green.
+ *
+ * v0 SvmChainClient: serializes the args as JSON and submits via
+ * `EtoRpcClient.sendTransaction`. Real Borsh-encoded instruction
+ * data lands in a follow-up (FN-091 §details "Real Borsh encoding").
+ * The wiring layer (this file + the dep injection) is what FN-091 asks
+ * for; the encoding is a downstream task that can land without
+ * touching the gateway again.
+ */
+import { createHash } from "node:crypto";
+import { rpc as defaultRpc, EtoRpcClient } from "../read/rpc-client.js";
+import type { BecknAction } from "./beckn.js";
+import { config } from "../config.js";
+
+export interface ChainSubmitResult {
+  tx_signature: string;
+  /** Slot at which the tx was accepted (best-effort; 0n for stub). */
+  submitted_at_slot?: bigint;
+}
+
+/**
+ * Chain action — narrow type for /search /select /init /confirm
+ * (Beckn-side) plus the BPP-side completion calls.
+ */
+export type ChainAction = BecknAction | "CompleteTask" | "FailTask";
+
+export interface ChainClient {
+  submit(action: ChainAction, args: unknown): Promise<ChainSubmitResult>;
+  submitSearch(args: unknown): Promise<ChainSubmitResult & { intent_pda?: string; deadline_slot?: bigint }>;
+  submitSelect(args: unknown): Promise<ChainSubmitResult>;
+  submitInit(args: unknown): Promise<ChainSubmitResult>;
+  submitConfirm(args: unknown): Promise<ChainSubmitResult>;
+}
+
+/* -------------------------------------------------------------------------- */
+/* StubChainClient — backward-compatible default                              */
+/* -------------------------------------------------------------------------- */
+
+/** Deterministic synthetic signature in the existing `stub-<hex>` shape. */
+function stubSig(action: ChainAction, args: unknown): string {
+  const h = createHash("sha256")
+    .update(action)
+    .update("|")
+    .update(JSON.stringify(args ?? {}))
+    .digest("hex")
+    .slice(0, 32);
+  return `stub-${h}`;
+}
+
+export class StubChainClient implements ChainClient {
+  async submit(action: ChainAction, args: unknown): Promise<ChainSubmitResult> {
+    return { tx_signature: stubSig(action, args), submitted_at_slot: 0n };
+  }
+  async submitSearch(args: unknown) {
+    const r = await this.submit("search", args);
+    // Stub-derived intent_pda for testability.
+    const intent_pda = createHash("sha256")
+      .update("intent_pda|stub|")
+      .update(JSON.stringify(args ?? {}))
+      .digest("hex");
+    return { ...r, intent_pda, deadline_slot: 0n };
+  }
+  submitSelect(args: unknown) { return this.submit("select", args); }
+  submitInit(args: unknown) { return this.submit("init", args); }
+  submitConfirm(args: unknown) { return this.submit("confirm", args); }
+}
+
+/* -------------------------------------------------------------------------- */
+/* SvmChainClient — real wiring (v0: JSON payload, real RPC)                  */
+/* -------------------------------------------------------------------------- */
+
+export interface SvmChainClientOpts {
+  /** Defaults to the module-level `rpc` singleton from src/read/rpc-client.ts. */
+  rpc?: EtoRpcClient;
+}
+
+export class SvmChainClient implements ChainClient {
+  private rpc: EtoRpcClient;
+  constructor(opts: SvmChainClientOpts = {}) {
+    this.rpc = opts.rpc ?? defaultRpc;
+  }
+
+  async submit(action: ChainAction, args: unknown): Promise<ChainSubmitResult> {
+    // v0 placeholder: serializes args as base64-encoded JSON instead of
+    // Borsh-encoded instruction data. The runtime currently accepts
+    // arbitrary opaque payloads on the BecknProgram entrypoint per the
+    // FN-050 instruction frame; real Borsh encoding is the next task to
+    // land on top of this wiring (see FN-091 follow-up note).
+    const payload = Buffer.from(JSON.stringify({ action, args }), "utf8").toString("base64");
+    const tx_signature = await this.rpc.sendTransaction(payload);
+    let submitted_at_slot: bigint | undefined;
+    try {
+      submitted_at_slot = BigInt(await this.rpc.getSlot());
+    } catch {
+      // best-effort
+    }
+    return { tx_signature, submitted_at_slot };
+  }
+
+  async submitSearch(args: unknown) {
+    const r = await this.submit("search", args);
+    // intent_pda + deadline_slot will be derived by the runtime; the
+    // bridge does not need to compute them here. Returned as undefined
+    // until FN-050 surfaces them in the tx receipt.
+    return r;
+  }
+  submitSelect(args: unknown) { return this.submit("select", args); }
+  submitInit(args: unknown) { return this.submit("init", args); }
+  submitConfirm(args: unknown) { return this.submit("confirm", args); }
+}
+
+/* -------------------------------------------------------------------------- */
+/* Factory                                                                    */
+/* -------------------------------------------------------------------------- */
+
+/**
+ * Returns SvmChainClient when `ETO_RPC_ENDPOINT` is set in the environment,
+ * else StubChainClient. Idempotent — safe to call from many places.
+ */
+export function createDefaultChainClient(): ChainClient {
+  const endpoint = process.env.ETO_RPC_ENDPOINT?.trim();
+  if (endpoint && endpoint.length > 0) {
+    return new SvmChainClient();
+  }
+  // Also honour config.etoRpcUrl when explicitly set to a non-localhost
+  // endpoint — covers production deployments that wire via config.
+  const url = config?.etoRpcUrl?.trim?.();
+  if (url && !/^https?:\/\/(127\.0\.0\.1|localhost)\b/.test(url)) {
+    return new SvmChainClient();
+  }
+  return new StubChainClient();
+}

--- a/src/gateway/inbound-bap.ts
+++ b/src/gateway/inbound-bap.ts
@@ -231,13 +231,40 @@ export function validateBecknEnvelopeFreshness(
 export type { BecknAction };
 
 export interface InboundBapDeps {
-  /** Submit an on-chain Beckn instruction. STUBBED today. */
-  submitOnChain: (action: BecknAction, args: unknown) => Promise<{ tx_signature: string }>;
+  /**
+   * Submit an on-chain Beckn instruction. Optional — when omitted the
+   * deps default to the ambient `ChainClient` (FN-091): real
+   * `SvmChainClient` if `ETO_RPC_ENDPOINT` is set, otherwise the
+   * `StubChainClient` that returns deterministic `stub-<hex>` sigs.
+   *
+   * Existing callers that pass an explicit `submitOnChain` continue to
+   * work unchanged — preserves the dep-injection seam used by tests.
+   */
+  submitOnChain?: (action: BecknAction, args: unknown) => Promise<{ tx_signature: string }>;
+  /**
+   * FN-091: optional chain client. If neither this nor `submitOnChain`
+   * is provided, the bridge constructs one via `createDefaultChainClient()`.
+   */
+  chainClient?: import("./chain-client.js").ChainClient;
   /** Resolve catalog responses for a SearchIntent. STUBBED today. */
   pollCatalogResponses?: (intent_hash: string, max: number) => Promise<unknown[]>;
 }
 
 export function mountInboundBap(app: Express, deps: InboundBapDeps): void {
+  // FN-091: resolve effective submit function once at mount time.
+  // Priority: explicit submitOnChain (legacy / test override) > injected
+  // chainClient > ambient default (Stub or Svm depending on env).
+  const resolvedSubmit: (action: BecknAction, args: unknown) => Promise<{ tx_signature: string }> =
+    deps.submitOnChain ??
+    (async (action, args) => {
+      const cc = deps.chainClient ?? (await import("./chain-client.js")).createDefaultChainClient();
+      const r = await cc.submit(action, args);
+      return { tx_signature: r.tx_signature };
+    });
+  // Wrap deps so existing handler bodies keep using `deps.submitOnChain`
+  // without a code shape change.
+  deps = { ...deps, submitOnChain: resolvedSubmit };
+
   app.post("/search", async (req: Request, res: Response) => {
     const now = Date.now();
     const envResult = validateBecknEnvelope((req.body as Record<string, unknown> | undefined)?.context, now);

--- a/src/gateway/inbound-bpp.ts
+++ b/src/gateway/inbound-bpp.ts
@@ -28,8 +28,15 @@ export interface InboundBppDeps {
   resolveBppEndpoint: (bpp_pubkey: string) => string;
   /** POST a Beckn JSON body to a URL. */
   postBecknRequest: (url: string, body: object) => Promise<{ status: number; body: unknown }>;
-  /** Submit on-chain instruction. STUBBED today. */
-  submitOnChain: (action: 'CompleteTask' | 'FailTask', args: unknown) => Promise<{ tx_signature: string }>;
+  /**
+   * Submit on-chain instruction. Optional — when omitted, the deps default
+   * to the ambient ChainClient (FN-091): real `SvmChainClient` if
+   * `ETO_RPC_ENDPOINT` is set, otherwise `StubChainClient`. Existing
+   * callers that pass an explicit `submitOnChain` continue to work.
+   */
+  submitOnChain?: (action: 'CompleteTask' | 'FailTask', args: unknown) => Promise<{ tx_signature: string }>;
+  /** FN-091: optional chain client; falls back to createDefaultChainClient(). */
+  chainClient?: import("./chain-client.js").ChainClient;
   /** Look up off-chain order details by terms_hash. */
   loadOrderByTermsHash?: (terms_hash: string) => Promise<object | null>;
 }
@@ -62,6 +69,15 @@ export async function handleConfirmTrigger(trigger: ConfirmTrigger, deps: Inboun
 
 /** Mount the /on_confirm callback receiver on the bridge express app. */
 export function mountOnConfirmCallback(app: Express, deps: InboundBppDeps): void {
+  // FN-091: resolve effective submit function once at mount time.
+  const resolvedSubmit: NonNullable<InboundBppDeps['submitOnChain']> =
+    deps.submitOnChain ??
+    (async (action, args) => {
+      const cc = deps.chainClient ?? (await import('./chain-client.js')).createDefaultChainClient();
+      const r = await cc.submit(action, args);
+      return { tx_signature: r.tx_signature };
+    });
+
   app.post('/on_confirm', async (req: Request, res: Response) => {
     const v = validateBecknRequest('on_confirm', req.body);
     if (!v.ok) {
@@ -71,7 +87,7 @@ export function mountOnConfirmCallback(app: Express, deps: InboundBppDeps): void
       const order = req.body.message?.order;
       const success = order?.state === 'COMPLETED' || order?.state === 'FULFILLED';
       const args = becknOnConfirmToTaskOutcome(req.body);
-      const { tx_signature } = await deps.submitOnChain(success ? 'CompleteTask' : 'FailTask', args);
+      const { tx_signature } = await resolvedSubmit(success ? 'CompleteTask' : 'FailTask', args);
       res.status(200).json({ message: { ack: { status: 'ACK' } }, tx_signature });
     } catch (err) {
       res.status(500).json({ error: 'submission_failed', details: String(err) });

--- a/src/index.ts
+++ b/src/index.ts
@@ -220,3 +220,21 @@ export type {
   TravelRuleReportJsonLd,
 } from "./services/indexer/travel-rule.js";
 
+// VC signer for audit-trail / travel-rule documents (FN-084) —
+// `Ed25519Signature2020` proof blocks per W3C VC Data Integrity / RFC 8785.
+export {
+  DEFAULT_UNSIGNED_DID,
+  Ed25519VcSigner,
+  NoOpVcSigner,
+  base64UrlEncode,
+  canonicalizeJcs,
+  createVcSignerFromEnv,
+} from "./services/indexer/vc-signer.js";
+export type {
+  CreateVcSignerFromEnvOpts,
+  Ed25519Signature2020Proof,
+  Ed25519VcSignerFromKeyFileOpts,
+  Ed25519VcSignerInit,
+  VcSigner,
+} from "./services/indexer/vc-signer.js";
+

--- a/src/issuers/bank-mock.ts
+++ b/src/issuers/bank-mock.ts
@@ -31,6 +31,7 @@
 
 import { createHash } from "node:crypto";
 
+import { computeClaimCommitments } from "./claim-commitments.js";
 import {
   BankMockIssueError,
   BankMockIssueRequest,
@@ -138,12 +139,19 @@ export async function issueBankFiatRampTest(
   const slot = await deps.clock.currentSlot();
   const nowUnix = (deps.nowUnix ?? defaultNowUnix)();
 
-  const vc = buildBankFiatRampTestVc({
+  const baseVc = buildBankFiatRampTestVc({
     agentCardPubkey,
     issuerAuthorityPubkey: deps.issuerAuthorityPubkey,
     checkingAccountId,
     issuanceDate: new Date(nowUnix * 1000).toISOString(),
   });
+  // §10.3.1: per-leaf Poseidon-2 commitments embedded BEFORE
+  // canonicalisation so `claim_hash` binds them.
+  const claimCommitments = computeClaimCommitments(
+    baseVc.credentialSubject as Record<string, unknown>,
+    { randomBytes: deps.randomBytes },
+  );
+  const vc = { ...baseVc, claimCommitments };
   const claimJcs = jcsCanonicalize(vc);
   const claimHashHex = sha256Hex(claimJcs);
 

--- a/src/issuers/bank-mock.types.ts
+++ b/src/issuers/bank-mock.types.ts
@@ -106,6 +106,11 @@ export interface BankMockIssuerDeps {
   readonly issuerAuthorityPubkey: string;
   /** Wall-clock for VC `issuanceDate` and store row timestamps. */
   readonly nowUnix?: () => number;
+  /**
+   * Optional CSPRNG hook for `claimCommitments` salt generation
+   * (§10.3.1). Defaults to `globalThis.crypto.getRandomValues`.
+   */
+  readonly randomBytes?: (len: number) => Uint8Array;
 }
 
 export interface BankMockIssueRequest {

--- a/src/issuers/civic.ts
+++ b/src/issuers/civic.ts
@@ -33,6 +33,7 @@
 
 import { createHash, createPublicKey, verify as cryptoVerify } from "node:crypto";
 
+import { computeClaimCommitments } from "./claim-commitments.js";
 import type {
   AgentCardSignatureVerifier,
   ChainClient,
@@ -438,6 +439,7 @@ export class CivicIssuer {
   private readonly issuerAuthorityPubkey: string;
   private readonly logger: IssuerLogger;
   private readonly nowUnix: () => number;
+  private readonly randomBytes: ((len: number) => Uint8Array) | undefined;
 
   public constructor(deps: CivicIssuerDeps) {
     if (deps.config.civic.enabled === false) {
@@ -457,6 +459,7 @@ export class CivicIssuer {
     this.issuerAuthorityPubkey = deps.issuerAuthorityPubkey;
     this.logger = deps.logger ?? defaultLogger();
     this.nowUnix = deps.nowUnix ?? (() => Math.floor(Date.now() / 1000));
+    this.randomBytes = deps.randomBytes;
   }
 
   public async issue(req: CivicIssueRequest): Promise<CivicIssueResponse> {
@@ -527,15 +530,22 @@ export class CivicIssuer {
       expectedOwner: req.agentCardPubkey,
     });
 
-    // 6. Build VC, pin, hash.
+    // 6. Build VC, embed §10.3.1 claimCommitments, pin, hash.
     const issuanceDate = new Date(this.nowUnix() * 1000).toISOString();
-    const vc = buildVerifiedHumanVc({
+    const baseVc = buildVerifiedHumanVc({
       agentCardPubkey: req.agentCardPubkey,
       issuerAuthorityPubkey: this.issuerAuthorityPubkey,
       civicVerifyResult: verifyResult,
       civicNullifier,
       issuanceDate,
     });
+    const claimCommitments = computeClaimCommitments(
+      baseVc.credentialSubject as Record<string, unknown>,
+      { randomBytes: this.randomBytes },
+    );
+    const vc = { ...baseVc, claimCommitments } as VerifiedHumanVc & {
+      claimCommitments: typeof claimCommitments;
+    };
     const claimHash = this.claimHasher.hash(vc);
     const claimJcs = jcsCanonicalize(vc);
     const { uri: claimUri } = await this.ipfsPinner.pin(claimJcs);

--- a/src/issuers/civic.types.ts
+++ b/src/issuers/civic.types.ts
@@ -241,4 +241,9 @@ export interface CivicIssuerDeps {
   readonly issuerAuthorityPubkey: string;
   /** Wall-clock for VC `issuanceDate`. Defaults to `Date.now()`. */
   readonly nowUnix?: () => number;
+  /**
+   * Optional CSPRNG hook for `claimCommitments` salt generation
+   * (§10.3.1). Defaults to `globalThis.crypto.getRandomValues`.
+   */
+  readonly randomBytes?: (len: number) => Uint8Array;
 }

--- a/src/issuers/claim-commitments.ts
+++ b/src/issuers/claim-commitments.ts
@@ -1,0 +1,197 @@
+/**
+ * `claimCommitments` — per-leaf Poseidon-2 commitments embedded into every
+ * issuer VC body before computing `claim_hash` per
+ * `spec/SINGULARITY-LAYER-1.md` §10.3.1.
+ *
+ * # Contract (§10.3.1)
+ *
+ * Each entry binds one leaf of `credentialSubject` to:
+ *
+ * | Field              | Definition                                                                |
+ * |--------------------|---------------------------------------------------------------------------|
+ * | `fieldPath`        | Dot-separated leaf path, prefixed by `pathPrefix` (default `credentialSubject`). |
+ * | `idx`              | 0-based position in the **byte-stable** lex sort of `fieldPath`s.         |
+ * | `commitment`       | 32-byte LE lowercase hex (no `0x`) of `Poseidon2_t3([value, salt, idx])`. |
+ * | `saltCommitment`   | 32-byte LE lowercase hex (no `0x`) of `Poseidon2_t3([salt, 0, idx])`.     |
+ *
+ * `idx` MUST equal the `field_index` public input of
+ * `verify_credential_predicate`, so the lex-sort over leaf paths is the
+ * security-critical contract that lets selective-disclosure proofs match.
+ *
+ * # Encoding
+ *
+ * Value encoding is delegated to `encodeFr` (§10.3.1 type table: number /
+ * bigint, string with NFC + 31-byte truncation + length byte, bool, null).
+ * Salt encoding uses `encodeSalt` (LE → Fr) — never BE.
+ *
+ * Output hex serialization uses `bytesToHex32` which emits 32-byte LE
+ * lowercase hex with no `0x` prefix (matches arkworks
+ * `CanonicalSerialize::serialize_compressed` for BN254 Fr).
+ *
+ * # Array-leaf encoding (v0 caveat)
+ *
+ * §10.3.1's encoding table does not enumerate arrays. As a v0 convention
+ * (pending §10.3.1 clarification), array leaves are encoded via
+ * `encodeFr(JSON.stringify(arrayValue))` — i.e. the string path with NFC +
+ * 31-byte truncation + length byte. This means two arrays whose
+ * stringifications truncate to the same 31-byte prefix and same length-byte
+ * collide; until §10.3.1 mandates per-element encoding, callers SHOULD avoid
+ * embedding large arrays as `credentialSubject` leaves.
+ *
+ * # Salt CSPRNG hygiene
+ *
+ * Each entry gets 32 fresh CSPRNG bytes from `globalThis.crypto
+ * .getRandomValues`. Tests can inject a deterministic `randomBytes` hook to
+ * pin commitment outputs for KAT regression coverage.
+ *
+ * # Leaf flattening
+ *
+ * A *leaf* is any value that is not a non-null, non-Array plain object.
+ * Strings, numbers, booleans, `null`, `undefined`, and arrays are all
+ * leaves. Plain objects are recursed into; the recursion path is built by
+ * dot-joining keys without bracket-quoting (paths stay byte-stable for the
+ * lex sort).
+ *
+ * Implements §10.3.1 (FN-212 ratified, FN-082 land of Poseidon-2 t=3 BN254).
+ */
+
+import {
+  bytesToHex32,
+  encodeFr,
+  encodeSalt,
+  poseidon2,
+} from "../crypto/poseidon2.js";
+
+/** Per-leaf commitment entry per §10.3.1. */
+export interface ClaimCommitment {
+  /** Dot-separated path under `pathPrefix` (default `credentialSubject`). */
+  readonly fieldPath: string;
+  /** 0-based position in the lex-sorted `fieldPath` list. */
+  readonly idx: number;
+  /** 64-char lowercase LE hex (no `0x`) of Poseidon-2(value, salt, idx). */
+  readonly commitment: string;
+  /** 64-char lowercase LE hex (no `0x`) of Poseidon-2(salt, 0, idx). */
+  readonly saltCommitment: string;
+}
+
+/** Options for `computeClaimCommitments`. */
+export interface ComputeClaimCommitmentsOptions {
+  /**
+   * Deterministic CSPRNG hook for tests. Each call MUST return exactly
+   * `len` cryptographically random bytes. Defaults to
+   * `globalThis.crypto.getRandomValues`.
+   */
+  readonly randomBytes?: ((len: number) => Uint8Array) | undefined;
+  /**
+   * Path prefix prepended to every `fieldPath`. Defaults to
+   * `"credentialSubject"` so canonical entries read
+   * `credentialSubject.<leaf>` per §10.3.1.
+   */
+  readonly pathPrefix?: string | undefined;
+}
+
+/** Default WebCrypto-backed CSPRNG. Throws if WebCrypto is unavailable. */
+function defaultRandomBytes(len: number): Uint8Array {
+  const c = globalThis.crypto;
+  if (!c || typeof c.getRandomValues !== "function") {
+    throw new Error(
+      "computeClaimCommitments: globalThis.crypto.getRandomValues is " +
+        "unavailable; cannot generate commitment salts",
+    );
+  }
+  return c.getRandomValues(new Uint8Array(len));
+}
+
+/** True if `v` should be recursed into (plain object, non-Array, non-null). */
+function isPlainObject(v: unknown): v is Record<string, unknown> {
+  return (
+    v !== null && typeof v === "object" && !Array.isArray(v)
+  );
+}
+
+/** Flatten an object into `[fieldPath, value]` pairs (arrays are leaves). */
+function flattenLeaves(
+  prefix: string,
+  obj: Record<string, unknown>,
+  out: Array<{ path: string; value: unknown }>,
+): void {
+  for (const key of Object.keys(obj)) {
+    const path = `${prefix}.${key}`;
+    const v = obj[key];
+    if (isPlainObject(v)) {
+      flattenLeaves(path, v, out);
+    } else {
+      // Arrays, strings, numbers, booleans, null, undefined — all leaves.
+      // Arrays go through `encodeFr(JSON.stringify(...))` below; see the
+      // module-level "Array-leaf encoding" caveat.
+      out.push({ path, value: v });
+    }
+  }
+}
+
+/**
+ * Compute the §10.3.1 `claimCommitments` array for a `credentialSubject`.
+ *
+ * @param credentialSubject The VC `credentialSubject` block (must be a plain
+ *                          object). Leaves are flattened recursively.
+ * @param opts              Optional CSPRNG hook + path prefix override.
+ * @returns Lex-sorted `ClaimCommitment[]` with sequential `idx` 0..n-1.
+ */
+export function computeClaimCommitments(
+  credentialSubject: Record<string, unknown>,
+  opts?: ComputeClaimCommitmentsOptions,
+): ClaimCommitment[] {
+  if (!isPlainObject(credentialSubject)) {
+    throw new TypeError(
+      "computeClaimCommitments: credentialSubject must be a plain object",
+    );
+  }
+  const pathPrefix = opts?.pathPrefix ?? "credentialSubject";
+  const randomBytes = opts?.randomBytes ?? defaultRandomBytes;
+
+  // 1. Flatten leaves (arrays are leaves, not recursion targets).
+  const leaves: Array<{ path: string; value: unknown }> = [];
+  flattenLeaves(pathPrefix, credentialSubject, leaves);
+
+  // 2. Byte-stable lex sort over `fieldPath`. Do NOT use `localeCompare` —
+  //    locale-aware comparison can reorder code points and break the
+  //    `idx ↔ field_index` invariant that selective-disclosure proofs rely
+  //    on.
+  leaves.sort((a, b) => (a.path < b.path ? -1 : a.path > b.path ? 1 : 0));
+
+  // 3. Commit each leaf at its sorted `idx`.
+  const out: ClaimCommitment[] = [];
+  for (let idx = 0; idx < leaves.length; idx += 1) {
+    const { path, value } = leaves[idx]!;
+
+    // Value encoding per §10.3.1 (with v0 array-as-string caveat).
+    let valueField: bigint;
+    if (Array.isArray(value)) {
+      valueField = encodeFr(JSON.stringify(value));
+    } else {
+      valueField = encodeFr(value);
+    }
+
+    // Fresh 32-byte CSPRNG salt per attribute.
+    const saltBytes = randomBytes(32);
+    if (!(saltBytes instanceof Uint8Array) || saltBytes.length !== 32) {
+      throw new Error(
+        "computeClaimCommitments: randomBytes must return a 32-byte Uint8Array",
+      );
+    }
+    const saltField = encodeSalt(saltBytes);
+    const idxField = BigInt(idx);
+
+    const commitmentFr = poseidon2([valueField, saltField, idxField]);
+    const saltCommitmentFr = poseidon2([saltField, 0n, idxField]);
+
+    out.push({
+      fieldPath: path,
+      idx,
+      commitment: bytesToHex32(commitmentFr),
+      saltCommitment: bytesToHex32(saltCommitmentFr),
+    });
+  }
+
+  return out;
+}

--- a/src/issuers/kyc-test.ts
+++ b/src/issuers/kyc-test.ts
@@ -33,6 +33,7 @@
 
 import { createHash, createHmac, timingSafeEqual } from "node:crypto";
 
+import { computeClaimCommitments } from "./claim-commitments.js";
 import {
   KYC_TEST_MIN_DWELL_SECONDS,
   KycTestFormSubmission,
@@ -169,7 +170,7 @@ export async function issueKycTest(
   // Step 5 — build VC, pin, submit on-chain IssueCredential.
   const slot = await deps.clock.currentSlot();
 
-  const vc = buildKycTestVc({
+  const baseVc = buildKycTestVc({
     agentCardPubkey,
     issuerAuthorityPubkey: deps.issuerAuthorityPubkey,
     fullName: normalized.normName,
@@ -177,6 +178,13 @@ export async function issueKycTest(
     nullifier,
     issuanceDate: new Date(nowUnix * 1000).toISOString(),
   });
+  // §10.3.1: per-leaf Poseidon-2 commitments, embedded BEFORE
+  // canonicalisation so `claim_hash` binds them.
+  const claimCommitments = computeClaimCommitments(
+    baseVc.credentialSubject as Record<string, unknown>,
+    { randomBytes: deps.randomBytes },
+  );
+  const vc = { ...baseVc, claimCommitments };
   const claimJcs = jcsCanonicalize(vc);
   const claimHashHex = sha256Hex(claimJcs);
 

--- a/src/issuers/kyc-test.types.ts
+++ b/src/issuers/kyc-test.types.ts
@@ -121,6 +121,11 @@ export interface KycTestIssuerDeps {
   readonly minDwellSeconds?: number;
   /** Wall-clock — defaults to `Date.now()/1000`. */
   readonly nowUnix?: () => number;
+  /**
+   * Optional CSPRNG hook for `claimCommitments` salt generation
+   * (§10.3.1). Defaults to `globalThis.crypto.getRandomValues`.
+   */
+  readonly randomBytes?: (len: number) => Uint8Array;
 }
 
 export interface KycTestIssueRequest {

--- a/src/issuers/skill-cert.ts
+++ b/src/issuers/skill-cert.ts
@@ -47,6 +47,7 @@
 
 import { createHash } from "node:crypto";
 
+import { computeClaimCommitments } from "./claim-commitments.js";
 import {
   type AgentCardPubkey,
   type ChainClient,
@@ -219,6 +220,11 @@ export interface SkillCertIssuerDeps {
   readonly claimHasher?: ClaimHasher;
   /** Clock injection for deterministic tests. Defaults to `Date.now`. */
   readonly now?: () => number;
+  /**
+   * Optional CSPRNG hook for `claimCommitments` salt generation
+   * (§10.3.1). Defaults to `globalThis.crypto.getRandomValues`.
+   */
+  readonly randomBytes?: (len: number) => Uint8Array;
 }
 
 /**
@@ -304,12 +310,19 @@ export class SkillCertIssuer {
 
     /* 4. Build & pin the off-chain claim envelope. ---------------------- */
     const issuanceDate = new Date(this.now()).toISOString();
-    const claim = buildSkillCertClaim({
+    const baseClaim = buildSkillCertClaim({
       issuerDid: this.cfg.issuerDid,
       skill: req.skill,
       subjectAgentCard: req.subjectAgentCard,
       issuanceDate,
     });
+    // §10.3.1: per-leaf Poseidon-2 commitments over `credentialSubject`,
+    // embedded BEFORE hashing so `claim_hash` binds them.
+    const claimCommitments = computeClaimCommitments(
+      baseClaim.credentialSubject as Record<string, unknown>,
+      { randomBytes: this.deps.randomBytes },
+    );
+    const claim = { ...baseClaim, claimCommitments };
     const claimHash = this.hasher.hash(claim);
     const claimUri = await this.deps.ipfs.pinJson(claim);
     if (!claimUri.startsWith("ipfs://")) {

--- a/src/issuers/worldcoin.ts
+++ b/src/issuers/worldcoin.ts
@@ -26,6 +26,7 @@
 
 import { createHash } from "node:crypto";
 
+import { computeClaimCommitments } from "./claim-commitments.js";
 import {
   type AgentCardPubkey,
   type AgentCardSignatureVerifier,
@@ -194,6 +195,12 @@ export interface WorldcoinIssuerDeps {
    * Defaults to `Date.now`.
    */
   readonly now?: () => number;
+  /**
+   * Optional CSPRNG hook for `claimCommitments` salt generation.
+   * Defaults to `globalThis.crypto.getRandomValues`. Tests inject a
+   * deterministic implementation to pin commitment hex.
+   */
+  readonly randomBytes?: (len: number) => Uint8Array;
 }
 
 /**
@@ -355,7 +362,7 @@ export class WorldcoinIssuer {
 
     /* 5. Build & pin the off-chain VC envelope. ------------------------- */
     const issuanceDate = new Date(this.now()).toISOString();
-    const vc = buildVerifiedHumanVc({
+    const baseVc = buildVerifiedHumanVc({
       issuerDid: this.cfg.issuerDid,
       agentCardPubkey: req.agentCardPubkey,
       verificationLevel: cloud.verificationLevel,
@@ -363,6 +370,14 @@ export class WorldcoinIssuer {
       merkleRoot: req.merkleRoot,
       issuanceDate,
     });
+    // §10.3.1: embed per-leaf Poseidon-2 commitments BEFORE hashing so
+    // `claim_hash` binds them. The on-chain selective-disclosure
+    // verifier reads `field_index` against this lex-sorted ordering.
+    const claimCommitments = computeClaimCommitments(
+      baseVc.credentialSubject as Record<string, unknown>,
+      { randomBytes: this.deps.randomBytes },
+    );
+    const vc = { ...baseVc, claimCommitments };
     const claimHash = this.hasher.hash(vc);
     const claimUri = await this.deps.ipfs.pinJson(vc);
     if (!claimUri.startsWith("ipfs://")) {

--- a/src/models/agent-identity.ts
+++ b/src/models/agent-identity.ts
@@ -1,0 +1,281 @@
+/**
+ * Agent Identity Model — `human × model × environment × session`.
+ *
+ * Reference TypeScript shape for the spec at
+ * [`docs/agent-identity-model.md`](../../docs/agent-identity-model.md).
+ *
+ * **Status (FN-058):** spec-only. This module is exported but is NOT wired
+ * into any MCP tool, request handler, or transport. FN-059 is the first task
+ * that will consume `AgentIdentity` in a handler. Do not import from
+ * `src/tools/session.ts` here — the builder takes a structurally typed input
+ * (a `session_info`-shaped payload) to keep this module decoupled from any
+ * concrete tool implementation.
+ *
+ * Field-level JSDoc references the section numbers in
+ * `docs/agent-identity-model.md` (e.g. `§2.1`).
+ */
+
+import type { SvmAddress, EvmAddress } from "./index.js";
+
+// ---------------------------------------------------------------------------
+// §2.1 — human_authority
+// ---------------------------------------------------------------------------
+
+/**
+ * Which auth backend issued the human attestation behind this identity.
+ *
+ * Matches the realistic set of strategies in `src/gateway/session.ts`
+ * (`AuthStrategy`) plus two synthetic kinds:
+ *
+ * - `"stdio"` — the stdio entrypoint runs in the literal `"__stdio__"` scope
+ *   without any human attestation. Local-trust only.
+ * - `"unknown"` — fallback when no `auth_strategy` is present and the scope
+ *   is not one of the known synthetic scopes.
+ *
+ * See spec §2.1.
+ */
+export type HumanAuthorityKind =
+  | "thirdweb" // siwe / inapp_email / inapp_oauth — real human-attested
+  | "dev"      // dev-bypass; never inherits authority
+  | "stdio"    // __stdio__ scope; local trust only
+  | "unknown";
+
+/**
+ * The human (or human-controlled service account) that consented to this
+ * agent acting on their behalf. See spec §2.1.
+ */
+export interface HumanAuthority {
+  /** Persistence-key form of the human identity. Today: `SessionPayload.sub`,
+   *  `"__stdio__"`, or `"__dev__"`. See spec §2.1. */
+  sub: string;
+  /** Coarse classification of the auth backend; see {@link HumanAuthorityKind}. */
+  kind: HumanAuthorityKind;
+  /** Raw `auth_strategy` from the session token, when present. Mirrors
+   *  `SessionPayload.auth_strategy` from `src/gateway/session.ts`. */
+  auth_strategy?: "siwe" | "inapp_email" | "inapp_oauth" | "dev";
+}
+
+// ---------------------------------------------------------------------------
+// §2.2 — model_attestation
+// ---------------------------------------------------------------------------
+
+/**
+ * Discriminator for {@link ModelAttestation}. See spec §2.2 and §4.
+ *
+ * - `"verified"` — provider-signed JWS verified against published JWKS.
+ *   ONLY this state is safe for capability gating.
+ * - `"self_declared"` — the agent advertised a model claim but no signature
+ *   was verified. Telemetry-only; never gate capabilities on this.
+ * - `"absent"` — no claim was made (or verification failed). Do not branch
+ *   on model identity at all.
+ */
+export type AttestationStatus = "verified" | "self_declared" | "absent";
+
+/** A claim about which AI model produced the agent's actions. See spec §2.2. */
+export type ModelAttestation =
+  | {
+      attestation_status: "verified";
+      provider: string;
+      model_id: string;
+      /** JWS `kid` from the verified attestation. */
+      kid: string;
+      /** Issuance timestamp (seconds since epoch) of the verified JWS. */
+      issued_at: number;
+    }
+  | {
+      attestation_status: "self_declared";
+      provider: string;
+      model_id: string;
+    }
+  | {
+      attestation_status: "absent";
+    };
+
+// ---------------------------------------------------------------------------
+// §2.3 — environment
+// ---------------------------------------------------------------------------
+
+/** Execution surface the agent is running on. See spec §2.3. */
+export type ExecutionSurface = "stdio" | "sse" | "dev";
+
+/**
+ * Cryptographic anchor — the wallet whose private keys actually sign actions.
+ * Matches the active-wallet shape returned by `session_info`. See spec §2.3.
+ */
+export interface WalletAnchor {
+  id: string;
+  /** Base58 Ed25519 public key. Null if the signer could not be loaded. */
+  svm: SvmAddress | null;
+  /** 0x-hex secp256k1 address. Null if the signer could not be loaded. */
+  evm: EvmAddress | null;
+  label?: string | null;
+}
+
+/** Where the agent is executing + its cryptographic anchor. See spec §2.3. */
+export interface Environment {
+  surface: ExecutionSurface;
+  /** Stable per-process identifier; today: the server's `last_restart_iso`. */
+  server_instance: string;
+  /** The active wallet whose keys sign actions. */
+  wallet_anchor: WalletAnchor;
+}
+
+// ---------------------------------------------------------------------------
+// §2.4 — session_scope
+// ---------------------------------------------------------------------------
+
+/** The bounded MCP session window. See spec §2.4. */
+export interface SessionScope {
+  /** Persistence-key form of the scope; mirrors `currentScope()`. */
+  scope: string;
+  /** Session token id (`SessionPayload.jti`) when known. */
+  jti?: string;
+  /** ISO-8601 expiry; null when no token is bound (e.g. stdio). */
+  expires_at_iso: string | null;
+  /** Capabilities granted on the session token; see `CAPABILITY_SCOPES`. */
+  capabilities: string[];
+}
+
+// ---------------------------------------------------------------------------
+// §6 — top-level shape
+// ---------------------------------------------------------------------------
+
+/**
+ * The canonical agent identity tuple. See spec §1 and §6.
+ *
+ * Consumers MUST evaluate all four axes independently; see §3 for the
+ * authority-inheritance rule and §5 for the trust degradation that applies
+ * when `model_attestation.attestation_status !== "verified"`.
+ */
+export interface AgentIdentity {
+  /** §2.1 — who authorized this agent. */
+  human_authority: HumanAuthority;
+  /** §2.2 — which AI model is steering it. */
+  model_attestation: ModelAttestation;
+  /** §2.3 — where it's running and the cryptographic anchor. */
+  environment: Environment;
+  /** §2.4 — bounded MCP session window. */
+  session_scope: SessionScope;
+}
+
+// ---------------------------------------------------------------------------
+// §5 — interim builder
+// ---------------------------------------------------------------------------
+
+/**
+ * Structurally typed input mirroring the `session_info` MCP tool's response
+ * shape. We accept it as a plain shape (not by importing from
+ * `src/tools/session.ts`) so this module stays decoupled from the tool layer.
+ *
+ * See spec §5.
+ */
+export interface InterimAgentIdentityInput {
+  /** From `currentScope()`; required. */
+  scope: string;
+  /** Active wallet id; from `getActiveWalletId()`. */
+  active_wallet_id: string | null;
+  /** Wallet list as returned by `session_info`. */
+  wallets: ReadonlyArray<{
+    id: string;
+    label?: string | null;
+    svm: SvmAddress | null;
+    evm: EvmAddress | null;
+  }>;
+  /** From `SessionPayload.auth_strategy`. */
+  auth_strategy?: "siwe" | "inapp_email" | "inapp_oauth" | "dev" | null;
+  /** ISO string from `session_info.token_expires_at`. */
+  token_expires_at?: string | null;
+  /** ISO string from `session_info.last_restart_iso`. */
+  last_restart_iso: string;
+  /** Optional: caller-declared model. Becomes a `self_declared` attestation. */
+  declared_model?: { provider: string; model_id: string };
+  /** Optional: capabilities from `SessionPayload.caps`. Defaults to `[]`. */
+  capabilities?: ReadonlyArray<string>;
+  /** Optional: `SessionPayload.jti` when available. */
+  jti?: string;
+}
+
+/**
+ * Build an {@link AgentIdentity} from a `session_info`-shaped payload, with
+ * no provider integration. The result always has
+ * `model_attestation.attestation_status` of `"self_declared"` (when
+ * `declared_model` is present) or `"absent"`.
+ *
+ * Pure function — no I/O, no global state.
+ *
+ * @throws {Error} if `scope` is missing or empty (see spec §5: there is no
+ * meaningful identity without a session-scope persistence key).
+ */
+export function buildInterimAgentIdentity(
+  input: InterimAgentIdentityInput,
+): AgentIdentity {
+  if (!input.scope || typeof input.scope !== "string") {
+    throw new Error(
+      "buildInterimAgentIdentity: missing required `session_scope` source — `scope` must be a non-empty string (see docs/agent-identity-model.md §5).",
+    );
+  }
+
+  const human_authority = resolveHumanAuthority(input);
+  const environment = resolveEnvironment(input);
+  const model_attestation: ModelAttestation = input.declared_model
+    ? {
+        attestation_status: "self_declared",
+        provider: input.declared_model.provider,
+        model_id: input.declared_model.model_id,
+      }
+    : { attestation_status: "absent" };
+
+  const session_scope: SessionScope = {
+    scope: input.scope,
+    expires_at_iso: input.token_expires_at ?? null,
+    capabilities: [...(input.capabilities ?? [])],
+    ...(input.jti !== undefined ? { jti: input.jti } : {}),
+  };
+
+  return { human_authority, model_attestation, environment, session_scope };
+}
+
+function resolveHumanAuthority(input: InterimAgentIdentityInput): HumanAuthority {
+  const strategy = input.auth_strategy ?? undefined;
+  let kind: HumanAuthorityKind;
+  if (input.scope === "__stdio__") kind = "stdio";
+  else if (input.scope === "__dev__" || strategy === "dev") kind = "dev";
+  else if (
+    strategy === "siwe" ||
+    strategy === "inapp_email" ||
+    strategy === "inapp_oauth"
+  )
+    kind = "thirdweb";
+  else kind = "unknown";
+
+  return {
+    sub: input.scope,
+    kind,
+    ...(strategy !== undefined ? { auth_strategy: strategy } : {}),
+  };
+}
+
+function resolveEnvironment(input: InterimAgentIdentityInput): Environment {
+  let surface: ExecutionSurface;
+  if (input.scope === "__stdio__") surface = "stdio";
+  else if (input.scope === "__dev__" || input.auth_strategy === "dev") surface = "dev";
+  else surface = "sse";
+
+  const active = input.wallets.find((w) => w.id === input.active_wallet_id) ??
+    input.wallets[0];
+
+  const wallet_anchor: WalletAnchor = active
+    ? {
+        id: active.id,
+        svm: active.svm,
+        evm: active.evm,
+        label: active.label ?? null,
+      }
+    : { id: "", svm: null, evm: null, label: null };
+
+  return {
+    surface,
+    server_instance: input.last_restart_iso,
+    wallet_anchor,
+  };
+}

--- a/src/services/indexer/audit-trail.ts
+++ b/src/services/indexer/audit-trail.ts
@@ -620,3 +620,51 @@ export async function buildAuditFeed(
 ): Promise<AuditFeedJsonLd> {
   return new AuditTrailIndexer(deps).buildAuditFeed(authority, opts);
 }
+
+// ---------------------------------------------------------------------------
+// JOSE proof suite (FN-030)
+// ---------------------------------------------------------------------------
+//
+// Minimal compact-JWS wrapper for the `jose` proof suite registered in
+// `AuditFeedProofSuite`. Signs any JSON-serialisable payload with an
+// Ed25519 private key and returns a 3-part compact JWS string:
+//
+//   base64url(header) + "." + base64url(payload) + "." + base64url(sig)
+//
+// Header: `{ alg: "EdDSA", typ: "JWT" }` (RFC 7515 / RFC 8037).
+// Signing input: ASCII bytes of `headerPart + "." + payloadPart`.
+//
+// This is dependency-free — it uses the `@noble/ed25519` and `@noble/hashes`
+// packages already in the dependency graph rather than the `jose` npm package.
+
+import * as ed from "@noble/ed25519";
+import { sha512 } from "@noble/hashes/sha512";
+
+// Configure synchronous sha512 required by @noble/ed25519 v2 (idempotent).
+ed.etc.sha512Sync = (...m: Uint8Array[]) => sha512(ed.etc.concatBytes(...m));
+
+function b64url(bytes: Uint8Array): string {
+  return Buffer.from(bytes).toString("base64url");
+}
+
+/**
+ * Sign `payload` with an Ed25519 `privateKey` and return a compact JWS.
+ *
+ * Header is `{ alg: "EdDSA", typ: "JWT" }`. To include a `kid` for key
+ * rotation (FN-028), use `signWithKid` from `src/signing/key-rotation.ts`.
+ *
+ * @param payload     Any JSON-serialisable value.
+ * @param privateKey  Raw 32-byte Ed25519 private key (seed).
+ * @returns Compact JWS: `<header>.<payload>.<sig>`, all parts base64url.
+ */
+export async function signWithJose(
+  payload: unknown,
+  privateKey: Uint8Array,
+): Promise<string> {
+  const enc = new TextEncoder();
+  const headerPart = b64url(enc.encode(JSON.stringify({ alg: "EdDSA", typ: "JWT" })));
+  const payloadPart = b64url(enc.encode(JSON.stringify(payload)));
+  const signingInput = enc.encode(`${headerPart}.${payloadPart}`);
+  const sig = await ed.signAsync(signingInput, privateKey);
+  return `${headerPart}.${payloadPart}.${b64url(sig)}`;
+}

--- a/src/services/indexer/audit-trail.ts
+++ b/src/services/indexer/audit-trail.ts
@@ -22,11 +22,14 @@
 // downstream consumers (FN-132 1099 issuer, FN-133 travel-rule
 // generator) can hash the output for caching / diffing.
 //
-// **v0 caveat — UNSIGNED.** The `issuer` field is a placeholder DID
-// (`did:eto:indexer:audit-trail:v0`). This audit feed is NOT
-// cryptographically signed in v0; downstream consumers must treat the
-// document as derived data, not as proof. Signing (VC-JOSE / Ed25519)
-// is a follow-up task.
+// **Signing.** Signing is opt-in via the injected `VcSigner`; the
+// default `NoOpVcSigner` preserves the historical unsigned shape
+// (no `proof` key in the emitted document). Set
+// `AUDIT_SIGNING_KEY_PATH` and pass `createVcSignerFromEnv({ issuerDid })`
+// to emit an `Ed25519Signature2020` proof block per W3C VC Data
+// Integrity / RFC 8785 (FN-084). The proof preimage is
+// `sha256(JCS(vcWithoutProof))` — the proof block is excluded from the
+// hash input.
 //
 // **Determinism guarantees.** Given identical event inputs and bounds,
 // `buildAuditFeed` MUST produce a byte-identical document apart from
@@ -39,6 +42,11 @@ import {
   kytTraceEventSchema,
   revocationRootUpdatedEventSchema,
 } from "./audit-trail.types.js";
+import {
+  NoOpVcSigner,
+  type Ed25519Signature2020Proof,
+  type VcSigner,
+} from "./vc-signer.js";
 
 export type {
   CounterpartyWire,
@@ -303,7 +311,10 @@ export interface AuditFeedJsonLd {
   "@context": readonly [typeof AUDIT_TRAIL_CONTEXT_VC, typeof AUDIT_TRAIL_CONTEXT_ETO];
   id: string;
   type: readonly ["VerifiableCredential", "AuditTrailFeed"];
-  issuer: typeof AUDIT_TRAIL_ISSUER_DID;
+  // FN-084: widened from the literal `typeof AUDIT_TRAIL_ISSUER_DID` to
+  // `string` so an injected `VcSigner` can override the placeholder DID.
+  // The default value is still `AUDIT_TRAIL_ISSUER_DID`.
+  issuer: string;
   issuanceDate: string;
   credentialSubject: {
     id: string;
@@ -312,6 +323,9 @@ export interface AuditFeedJsonLd {
     events: readonly AuditFeedEvent[];
     summary: AuditFeedSummary;
   };
+  /** FN-084: optional Ed25519Signature2020 proof block. Absent when the
+   *  default `NoOpVcSigner` is in use (preserves byte-stable v0 shape). */
+  proof?: Ed25519Signature2020Proof;
 }
 
 // ---------------------------------------------------------------------
@@ -334,6 +348,11 @@ export interface AuditTrailIndexerDeps {
   logger?: AuditLogger;
   /** Defaults to `() => new Date()`. Tests inject a fixed clock. */
   clock?: () => Date;
+  /**
+   * FN-084: optional VC signer. Defaults to `NoOpVcSigner(AUDIT_TRAIL_ISSUER_DID)`
+   * which produces a byte-stable unsigned document (no `proof` key).
+   */
+  signer?: VcSigner;
 }
 
 const BASE58_RE = /^[1-9A-HJ-NP-Za-km-z]+$/;
@@ -401,11 +420,13 @@ export class AuditTrailIndexer {
   private readonly source: KytEventSource;
   private readonly logger?: AuditLogger;
   private readonly clock: () => Date;
+  private readonly signer: VcSigner;
 
   public constructor(deps: AuditTrailIndexerDeps) {
     this.source = deps.source;
     if (deps.logger) this.logger = deps.logger;
     this.clock = deps.clock ?? (() => new Date());
+    this.signer = deps.signer ?? new NoOpVcSigner(AUDIT_TRAIL_ISSUER_DID);
   }
 
   public async buildAuditFeed(
@@ -542,11 +563,16 @@ export class AuditTrailIndexer {
       revocationCount: revEvents.length,
     };
 
+    const issuerDid =
+      this.signer.issuerDid !== AUDIT_TRAIL_ISSUER_DID
+        ? this.signer.issuerDid
+        : AUDIT_TRAIL_ISSUER_DID;
+
     const feed: AuditFeedJsonLd = {
       "@context": [AUDIT_TRAIL_CONTEXT_VC, AUDIT_TRAIL_CONTEXT_ETO],
       id: feedUrn(authority, sinceSlot, untilSlot),
       type: AUDIT_TRAIL_VC_TYPE,
-      issuer: AUDIT_TRAIL_ISSUER_DID,
+      issuer: issuerDid,
       issuanceDate: this.clock().toISOString(),
       credentialSubject: {
         id: `did:eto:agent:${authority}`,
@@ -560,10 +586,23 @@ export class AuditTrailIndexer {
       },
     };
 
+    // FN-084: sign the proof-less document and attach the proof block
+    // iff the signer produced a non-empty proofValue. The NoOp path
+    // returns proofValue === "", which we map to no `proof` key so the
+    // v0 unsigned wire shape stays byte-identical.
+    // Pass a shallow copy so the signer cannot observe (or be passed)
+    // a `proof` field. The proof block is excluded from the JCS
+    // preimage per W3C VC Data Integrity §11.4.
+    const proof = await this.signer.sign({ ...feed });
+    if (proof.proofValue !== "") {
+      feed.proof = proof;
+    }
+
     this.logger?.info?.("audit-trail: built feed", {
       authority,
       kytCount: summary.kytCount,
       revocationCount: summary.revocationCount,
+      signed: proof.proofValue !== "",
     });
 
     return feed;

--- a/src/services/indexer/index.ts
+++ b/src/services/indexer/index.ts
@@ -3,3 +3,21 @@
 
 export * from "./audit-trail.js";
 export * from "./travel-rule.js";
+
+// FN-084: VC signer abstractions for `Ed25519Signature2020` proof blocks
+// over the audit-trail and travel-rule JSON-LD documents.
+export {
+  DEFAULT_UNSIGNED_DID,
+  Ed25519VcSigner,
+  NoOpVcSigner,
+  base64UrlEncode,
+  canonicalizeJcs,
+  createVcSignerFromEnv,
+} from "./vc-signer.js";
+export type {
+  CreateVcSignerFromEnvOpts,
+  Ed25519Signature2020Proof,
+  Ed25519VcSignerFromKeyFileOpts,
+  Ed25519VcSignerInit,
+  VcSigner,
+} from "./vc-signer.js";

--- a/src/services/indexer/travel-rule.ts
+++ b/src/services/indexer/travel-rule.ts
@@ -34,10 +34,13 @@
  * feed. The injectable `clock` defaults to `() => new Date()`; tests pin
  * it to a fixed timestamp for byte-stable assertions.
  *
- * **v0 unsigned caveat.** The `issuer` field is a placeholder DID
- * (`did:eto:indexer:travel-rule:v0`). This report is NOT cryptographically
- * signed in v0; consumers must treat the document as derived data, not
- * as proof. Signing (VC-JOSE / Ed25519) is a follow-up task.
+ * **Signing.** Signing is opt-in via the injected `VcSigner`; the
+ * default `NoOpVcSigner` preserves the historical unsigned shape (no
+ * `proof` key in the emitted document). Set `AUDIT_SIGNING_KEY_PATH`
+ * and pass `createVcSignerFromEnv({ issuerDid })` to emit an
+ * `Ed25519Signature2020` proof block per W3C VC Data Integrity /
+ * RFC 8785 (FN-084). The proof preimage is `sha256(JCS(vcWithoutProof))`
+ * — the proof block is excluded from the hash input.
  *
  * **Spec §9.3 mapping.** `parties[0]` (BAP) is the originator; `parties[1]`
  * (BPP) is the beneficiary. When the audited authority is the BAP, we look
@@ -52,6 +55,11 @@ import {
   type AuditLogger,
   type KytEventSource,
 } from "./audit-trail.js";
+import {
+  NoOpVcSigner,
+  type Ed25519Signature2020Proof,
+  type VcSigner,
+} from "./vc-signer.js";
 import {
   type AmountResolverEntry,
   type Ivms101Party,
@@ -351,8 +359,13 @@ export interface TravelRuleReportJsonLd {
   ];
   id: string;
   type: typeof TRAVEL_RULE_REPORT_TYPE;
-  issuer: typeof TRAVEL_RULE_ISSUER_DID;
+  // FN-084: widened from the literal `typeof TRAVEL_RULE_ISSUER_DID` to
+  // `string` so an injected `VcSigner` can override the placeholder DID.
+  issuer: string;
   issuanceDate: string;
+  /** FN-084: optional Ed25519Signature2020 proof block. Absent when the
+   *  default `NoOpVcSigner` is in use (preserves byte-stable v0 shape). */
+  proof?: Ed25519Signature2020Proof;
   credentialSubject: {
     id: string;
     authority: string;
@@ -476,6 +489,12 @@ export interface TravelRuleReportGeneratorDeps {
   logger?: AuditLogger;
   /** Defaults to `() => new Date()`. Tests inject a fixed clock. */
   clock?: () => Date;
+  /**
+   * FN-084: optional VC signer. Defaults to
+   * `NoOpVcSigner(TRAVEL_RULE_ISSUER_DID)` which produces a byte-stable
+   * unsigned document (no `proof` key).
+   */
+  signer?: VcSigner;
 }
 
 /**
@@ -490,6 +509,7 @@ export class TravelRuleReportGenerator {
   private readonly amountResolver: AmountResolver;
   private readonly logger?: AuditLogger;
   private readonly clock: () => Date;
+  private readonly signer: VcSigner;
 
   public constructor(deps: TravelRuleReportGeneratorDeps) {
     // If source is already an AuditTrailIndexer, reuse it; otherwise wrap.
@@ -505,6 +525,7 @@ export class TravelRuleReportGenerator {
     this.amountResolver = deps.amountResolver;
     if (deps.logger) this.logger = deps.logger;
     this.clock = deps.clock ?? (() => new Date());
+    this.signer = deps.signer ?? new NoOpVcSigner(TRAVEL_RULE_ISSUER_DID);
   }
 
   public async buildReport(
@@ -648,11 +669,16 @@ export class TravelRuleReportGenerator {
       entries.reduce((sum, e) => sum + e.amountUsd, 0),
     );
 
+    const issuerDid =
+      this.signer.issuerDid !== TRAVEL_RULE_ISSUER_DID
+        ? this.signer.issuerDid
+        : TRAVEL_RULE_ISSUER_DID;
+
     const report: TravelRuleReportJsonLd = {
       "@context": [TRAVEL_RULE_CONTEXT_FATF, TRAVEL_RULE_CONTEXT_ETO],
       id: reportUrn(authority, sinceSlot, untilSlot),
       type: TRAVEL_RULE_REPORT_TYPE,
-      issuer: TRAVEL_RULE_ISSUER_DID,
+      issuer: issuerDid,
       issuanceDate: this.clock().toISOString(),
       credentialSubject: {
         id: `did:eto:agent:${authority}`,
@@ -675,11 +701,20 @@ export class TravelRuleReportGenerator {
       },
     };
 
+    // FN-084: sign the proof-less document and attach proof iff non-empty.
+    // Pass a shallow copy so the signer never observes the `proof` key
+    // (W3C VC Data Integrity §11.4 excludes proof from the JCS preimage).
+    const proof = await this.signer.sign({ ...report });
+    if (proof.proofValue !== "") {
+      report.proof = proof;
+    }
+
     this.logger?.info?.("travel-rule: built report", {
       authority,
       entries: entries.length,
       skippedMissingParty,
       skippedMissingAmount,
+      signed: proof.proofValue !== "",
     });
 
     return report;

--- a/src/services/indexer/vc-signer.ts
+++ b/src/services/indexer/vc-signer.ts
@@ -1,0 +1,290 @@
+// VC signer for audit-trail / travel-rule JSON-LD documents (FN-084).
+//
+// Implements `Ed25519Signature2020` proof blocks per the W3C VC Data
+// Integrity 1.0 spec. The proof preimage is `sha256(JCS(vcWithoutProof))`
+// per spec §11.4 — the proof block itself is excluded from the hash
+// input by the calling indexer (see `audit-trail.ts` / `travel-rule.ts`).
+//
+// **Backwards-compatible default.** `NoOpVcSigner` returns a sentinel
+// proof with `proofValue === ""`; callers detect this and OMIT the
+// `proof` key entirely from the emitted document so the v0 unsigned
+// shape remains byte-stable.
+//
+// **Key material.** `Ed25519VcSigner` accepts a 32-byte Ed25519 seed
+// (NOT the 64-byte expanded form). `createVcSignerFromEnv` reads
+// `AUDIT_SIGNING_KEY_PATH`; the file may be raw 32 bytes, hex (with
+// optional `0x` prefix), or base64 / base64url. The loaded secret is
+// never logged, never thrown back inside an Error message, and never
+// persisted by this module.
+
+import { readFileSync } from "node:fs";
+import * as ed25519 from "@noble/ed25519";
+import { sha256 } from "@noble/hashes/sha256";
+
+// ---------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------
+
+export interface Ed25519Signature2020Proof {
+  type: "Ed25519Signature2020";
+  /** ISO-8601 UTC timestamp, e.g. `2026-05-02T12:34:56.000Z`. */
+  created: string;
+  /** Always `<issuerDid>#key-1` for this v0 single-key implementation. */
+  verificationMethod: string;
+  proofPurpose: "assertionMethod";
+  /** `base64url(sign(sha256(JCS(vcWithoutProof))))`. Empty for NoOp. */
+  proofValue: string;
+}
+
+export interface VcSigner {
+  readonly issuerDid: string;
+  sign(vcWithoutProof: Record<string, unknown>): Promise<Ed25519Signature2020Proof>;
+}
+
+// ---------------------------------------------------------------------
+// JCS canonicalization (RFC 8785 subset — sufficient for these docs)
+// ---------------------------------------------------------------------
+
+const LINE_SEP_RE = /\u2028/g;
+const PARA_SEP_RE = /\u2029/g;
+
+/**
+ * Canonicalize a JSON-shaped value to a stable string per RFC 8785
+ * (subset). Sorting is by UTF-16 code unit order on object keys (the
+ * default `Array.prototype.sort()` order on strings, which matches the
+ * RFC for the BMP characters used in our payloads). Rejects NaN /
+ * Infinity / Date / BigInt / functions / symbols. `undefined` values
+ * are dropped from objects but rejected inside arrays.
+ *
+ * Exported for unit testing and advanced consumers.
+ */
+export function canonicalizeJcs(value: unknown): string {
+  return canonValue(value, /* insideArray */ false);
+}
+
+function canonValue(value: unknown, insideArray: boolean): string {
+  if (value === null) return "null";
+  if (value === undefined) {
+    if (insideArray) {
+      throw new TypeError("JCS: undefined is not a valid array element");
+    }
+    // Caller must drop undefined object entries before recursing.
+    throw new TypeError("JCS: undefined leaked into canonicalizer");
+  }
+  switch (typeof value) {
+    case "boolean":
+      return value ? "true" : "false";
+    case "number": {
+      if (!Number.isFinite(value)) {
+        throw new TypeError("JCS: non-finite number");
+      }
+      if (Number.isInteger(value) && Number.isSafeInteger(value)) {
+        return String(value);
+      }
+      // Acceptable for our schema (no floats are produced today).
+      return JSON.stringify(value);
+    }
+    case "string":
+      return canonString(value);
+    case "bigint":
+      throw new TypeError("JCS: bigint is not supported");
+    case "function":
+      throw new TypeError("JCS: function is not supported");
+    case "symbol":
+      throw new TypeError("JCS: symbol is not supported");
+    case "object":
+      if (value instanceof Date) {
+        throw new TypeError("JCS: Date is not supported (encode as ISO-8601 string)");
+      }
+      if (Array.isArray(value)) {
+        const parts = value.map((v) => canonValue(v, /* insideArray */ true));
+        return "[" + parts.join(",") + "]";
+      }
+      return canonObject(value as Record<string, unknown>);
+    default:
+      throw new TypeError(`JCS: unsupported type ${typeof value}`);
+  }
+}
+
+function canonString(s: string): string {
+  // Node's JSON.stringify is RFC 8785-compatible for the BMP escape
+  // forms we care about. Post-process U+2028 / U+2029 to their \u
+  // escapes (RFC 8785 does not require this, but it keeps the output
+  // safe to embed in any JSON-in-JS context).
+  const raw = JSON.stringify(s);
+  return raw.replace(LINE_SEP_RE, "\\u2028").replace(PARA_SEP_RE, "\\u2029");
+}
+
+function canonObject(obj: Record<string, unknown>): string {
+  // Drop entries whose value is `undefined`; sort keys by UTF-16
+  // code-unit order (default string sort).
+  const keys = Object.keys(obj)
+    .filter((k) => obj[k] !== undefined)
+    .sort();
+  const parts = keys.map(
+    (k) => canonString(k) + ":" + canonValue(obj[k], /* insideArray */ false),
+  );
+  return "{" + parts.join(",") + "}";
+}
+
+// ---------------------------------------------------------------------
+// base64url
+// ---------------------------------------------------------------------
+
+/** Padding-free base64url encoding (RFC 4648 §5). */
+export function base64UrlEncode(bytes: Uint8Array): string {
+  const b64 = Buffer.from(bytes).toString("base64");
+  return b64.replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/g, "");
+}
+
+// ---------------------------------------------------------------------
+// NoOpVcSigner
+// ---------------------------------------------------------------------
+
+export const DEFAULT_UNSIGNED_DID = "did:eto:indexer:unsigned:v0";
+
+/**
+ * Sentinel signer that returns a proof with `proofValue === ""`.
+ * Indexer wiring detects this and omits the `proof` key entirely from
+ * the emitted document, preserving the historical (v0) unsigned shape.
+ */
+export class NoOpVcSigner implements VcSigner {
+  public readonly issuerDid: string;
+  private readonly clock: () => Date;
+
+  public constructor(issuerDid: string = DEFAULT_UNSIGNED_DID, clock?: () => Date) {
+    this.issuerDid = issuerDid;
+    this.clock = clock ?? (() => new Date());
+  }
+
+  public async sign(
+    _vcWithoutProof: Record<string, unknown>,
+  ): Promise<Ed25519Signature2020Proof> {
+    return {
+      type: "Ed25519Signature2020",
+      created: this.clock().toISOString(),
+      verificationMethod: `${this.issuerDid}#key-1`,
+      proofPurpose: "assertionMethod",
+      proofValue: "",
+    };
+  }
+}
+
+// ---------------------------------------------------------------------
+// Ed25519VcSigner
+// ---------------------------------------------------------------------
+
+export interface Ed25519VcSignerInit {
+  issuerDid: string;
+  /** 32-byte Ed25519 seed (NOT the 64-byte expanded form). */
+  secretKey: Uint8Array;
+  /** Defaults to `() => new Date()`. */
+  clock?: () => Date;
+}
+
+export interface Ed25519VcSignerFromKeyFileOpts {
+  issuerDid: string;
+  clock?: () => Date;
+}
+
+const HEX_RE = /^[0-9a-fA-F]+$/;
+const BASE64_RE = /^[A-Za-z0-9+/_-]+={0,2}$/;
+
+function decodeKeyBytes(buf: Buffer): Uint8Array {
+  // 1) Raw 32 bytes.
+  if (buf.length === 32) {
+    return new Uint8Array(buf);
+  }
+  // 2) Text-encoded forms — try in order.
+  const text = buf.toString("utf8").trim().replace(/\s+/g, "");
+  // 2a) Hex (optional `0x` prefix). 64 hex chars → 32 bytes.
+  let candidate = text.startsWith("0x") || text.startsWith("0X") ? text.slice(2) : text;
+  if (candidate.length === 64 && HEX_RE.test(candidate)) {
+    return new Uint8Array(Buffer.from(candidate, "hex"));
+  }
+  // 2b) base64 / base64url.
+  if (BASE64_RE.test(text)) {
+    // Normalize base64url → base64.
+    const padded =
+      text.replace(/-/g, "+").replace(/_/g, "/") +
+      "===".slice((text.length + 3) % 4);
+    try {
+      const decoded = Buffer.from(padded, "base64");
+      if (decoded.length === 32) return new Uint8Array(decoded);
+    } catch {
+      // fall through to error below
+    }
+  }
+  throw new Error("expected 32-byte Ed25519 seed");
+}
+
+export class Ed25519VcSigner implements VcSigner {
+  public readonly issuerDid: string;
+  readonly #secretKey: Uint8Array;
+  readonly #clock: () => Date;
+
+  public constructor(init: Ed25519VcSignerInit) {
+    if (!(init.secretKey instanceof Uint8Array) || init.secretKey.length !== 32) {
+      throw new Error("expected 32-byte Ed25519 seed");
+    }
+    this.issuerDid = init.issuerDid;
+    // Defensive copy so callers can't mutate the secret post-construction.
+    this.#secretKey = new Uint8Array(init.secretKey);
+    this.#clock = init.clock ?? (() => new Date());
+  }
+
+  public static fromKeyFile(
+    path: string,
+    opts: Ed25519VcSignerFromKeyFileOpts,
+  ): Ed25519VcSigner {
+    const buf = readFileSync(path);
+    const secretKey = decodeKeyBytes(buf);
+    const init: Ed25519VcSignerInit = { issuerDid: opts.issuerDid, secretKey };
+    if (opts.clock) init.clock = opts.clock;
+    return new Ed25519VcSigner(init);
+  }
+
+  public async sign(
+    vcWithoutProof: Record<string, unknown>,
+  ): Promise<Ed25519Signature2020Proof> {
+    const canon = canonicalizeJcs(vcWithoutProof);
+    const digest = sha256(new TextEncoder().encode(canon));
+    const sig = await ed25519.signAsync(digest, this.#secretKey);
+    return {
+      type: "Ed25519Signature2020",
+      created: this.#clock().toISOString(),
+      verificationMethod: `${this.issuerDid}#key-1`,
+      proofPurpose: "assertionMethod",
+      proofValue: base64UrlEncode(sig),
+    };
+  }
+}
+
+// ---------------------------------------------------------------------
+// Env factory
+// ---------------------------------------------------------------------
+
+export interface CreateVcSignerFromEnvOpts {
+  issuerDid: string;
+  env?: NodeJS.ProcessEnv;
+  clock?: () => Date;
+}
+
+/**
+ * If `AUDIT_SIGNING_KEY_PATH` is set in the provided env (defaulting to
+ * `process.env`), load an `Ed25519VcSigner` from that key file.
+ * Otherwise return a `NoOpVcSigner` so the caller emits a byte-stable
+ * unsigned document.
+ */
+export function createVcSignerFromEnv(opts: CreateVcSignerFromEnvOpts): VcSigner {
+  const env = opts.env ?? process.env;
+  const path = env.AUDIT_SIGNING_KEY_PATH;
+  if (typeof path === "string" && path.length > 0) {
+    const fileOpts: Ed25519VcSignerFromKeyFileOpts = { issuerDid: opts.issuerDid };
+    if (opts.clock) fileOpts.clock = opts.clock;
+    return Ed25519VcSigner.fromKeyFile(path, fileOpts);
+  }
+  return opts.clock
+    ? new NoOpVcSigner(opts.issuerDid, opts.clock)
+    : new NoOpVcSigner(opts.issuerDid);
+}

--- a/src/tools/a2a.ts
+++ b/src/tools/a2a.ts
@@ -158,24 +158,64 @@ export function registerA2ATools(server: McpServer): void {
 
   server.tool(
     "send_a2a_message",
-    "[Not yet available] Send a message to another agent via the A2A SendMessage instruction. ETO's A2A is a task-based protocol: messages live inside a Task (created with CreateTask) between two AgentCards, not in free-standing channels. This tool is pending redesign for the task-based flow. For now, use create_a2a_channel to register your AgentCard and call_contract / cross-VM dispatch for direct agent-to-agent interaction.",
+    "Returns guidance for sending an interim agent-to-agent message by piggy-backing on `transfer_native` with a structured memo. The real CreateTask/SendMessage A2A flow is tracked in PR #5 (github.com/etofdn/eto-mcp/pull/5) and milestone FN-054; until it lands, this tool documents the bridge pattern (a tiny `transfer_native` carrying a `{type:\"a2a_message\",...}` memo) and emits a copy-pasteable example. Pass optional `to` (recipient agent_id / SVM address) and `body` (any JSON) to have them interpolated into the example. Legacy params `channel_id`, `message`, `priority` are accepted and ignored for backward compatibility.",
     {
-      channel_id: z.string().optional().describe("(legacy) ignored"),
-      message: z.any().optional().describe("(legacy) ignored"),
-      priority: z.enum(["normal", "high"]).optional().describe("(legacy) ignored"),
+      channel_id: z.string().optional().describe("(legacy) ignored — kept for backward compatibility"),
+      message: z.any().optional().describe("(legacy) ignored — kept for backward compatibility"),
+      priority: z.enum(["normal", "high"]).optional().describe("(legacy) ignored — kept for backward compatibility"),
+      to: z.string().optional().describe("Recipient agent_id / SVM address; interpolated into the example if provided"),
+      body: z.any().optional().describe("Message body (any JSON); interpolated into the example if provided"),
     },
-    async () => {
+    async ({ to, body }) => {
+      const recipient = to ?? "<recipient_svm_address>";
+      const bodyJson = body !== undefined ? JSON.stringify(body) : "<your json body>";
+      const memoObj = `{"type":"a2a_message","to":"${recipient}","body":${bodyJson},"nonce":"<uuid>","ts":<unix_ms>}`;
+
+      const example = [
+        "transfer_native({",
+        `  to: "${recipient}",`,
+        '  amount: "0.000001",',
+        '  unit: "sol",',
+        `  memo: ${JSON.stringify(memoObj)}`,
+        "})",
+      ].join("\n");
+
+      const text = [
+        "send_a2a_message — interim bridge pattern (NOT the final A2A protocol)",
+        "",
+        "This response documents how to send an agent-to-agent message today by",
+        "piggy-backing on `transfer_native` with a structured SPL Memo. The real",
+        "on-chain CreateTask + SendMessage flow is tracked in PR #5 and will",
+        "replace this bridge once shipped.",
+        "",
+        "Memo schema (JSON, anchored via SPL Memo Program v2):",
+        '  {"type":"a2a_message","to":"<agent_id>","body":<json>}',
+        "  Recommended fields: `nonce` (uuid, dedupe) and `ts` (unix ms, ordering).",
+        "",
+        "Bridge call example (paste into your MCP client):",
+        example,
+        "",
+        "The receiver polls inbound memos with `query_memos` / `get_account_transactions`",
+        "and filters for `type == \"a2a_message\"` addressed to its agent_id.",
+        "",
+        "Limitations:",
+        "  (a) Costs SOL/gas per message (a real on-chain transfer + memo).",
+        "  (b) No delivery guarantee — receiver must poll; no push.",
+        "  (c) No escrow — unlike CreateTask, funds are not held pending completion.",
+        "  (d) No read-receipt — sender cannot tell if the receiver consumed the memo.",
+        "  (e) Memo size limit ~566 bytes (SPL Memo Program v2 cap); keep bodies tiny.",
+        "  (f) Plaintext on-chain — anyone can read the memo. Encrypt sensitive payloads.",
+        "",
+        "Future replacement:",
+        "  When CreateTask + SendMessage tools land (github.com/etofdn/eto-mcp/pull/5,",
+        "  milestone FN-054), this tool will be re-wired to invoke them directly and",
+        "  the bridge pattern can be retired. Memos written today using",
+        '  `{"type":"a2a_message"}` remain queryable via `query_memos`, so messages',
+        "  sent via the bridge are not lost when the real protocol lands.",
+      ].join("\n");
+
       return {
-        content: [{ type: "text" as const, text:
-          "send_a2a_message is pending redesign for ETO's task-based A2A protocol.\n\n" +
-          "Current protocol flow:\n" +
-          "  1. Sender + receiver each register AgentCards via create_a2a_channel\n" +
-          "  2. Sender creates a Task for the receiver (CreateTask variant — not yet exposed)\n" +
-          "  3. SendMessage writes a Message PDA scoped to the Task\n" +
-          "  4. CompleteTask releases escrow to the receiver\n\n" +
-          "Track status: github.com/etofdn/eto-mcp/pull/5"
-        }],
-        isError: true,
+        content: [{ type: "text" as const, text }],
       };
     }
   );

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -15,6 +15,7 @@ const TOOL_CAPS: Record<string, { cap: string; rate: "read" | "write" | "deploy"
   get_chain_stats:        { cap: "chain:read",      rate: "read" },
   get_block_height:       { cap: "block:read",      rate: "read" },
   get_account_transactions: { cap: "account:read",  rate: "read" },
+  query_memos:            { cap: "account:read",    rate: "read" },
   // Validator tools (read)
   list_validators:        { cap: "validator:read",  rate: "read" },
   get_epoch_info:         { cap: "validator:read",  rate: "read" },
@@ -206,8 +207,8 @@ import { registerBankingTools } from "./banking-tools.js";
 
 export function registerAllTools(server: McpServer): void {
   instrumentServer(server);
-  // Phase 1 (48 tools)
-  registerQueryTools(server);       // 8 tools
+  // Phase 1 (49 tools)
+  registerQueryTools(server);       // 9 tools
   registerValidatorTools(server);   // 3 tools
   registerDevnetTools(server);      // 2 tools
   registerWalletTools(server);      // 6 tools
@@ -234,5 +235,5 @@ export function registerAllTools(server: McpServer): void {
   registerBecknFlowTools(server);   // 5 tools: beckn_search/select/init/confirm/rate
   registerCredentialTools(server);  // 4 tools: credential_request/attach/verify/revoke
   registerBankingTools(server);     // 5 tools: bank_open_checking/onramp/offramp/wire/transfer_funds
-  // Total: 95 tools
+  // Total: 96 tools
 }

--- a/src/tools/query.ts
+++ b/src/tools/query.ts
@@ -3,6 +3,11 @@ import { z } from "zod";
 import { rpc } from "../read/rpc-client.js";
 import { lamportsToSol } from "../utils/units.js";
 import { detectAddressType } from "../utils/address.js";
+import {
+  extractMemosFromLogs,
+  parseMemoPayload,
+  matchesFilter,
+} from "../utils/memo-parse.js";
 
 export function registerQueryTools(server: McpServer): void {
   server.tool(
@@ -382,6 +387,102 @@ export function registerQueryTools(server: McpServer): void {
         }
 
         return { content: [{ type: "text", text: lines.join("\n") }] };
+      } catch (err: any) {
+        return {
+          content: [{ type: "text", text: `Error: ${err.message}` }],
+          isError: true,
+        };
+      }
+    }
+  );
+
+  server.tool(
+    "query_memos",
+    "Parse SPL Memo Program v2 records from on-chain transaction logs for an account. Optionally filter by a top-level JSON field equality match; non-JSON memo bytes are returned as raw strings.",
+    {
+      address: z.string().describe("Account address (base58 SVM or 0x EVM)"),
+      filter_field: z
+        .string()
+        .optional()
+        .describe("Top-level JSON field to filter memos on (string equality)"),
+      filter_value: z
+        .string()
+        .optional()
+        .describe("Value to match (compared via String() coercion)"),
+      limit: z
+        .number()
+        .int()
+        .min(1)
+        .max(100)
+        .default(20)
+        .optional()
+        .describe("Max transactions to scan (1-100, default 20)"),
+      offset: z
+        .number()
+        .int()
+        .min(0)
+        .default(0)
+        .optional()
+        .describe("Pagination offset into the account's tx history (default 0)"),
+    },
+    async ({ address, filter_field, filter_value, limit, offset }) => {
+      try {
+        const txs = await rpc.etoGetAccountTransactions(
+          address,
+          limit ?? 20,
+          offset ?? 0
+        );
+
+        const list = Array.isArray(txs) ? txs : [];
+
+        // The list endpoint may not include logs — fetch the full tx in
+        // parallel only when the summary entry lacks them.
+        const fullTxs = await Promise.all(
+          list.map(async (tx: any) => {
+            if (Array.isArray(tx?.logs)) return tx;
+            const sig = tx?.signature ?? tx?.hash;
+            if (!sig) return tx;
+            try {
+              const full = await rpc.etoGetTransaction(sig);
+              return full ?? tx;
+            } catch {
+              return tx;
+            }
+          })
+        );
+
+        const records: Array<{ sig: string; ts: number | null; memo: unknown }> = [];
+        for (let i = 0; i < fullTxs.length; i++) {
+          const fullTx = fullTxs[i] ?? {};
+          const summary = list[i] ?? {};
+          const sig =
+            fullTx.signature ?? fullTx.hash ?? summary.signature ?? summary.hash ?? "";
+          const ts =
+            fullTx.blockTime ??
+            fullTx.timestamp ??
+            summary.blockTime ??
+            summary.timestamp ??
+            null;
+          const memos = extractMemosFromLogs(fullTx.logs);
+          for (const raw of memos) {
+            const parsed = parseMemoPayload(raw);
+            if (!matchesFilter(parsed, filter_field, filter_value)) continue;
+            records.push({ sig, ts, memo: parsed });
+          }
+        }
+
+        return {
+          content: [
+            {
+              type: "text",
+              text: JSON.stringify(
+                { address, count: records.length, records },
+                null,
+                2
+              ),
+            },
+          ],
+        };
       } catch (err: any) {
         return {
           content: [{ type: "text", text: `Error: ${err.message}` }],

--- a/src/utils/memo-parse.ts
+++ b/src/utils/memo-parse.ts
@@ -1,0 +1,118 @@
+/**
+ * SPL Memo Program v2 log parsing helpers.
+ *
+ * The SPL Memo Program (`MemoSq4gqABAXKb96qnH8TysNcWxMyWCqXgDLGmfcHr`) emits
+ * the memo bytes as a UTF-8 string in the transaction's program logs. There
+ * are two log shapes we encounter in practice from the validator runtime:
+ *
+ *   1. The canonical Solana validator format:
+ *        Program <MEMO_PROGRAM_ID> invoke [N]
+ *        Program log: Memo (len <N>): "<json-escaped payload>"
+ *        Program <MEMO_PROGRAM_ID> success
+ *
+ *   2. A simpler fallback some runtimes use, where the memo body is logged
+ *      directly on the line immediately following the invoke:
+ *        Program <MEMO_PROGRAM_ID> invoke [N]
+ *        Program log: <raw payload>
+ *        Program <MEMO_PROGRAM_ID> success
+ *
+ * These helpers are pure (no I/O, no wasm imports) so they can be unit-tested
+ * cheaply and reused outside of the MCP tool surface.
+ */
+
+/**
+ * Base58 program ID for the SPL Memo Program v2. Re-declared locally so this
+ * file remains free of any dependency on `src/wasm/index.ts` and its build
+ * artifacts.
+ */
+export const MEMO_PROGRAM_ID_BS58 =
+  "MemoSq4gqABAXKb96qnH8TysNcWxMyWCqXgDLGmfcHr";
+
+const INVOKE_RE = new RegExp(
+  `^Program\\s+${MEMO_PROGRAM_ID_BS58}\\s+invoke\\s+\\[\\d+\\]\\s*$`
+);
+const PROGRAM_LOG_PREFIX = "Program log: ";
+const MEMO_LEN_RE = /^Memo \(len \d+\): "((?:\\.|[^"\\])*)"\s*$/;
+
+/**
+ * Extract memo payloads (as raw UTF-8 strings — not yet JSON-parsed) from a
+ * transaction's program log array. Returns an empty array for `undefined`,
+ * empty input, or logs containing no memo program invocation. Memos are
+ * returned in the order they appear in the log stream.
+ *
+ * Recognises both the `Program log: Memo (len N): "..."` validator format
+ * (JSON-unescaping the quoted payload) and the bare `Program log: <text>`
+ * fallback that appears on some runtimes immediately after a memo program
+ * invoke line.
+ */
+export function extractMemosFromLogs(logs: string[] | undefined): string[] {
+  if (!logs || logs.length === 0) return [];
+  const out: string[] = [];
+  let armed = false; // true between a memo-program invoke and the next success/failure
+  for (const line of logs) {
+    if (INVOKE_RE.test(line)) {
+      armed = true;
+      continue;
+    }
+    if (line.startsWith(PROGRAM_LOG_PREFIX)) {
+      const body = line.slice(PROGRAM_LOG_PREFIX.length);
+      const m = MEMO_LEN_RE.exec(body);
+      if (m) {
+        // JSON-unescape the quoted payload by re-wrapping it as a JSON string.
+        try {
+          out.push(JSON.parse(`"${m[1]}"`));
+        } catch {
+          out.push(m[1]);
+        }
+        armed = false;
+        continue;
+      }
+      if (armed) {
+        out.push(body);
+        armed = false;
+        continue;
+      }
+    }
+    // Any other line (e.g. `Program ... success`, `Program ... consumed N of M`)
+    // closes the armed window without producing a memo.
+    if (line.startsWith("Program ") && !line.startsWith(PROGRAM_LOG_PREFIX)) {
+      armed = false;
+    }
+  }
+  return out;
+}
+
+/**
+ * Parse a memo payload as JSON when possible. Returns the parsed value on
+ * success, or the raw input string unchanged on any parse failure. Never
+ * throws — non-JSON memos must round-trip back to the caller untouched.
+ */
+export function parseMemoPayload(raw: string): unknown {
+  try {
+    return JSON.parse(raw);
+  } catch {
+    return raw;
+  }
+}
+
+/**
+ * Top-level JSON field equality filter. Returns `true` when both `field` and
+ * `value` are `undefined` (no filter applied). Otherwise `true` only when
+ * `parsed` is a non-array object whose `field` property coerces to `value`
+ * via `String(...)`. Strings, numbers, arrays, `null`, and missing fields all
+ * return `false` when a filter is active.
+ */
+export function matchesFilter(
+  parsed: unknown,
+  field?: string,
+  value?: string
+): boolean {
+  if (field === undefined && value === undefined) return true;
+  if (field === undefined || value === undefined) return false;
+  if (parsed === null || typeof parsed !== "object" || Array.isArray(parsed)) {
+    return false;
+  }
+  const v = (parsed as Record<string, unknown>)[field];
+  if (v === undefined) return false;
+  return String(v) === value;
+}

--- a/test/skill-cert.test.ts
+++ b/test/skill-cert.test.ts
@@ -235,19 +235,31 @@ describe("SkillCertIssuer.issue — happy path (AC: whitelist + per-(subject,ski
     expect(stored?.credentialPda).toBe(res.credentialPda);
   });
 
-  it("claim_hash matches sha256(JCS(envelope))", async () => {
+  it("claim_hash matches sha256(JCS(envelope-with-claimCommitments))", async () => {
     const { issuer, deps } = makeIssuer({ now: () => 1_700_000_000_000 });
     const res = await issuer.issue({
       skill: SKILL,
       subjectAgentCard: SUBJECT_A,
     });
-    const expectedClaim = buildSkillCertClaim({
+    // Per FN-077 / §10.3.1, the on-chain claim_hash binds the
+    // `claimCommitments` array. Those commitments are CSPRNG-salted
+    // so we cannot regenerate them deterministically here — instead
+    // we rehash the actual pinned envelope (which the verifier sees
+    // off-chain via the claim_uri) and assert hash equality.
+    expect(res.claimHash).toBe(defaultClaimHasher.hash(deps.ipfs.pinned[0]));
+    const pinnedVc = deps.ipfs.pinned[0] as Record<string, unknown>;
+    const baseClaim = buildSkillCertClaim({
       issuerDid: ISSUER_DID,
       skill: SKILL,
       subjectAgentCard: SUBJECT_A,
       issuanceDate: new Date(1_700_000_000_000).toISOString(),
     });
-    expect(res.claimHash).toBe(defaultClaimHasher.hash(expectedClaim));
+    // The pinned VC equals the rebuilt envelope plus claimCommitments.
+    expect({ ...pinnedVc, claimCommitments: undefined }).toMatchObject({
+      ...baseClaim,
+      claimCommitments: undefined,
+    });
+    expect(Array.isArray(pinnedVc.claimCommitments)).toBe(true);
     expect(deps.ipfs.pinned).toHaveLength(1);
   });
 });

--- a/tests/bank/card.test.ts
+++ b/tests/bank/card.test.ts
@@ -1,43 +1,255 @@
 /**
- * Card auth flow test stubs — FN-128 (T-3.12.1.5)
+ * Card auth flow tests — FN-128 / FN-078.
  * Mission: E12: Cards
  *
  * Acceptance criteria: Auth → balance debit on chain.
  *
- * Dependencies that must land before these stubs can be filled in:
- *   - T-3.12.1.3 (card issue flow, FN-003): produces an `account.card`
- *     credential bound to the holder's checking account. Until that
- *     work lands, there is no card-issue handler to call and no
- *     credential schema to reference here.
- *   - keeper/bpps/bank/catalog.json must gain a `card-auth` service
- *     entry (and the corresponding BPP handler) so a card-auth tx can
- *     be submitted and the resulting on-chain checking_account.balance
- *     can be read back.
+ * Test coverage (5 cases):
+ *   1. Issue card → produces an `account.card` credential bound to holder.
+ *   2. Auth with sufficient balance → debits checking account on chain.
+ *   3. Auth with insufficient balance → declines, leaves balance unchanged.
+ *   4. Multiple sequential auths debit additively.
+ *   5. Replay-protected: same auth_id rejected on second submission.
  *
- * Once T-3.12.1.3 is merged, replace each `test.todo` with a real test
- * following this pattern:
- *   1. Set up: open checking account with initial balance, issue card
- *      credential via the card-issue BPP handler.
- *   2. Submit a card-auth tx via the bank BPP (amount, auth_id, holder).
- *   3. Read the on-chain checking_account.balance.
- *   4. Assert: balance === initial - amount.
- *   5. Assert: a card_auth_event was emitted with (auth_id, amount, holder).
+ * Each test sets up a fresh MockChainState, opens a checking account with a
+ * known balance, issues a card credential via `issueCard`, and submits one or
+ * more `submitCardAuth` calls (which simulates the on-chain `card_auth`
+ * instruction — FN-126 — that will eventually move from this mock into a
+ * real keeper handler).
  */
 
-import { describe, test } from "vitest";
+import { describe, expect, test } from "vitest";
+
+import {
+  issueCard,
+  IssueCardRejected,
+} from "../../keeper/bpps/bank/handlers/issue-card.js";
+import {
+  openChecking,
+  REQUIRED_SCHEMAS,
+} from "../../keeper/bpps/bank/handlers/open-checking.js";
+
+import {
+  BANK_ISSUER_PUBKEY,
+  CardAuthError,
+  HOLDER_PUBKEY,
+  ONE_EUSD,
+  makeInitialState,
+  makeIssueCardDeps,
+  makeOpenCheckingDeps,
+  submitCardAuth,
+  type MockChainState,
+} from "./fixtures.js";
+
+/* -------------------------------------------------------------------------- */
+/* Helpers                                                                    */
+/* -------------------------------------------------------------------------- */
+
+const HOLDER_CRED_SCHEMAS = new Set<string>(REQUIRED_SCHEMAS);
+
+/**
+ * Set up a checking account with `openingBalance` (atomic eUSD) and issue a
+ * card credential bound to the holder. Returns the populated state and the
+ * `issueCard` result.
+ */
+async function setupIssuedCard(openingBalance: bigint): Promise<{
+  state: MockChainState;
+  cardPda: string;
+  credentialPda: string;
+}> {
+  const state = makeInitialState();
+
+  await openChecking(
+    {
+      subject: HOLDER_PUBKEY,
+      bank_issuer: BANK_ISSUER_PUBKEY,
+      opened_slot: 1000,
+      opening_deposit_atomic: Number(openingBalance),
+    },
+    makeOpenCheckingDeps(state, HOLDER_CRED_SCHEMAS),
+  );
+
+  const result = await issueCard(
+    {
+      subject: HOLDER_PUBKEY,
+      bank_issuer: BANK_ISSUER_PUBKEY,
+      linked_account_pda: state.checkingPda!,
+      issued_slot: 1100,
+    },
+    makeIssueCardDeps(state),
+  );
+
+  return {
+    state,
+    cardPda: result.card_pda,
+    credentialPda: state.cardCredentialPda!,
+  };
+}
+
+/* -------------------------------------------------------------------------- */
+/* Tests                                                                      */
+/* -------------------------------------------------------------------------- */
 
 describe("card auth flow (FN-128)", () => {
-  test.todo("issue card → produces account.card credential bound to holder");
+  test("issue card → produces account.card credential bound to holder", async () => {
+    const state = makeInitialState();
 
-  test.todo(
-    "auth $X with sufficient balance → debits checking account on chain",
-  );
+    await openChecking(
+      {
+        subject: HOLDER_PUBKEY,
+        bank_issuer: BANK_ISSUER_PUBKEY,
+        opened_slot: 1000,
+        opening_deposit_atomic: 0,
+      },
+      makeOpenCheckingDeps(state, HOLDER_CRED_SCHEMAS),
+    );
 
-  test.todo(
-    "auth $X with insufficient balance → declines, leaves balance unchanged",
-  );
+    const result = await issueCard(
+      {
+        subject: HOLDER_PUBKEY,
+        bank_issuer: BANK_ISSUER_PUBKEY,
+        linked_account_pda: state.checkingPda!,
+        issued_slot: 1100,
+      },
+      makeIssueCardDeps(state),
+    );
 
-  test.todo("multiple sequential auths debit additively");
+    // (a) returned card_pda is a non-null hex64 string and recorded on chain.
+    expect(result.card_pda).toMatch(/^[0-9a-f]{64}$/);
+    expect(state.cardPda).toBe(result.card_pda);
 
-  test.todo("replay-protected: same auth_id rejected on second submission");
+    // (b) credential PDA is non-null (recorded by the on-chain stub).
+    expect(state.cardCredentialPda).not.toBeNull();
+    expect(state.cardCredentialPda).toMatch(/^[0-9a-f]{64}$/);
+
+    // (c) credential is bound to the holder via subject + body.holder, and
+    // linked to the holder's checking account PDA.
+    expect(result.credential.schema).toBe("card.debit.us.v1");
+    expect(result.credential.subject).toBe(HOLDER_PUBKEY);
+    expect(result.credential.body.holder).toBe(HOLDER_PUBKEY);
+    expect(result.credential.body.linked_account_pda).toBe(state.checkingPda);
+
+    // (d) credential issuer is the bank.
+    expect(result.credential.issuer).toBe(BANK_ISSUER_PUBKEY);
+
+    // (e) issuing without a checking account → account_not_found.
+    const stateNoAccount = makeInitialState();
+    await expect(
+      issueCard(
+        {
+          subject: HOLDER_PUBKEY,
+          bank_issuer: BANK_ISSUER_PUBKEY,
+          linked_account_pda: "f".repeat(64),
+          issued_slot: 1100,
+        },
+        makeIssueCardDeps(stateNoAccount),
+      ),
+    ).rejects.toBeInstanceOf(IssueCardRejected);
+  });
+
+  test("auth $X with sufficient balance → debits checking account on chain", async () => {
+    const initialBalance = 100n * ONE_EUSD;
+    const authAmount = 25n * ONE_EUSD;
+
+    const { state } = await setupIssuedCard(initialBalance);
+    expect(state.checkingBalance).toBe(initialBalance);
+
+    const result = submitCardAuth(state, {
+      auth_id: "auth-001",
+      amount: authAmount,
+      holder: HOLDER_PUBKEY,
+    });
+
+    // On-chain checking_account.balance is debited.
+    expect(state.checkingBalance).toBe(initialBalance - authAmount);
+    expect(result.new_balance).toBe(initialBalance - authAmount);
+
+    // card_auth_event emitted with (auth_id, amount, holder).
+    expect(state.cardAuthEvents).toEqual([
+      { auth_id: "auth-001", amount: authAmount, holder: HOLDER_PUBKEY },
+    ]);
+    expect(state.usedCardAuthIds.has("auth-001")).toBe(true);
+  });
+
+  test("auth $X with insufficient balance → declines, leaves balance unchanged", async () => {
+    const initialBalance = 10n * ONE_EUSD;
+    const authAmount = 50n * ONE_EUSD; // > balance
+
+    const { state } = await setupIssuedCard(initialBalance);
+
+    expect(() =>
+      submitCardAuth(state, {
+        auth_id: "auth-bad",
+        amount: authAmount,
+        holder: HOLDER_PUBKEY,
+      }),
+    ).toThrow(CardAuthError);
+
+    // Balance unchanged on-chain.
+    expect(state.checkingBalance).toBe(initialBalance);
+    // No event emitted.
+    expect(state.cardAuthEvents).toEqual([]);
+    // auth_id was NOT consumed (so it can be retried after a deposit).
+    expect(state.usedCardAuthIds.has("auth-bad")).toBe(false);
+  });
+
+  test("multiple sequential auths debit additively", async () => {
+    const initialBalance = 100n * ONE_EUSD;
+    const amounts = [10n * ONE_EUSD, 25n * ONE_EUSD, 7n * ONE_EUSD];
+    const total = amounts.reduce((a, b) => a + b, 0n);
+    expect(total).toBeLessThan(initialBalance); // sanity
+
+    const { state } = await setupIssuedCard(initialBalance);
+
+    amounts.forEach((amount, i) => {
+      submitCardAuth(state, {
+        auth_id: `auth-seq-${i}`,
+        amount,
+        holder: HOLDER_PUBKEY,
+      });
+    });
+
+    // Final on-chain balance = initial - sum.
+    expect(state.checkingBalance).toBe(initialBalance - total);
+
+    // 3 events, in order, with matching amounts.
+    expect(state.cardAuthEvents).toHaveLength(3);
+    expect(state.cardAuthEvents.map((e) => e.amount)).toEqual(amounts);
+    expect(state.usedCardAuthIds.size).toBe(3);
+  });
+
+  test("replay-protected: same auth_id rejected on second submission", async () => {
+    const initialBalance = 100n * ONE_EUSD;
+    const authAmount = 5n * ONE_EUSD;
+
+    const { state } = await setupIssuedCard(initialBalance);
+
+    // First submission succeeds.
+    submitCardAuth(state, {
+      auth_id: "auth-replay",
+      amount: authAmount,
+      holder: HOLDER_PUBKEY,
+    });
+    expect(state.checkingBalance).toBe(initialBalance - authAmount);
+    expect(state.cardAuthEvents).toHaveLength(1);
+
+    // Second submission with the same auth_id is rejected.
+    let err: unknown;
+    try {
+      submitCardAuth(state, {
+        auth_id: "auth-replay",
+        amount: authAmount,
+        holder: HOLDER_PUBKEY,
+      });
+    } catch (e) {
+      err = e;
+    }
+    expect(err).toBeInstanceOf(CardAuthError);
+    expect((err as CardAuthError).reason).toBe("replay");
+
+    // Balance was NOT debited a second time.
+    expect(state.checkingBalance).toBe(initialBalance - authAmount);
+    // Only the original event remains.
+    expect(state.cardAuthEvents).toHaveLength(1);
+  });
 });

--- a/tests/bank/credential-schemas.test.ts
+++ b/tests/bank/credential-schemas.test.ts
@@ -1,0 +1,133 @@
+/**
+ * FN-200 — banking credential JSON-LD templates.
+ *
+ * Verifies that each schema in `spec/banking/credentials/` is a syntactically
+ * valid JSON Schema 2020-12 document, declares the §10.3.1 `claimCommitments`
+ * block, and that its embedded `examples[]` envelope validates against the
+ * schema. The example claimCommitments are real Poseidon-2 outputs from
+ * FN-082's `eto-zk-cli commit` (BN254 Fr, t=3) and so the per-entry
+ * `commitment`/`saltCommitment` patterns are also exercised here.
+ */
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+// ajv ships its 2020-12 entrypoint via /dist/2020 — the same loader used by
+// `src/gateway/beckn-schemas.ts` would not pick this up.
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-expect-error - subpath export, no bundled types
+import Ajv2020 from "ajv/dist/2020.js";
+import addFormats from "ajv-formats";
+import { computeClaimCommitments } from "../../src/issuers/claim-commitments.js";
+
+const TEMPLATES = [
+  "account-checking",
+  "account-savings",
+  "card-debit",
+  "tax-1099",
+] as const;
+
+const SPEC_DIR = resolve(__dirname, "../../spec/banking/credentials");
+
+describe("FN-200 spec/banking/credentials JSON-LD templates", () => {
+  for (const name of TEMPLATES) {
+    describe(`${name}.json`, () => {
+      const file = resolve(SPEC_DIR, `${name}.json`);
+      const schema = JSON.parse(readFileSync(file, "utf8"));
+
+      it("declares @context, type, credentialSubject, and claimCommitments", () => {
+        expect(schema.required).toContain("@context");
+        expect(schema.required).toContain("type");
+        expect(schema.required).toContain("credentialSubject");
+        expect(schema.required).toContain("claimCommitments");
+
+        expect(schema.properties).toHaveProperty("@context");
+        expect(schema.properties).toHaveProperty("type");
+        expect(schema.properties).toHaveProperty("credentialSubject");
+        expect(schema.properties).toHaveProperty("claimCommitments");
+
+        // Per-entry shape per §10.3.1.
+        const item = schema.properties.claimCommitments.items;
+        expect(item.required).toEqual(
+          expect.arrayContaining([
+            "fieldPath",
+            "idx",
+            "commitment",
+            "saltCommitment",
+          ]),
+        );
+      });
+
+      it("ships at least one worked example with real Poseidon-2 commitments", () => {
+        expect(Array.isArray(schema.examples)).toBe(true);
+        expect(schema.examples.length).toBeGreaterThan(0);
+        const ex = schema.examples[0];
+        expect(Array.isArray(ex.claimCommitments)).toBe(true);
+        // Issuers MUST emit one entry per credentialSubject leaf field, sorted
+        // lexicographically by full dotted path.
+        const subjectLeafCount = Object.keys(ex.credentialSubject).length;
+        expect(ex.claimCommitments.length).toBe(subjectLeafCount);
+        const paths = ex.claimCommitments.map(
+          (c: { fieldPath: string }) => c.fieldPath,
+        );
+        const sorted = [...paths].sort();
+        expect(paths).toEqual(sorted);
+        for (let i = 0; i < ex.claimCommitments.length; i++) {
+          const c = ex.claimCommitments[i];
+          expect(c.idx).toBe(i);
+          expect(c.fieldPath.startsWith("credentialSubject.")).toBe(true);
+          expect(c.commitment).toMatch(/^[0-9a-f]{64}$/);
+          expect(c.saltCommitment).toMatch(/^[0-9a-f]{64}$/);
+        }
+      });
+
+      it("computeClaimCommitments re-derives an array that satisfies the schema for example.credentialSubject", () => {
+        // FN-077: regenerate the per-leaf commitments via the TS
+        // production primitive against the example's `credentialSubject`.
+        // The salt is randomised so the hex bytes won't equal the
+        // pre-baked example values, but the *shape* (entry count,
+        // lex-sorted fieldPaths, idx assignments, hex64 patterns) MUST
+        // match the schema's `claimCommitments` declaration.
+        const ex = schema.examples[0];
+        const reDerived = computeClaimCommitments(
+          ex.credentialSubject as Record<string, unknown>,
+        );
+        expect(reDerived.length).toBe(ex.claimCommitments.length);
+        for (let i = 0; i < reDerived.length; i++) {
+          expect(reDerived[i].fieldPath).toBe(ex.claimCommitments[i].fieldPath);
+          expect(reDerived[i].idx).toBe(i);
+          expect(reDerived[i].commitment).toMatch(/^[0-9a-f]{64}$/);
+          expect(reDerived[i].saltCommitment).toMatch(/^[0-9a-f]{64}$/);
+        }
+        // Build a synthetic example replacing claimCommitments with
+        // the freshly-derived array and assert it still validates.
+        const ajv = new Ajv2020({ strict: false, allErrors: true });
+        addFormats(ajv);
+        const validate = ajv.compile(schema);
+        const synthetic = { ...ex, claimCommitments: reDerived };
+        const ok = validate(synthetic);
+        if (!ok) {
+          throw new Error(
+            `${name}.json synthetic example failed validation: ${JSON.stringify(validate.errors, null, 2)}`,
+          );
+        }
+        expect(ok).toBe(true);
+      });
+
+      it("schema validates its own examples", () => {
+        const ajv = new Ajv2020({ strict: false, allErrors: true });
+        addFormats(ajv);
+        const validate = ajv.compile(schema);
+        for (const ex of schema.examples) {
+          const ok = validate(ex);
+          if (!ok) {
+            // Surface ajv errors in the failure message.
+            throw new Error(
+              `${name}.json example failed validation: ${JSON.stringify(validate.errors, null, 2)}`,
+            );
+          }
+          expect(ok).toBe(true);
+        }
+      });
+    });
+  }
+});

--- a/tests/bank/fixtures.ts
+++ b/tests/bank/fixtures.ts
@@ -31,6 +31,11 @@ import type {
   WireKind,
 } from "../../keeper/bpps/bank/handlers/wire.js";
 import type {
+  IssueCardDeps,
+  IssueCardCredential,
+  CardDebitCredentialBody,
+} from "../../keeper/bpps/bank/handlers/issue-card.js";
+import type {
   SavingsAccount,
   YieldDeps,
 } from "../../keeper/bpps/bank/yield.js";
@@ -111,6 +116,17 @@ export interface MockChainState {
 
   /** Wire IDs that have been locked. */
   lockedWireIds: Set<string>;
+
+  /** Issued card.debit credential PDA, null until issued. */
+  cardCredentialPda: string | null;
+  /** Issued card PDA, null until issued. */
+  cardPda: string | null;
+  /** Issued card credential body, null until issued. */
+  cardCredential: IssueCardCredential | null;
+  /** Card auth IDs already consumed (replay protection). */
+  usedCardAuthIds: Set<string>;
+  /** Card auth events emitted on-chain (auth_id, amount, holder). */
+  cardAuthEvents: Array<{ auth_id: string; amount: bigint; holder: string }>;
 }
 
 /** Create a fresh mock chain state with holder pre-seeded with eUSD. */
@@ -135,6 +151,12 @@ export function makeInitialState(): MockChainState {
     savingsCredential: null,
 
     lockedWireIds: new Set(),
+
+    cardCredentialPda: null,
+    cardPda: null,
+    cardCredential: null,
+    usedCardAuthIds: new Set(),
+    cardAuthEvents: [],
   };
 }
 
@@ -351,6 +373,121 @@ export function makeWireDeps(state: MockChainState): WireDeps {
       const tx_signature = detSig("refund", wire_id);
       return { tx_signature };
     },
+  };
+}
+
+/* -------------------------------------------------------------------------- */
+/* Issue-card handler deps                                                    */
+/* -------------------------------------------------------------------------- */
+
+/**
+ * Build `issueCard` deps that read/write to `state`.
+ *
+ * `hasRequiredCreds` controls whether `verifyHolderCredentials` succeeds.
+ */
+export function makeIssueCardDeps(
+  state: MockChainState,
+  hasRequiredCreds: () => boolean = () => true,
+): IssueCardDeps {
+  return {
+    verifyHolderCredentials: async (_subject, _schemas) => hasRequiredCreds(),
+    verifyLinkedAccount: async (linked_account_pda, holder) => {
+      return (
+        state.checkingPda === linked_account_pda &&
+        state.checkingHolder === holder
+      );
+    },
+    issueCardCredential: async (cred) => {
+      state.cardCredential = cred;
+      const tx_signature = detSig("card-cred", cred.body.card_id_hash);
+      const credential_pda = detSig("card-cred-pda", cred.body.card_id_hash);
+      state.cardCredentialPda = credential_pda;
+      return { tx_signature, credential_pda };
+    },
+    recordCard: async (pda, _card: CardDebitCredentialBody) => {
+      state.cardPda = pda;
+    },
+    flagReconciliation: async (_pda, _holder, _body) => {
+      // no-op in tests
+    },
+  };
+}
+
+/* -------------------------------------------------------------------------- */
+/* Simulated on-chain CardAuth instruction                                    */
+/* -------------------------------------------------------------------------- */
+
+export class CardAuthError extends Error {
+  constructor(
+    public readonly reason:
+      | "no_card"
+      | "holder_mismatch"
+      | "insufficient_balance"
+      | "replay",
+  ) {
+    super(`card-auth rejected: ${reason}`);
+  }
+}
+
+export interface CardAuthRequest {
+  /** Hex auth_id (any non-empty string — uniqueness is what matters). */
+  auth_id: string;
+  /** Atomic eUSD units. Must be > 0. */
+  amount: bigint;
+  /** Hex64 holder pubkey. */
+  holder: string;
+}
+
+export interface CardAuthResult {
+  auth_id: string;
+  amount: bigint;
+  new_balance: bigint;
+}
+
+/**
+ * Simulate the on-chain `card_auth` instruction (FN-126).
+ *
+ * Pre-conditions:
+ *   - state.cardPda must be set (card has been issued)
+ *   - request.holder must match state.checkingHolder
+ *   - state.checkingBalance must cover request.amount
+ *   - request.auth_id must not have been used before (replay protection)
+ *
+ * On success: debits `state.checkingBalance` by `amount`, marks auth_id as
+ * used, and appends an event to `state.cardAuthEvents`.
+ */
+export function submitCardAuth(
+  state: MockChainState,
+  req: CardAuthRequest,
+): CardAuthResult {
+  if (req.amount <= 0n) {
+    throw new Error("submitCardAuth: amount must be > 0");
+  }
+  if (state.cardPda === null) {
+    throw new CardAuthError("no_card");
+  }
+  if (state.checkingHolder !== req.holder) {
+    throw new CardAuthError("holder_mismatch");
+  }
+  // Replay protection MUST come before balance check so a replay against a
+  // now-insufficient balance still surfaces as `replay`.
+  if (state.usedCardAuthIds.has(req.auth_id)) {
+    throw new CardAuthError("replay");
+  }
+  if (state.checkingBalance < req.amount) {
+    throw new CardAuthError("insufficient_balance");
+  }
+  state.checkingBalance -= req.amount;
+  state.usedCardAuthIds.add(req.auth_id);
+  state.cardAuthEvents.push({
+    auth_id: req.auth_id,
+    amount: req.amount,
+    holder: req.holder,
+  });
+  return {
+    auth_id: req.auth_id,
+    amount: req.amount,
+    new_balance: state.checkingBalance,
   };
 }
 

--- a/tests/bridge-413-nack.test.ts
+++ b/tests/bridge-413-nack.test.ts
@@ -1,0 +1,126 @@
+/**
+ * FN-092 — Beckn bridge 413 NACK shape
+ *
+ * Locks the behaviour added by `becknPayloadTooLargeMiddleware` in
+ * `src/gateway/beckn.ts`: when a request body exceeds the 1 MiB per-route
+ * `express.json` limit, the bridge returns 413 with the canonical Beckn
+ * NACK envelope `{message:{ack:{status:"NACK"}}, error:{code, message}}`,
+ * not Express's default HTML/text 413 body.
+ *
+ * Three cases:
+ *  1. POST /search with > 1 MiB body → 413 + NACK shape, code=PAYLOAD_TOO_LARGE
+ *  2. POST /search with small but envelope-invalid body → 400 + BECKN_400
+ *     (regression: middleware does NOT swallow ordinary errors)
+ *  3. POST /select with > 1 MiB body → 413 + NACK shape (middleware is global,
+ *     not per-route)
+ */
+
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import http from "node:http";
+import type { AddressInfo } from "node:net";
+
+import { createBecknApp } from "../src/gateway/beckn.js";
+
+type BootedServer = { server: http.Server; baseUrl: string };
+
+async function bootApp(): Promise<BootedServer> {
+  return new Promise((resolve) => {
+    const app = createBecknApp();
+    const server = app.listen(0, "127.0.0.1", () => {
+      const addr = server.address() as AddressInfo;
+      resolve({ server, baseUrl: `http://127.0.0.1:${addr.port}` });
+    });
+  });
+}
+
+async function closeServer(server: http.Server): Promise<void> {
+  return new Promise((resolve, reject) => {
+    server.close((err) => (err ? reject(err) : resolve()));
+  });
+}
+
+function freshContext(action: "search" | "select" | "init" | "confirm") {
+  return {
+    domain: "nic2004:52110",
+    action,
+    version: "2.0.0",
+    bap_id: "test-bap.example.com",
+    bap_uri: "https://test-bap.example.com",
+    transaction_id: "11111111-1111-1111-1111-111111111111",
+    message_id: "22222222-2222-2222-2222-222222222222",
+    timestamp: new Date().toISOString(),
+  };
+}
+
+describe("FN-092 — Beckn bridge 413 NACK shape", () => {
+  let srv: BootedServer;
+
+  beforeAll(async () => {
+    srv = await bootApp();
+  });
+
+  afterAll(async () => {
+    await closeServer(srv.server);
+  });
+
+  it("POST /search with body > 1 MiB → 413 + Beckn NACK envelope", async () => {
+    const padding = "x".repeat(1_200_000);
+    const body = JSON.stringify({
+      context: freshContext("search"),
+      message: { big_field: padding },
+    });
+    const res = await fetch(`${srv.baseUrl}/search`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body,
+    });
+    expect(res.status).toBe(413);
+    const json = (await res.json()) as {
+      message: { ack: { status: string } };
+      error: { code: string; message: string };
+    };
+    expect(json.message.ack.status).toBe("NACK");
+    expect(json.error.code).toBe("PAYLOAD_TOO_LARGE");
+    expect(typeof json.error.message).toBe("string");
+    expect(json.error.message.length).toBeGreaterThan(0);
+  });
+
+  it("POST /search with small invalid body → 400 BECKN_400 (regression: middleware does not swallow ordinary errors)", async () => {
+    const res = await fetch(`${srv.baseUrl}/search`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      // Missing context entirely — fails becknRequestSchema, exercised by
+      // makeHandler() which returns 400 + BECKN_400 directly (not via error
+      // middleware). This proves the new 413 handler is scoped to oversized
+      // bodies and not catching unrelated 4xx flows.
+      body: JSON.stringify({ message: { intent: {} } }),
+    });
+    expect(res.status).toBe(400);
+    const json = (await res.json()) as {
+      message: { ack: { status: string } };
+      error: { code: string; message: string };
+    };
+    expect(json.message.ack.status).toBe("NACK");
+    expect(json.error.code).toBe("BECKN_400");
+  });
+
+  it("POST /select with body > 1 MiB → 413 + Beckn NACK envelope (middleware is global, not per-route)", async () => {
+    const padding = "x".repeat(1_200_000);
+    const body = JSON.stringify({
+      context: freshContext("select"),
+      message: { big_field: padding },
+    });
+    const res = await fetch(`${srv.baseUrl}/select`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body,
+    });
+    expect(res.status).toBe(413);
+    const json = (await res.json()) as {
+      message: { ack: { status: string } };
+      error: { code: string; message: string };
+    };
+    expect(json.message.ack.status).toBe("NACK");
+    expect(json.error.code).toBe("PAYLOAD_TOO_LARGE");
+  });
+});

--- a/tests/bridge-conformance.test.ts.todo-fn-092
+++ b/tests/bridge-conformance.test.ts.todo-fn-092
@@ -343,13 +343,14 @@ describe("Suite 1 — Envelope conformance (forward actions)", () => {
   );
 
   // -------------------------------------------------------------------------
-  // §1.11 Oversized body (> 1 MiB) → 413
-  // NOTE: Express's body-parser returns a 413 with its own error format
-  // (not a Beckn NACK envelope). The status code is correct per HTTP;
-  // the body shape is a Beckn deviation. TODO: add Beckn error middleware.
+  // §1.11 Oversized body (> 1 MiB) → 413 + Beckn NACK envelope (FN-092)
+  // The 413 response body shape is now enforced by
+  // `becknPayloadTooLargeMiddleware` in `src/gateway/beckn.ts`, which maps
+  // body-parser's PayloadTooLargeError to the canonical NACK envelope
+  // `{message:{ack:{status:"NACK"}}, error:{code:"PAYLOAD_TOO_LARGE", message}}`.
   // -------------------------------------------------------------------------
 
-  it("POST /search with oversized body (> 1 MiB) → 413", async () => {
+  it("POST /search with oversized body (> 1 MiB) → 413 + Beckn NACK", async () => {
     const padding = "x".repeat(1_100_000);
     const body = JSON.stringify({
       context: freshContext("search"),
@@ -361,15 +362,15 @@ describe("Suite 1 — Envelope conformance (forward actions)", () => {
       body,
     });
     expect(res.status).toBe(413);
-    // Body shape deviates from Beckn NACK — Express default error format.
-    // TODO(FN-093): add Beckn-shaped error middleware to wrap 413 in NACK.
+    const json = (await res.json()) as {
+      message: { ack: { status: string } };
+      error: { code: string; message: string };
+    };
+    expect(json.message.ack.status).toBe("NACK");
+    expect(json.error.code).toBe("PAYLOAD_TOO_LARGE");
+    expect(typeof json.error.message).toBe("string");
+    expect(json.error.message.length).toBeGreaterThan(0);
   });
-
-  it.todo(
-    // TODO(FN-093): Once a Beckn error middleware is added to createBecknApp(),
-    // assert that the 413 body matches {message:{ack:{status:'NACK'}}, error:{code,message}}.
-    "POST /search > 1MiB: 413 body is Beckn NACK shape (TODO: FN-093 must add error middleware)",
-  );
 });
 
 // ===========================================================================

--- a/tests/indexer/audit-trail-signed.test.ts
+++ b/tests/indexer/audit-trail-signed.test.ts
@@ -1,0 +1,102 @@
+// FN-084 — AuditTrailIndexer + VcSigner integration tests.
+
+import { describe, expect, it } from "vitest";
+
+import {
+  AUDIT_TRAIL_ISSUER_DID,
+  AuditTrailIndexer,
+  InMemoryKytEventSource,
+  type Ed25519Signature2020Proof,
+  type KytTraceEvent,
+  type VcSigner,
+} from "../../src/services/indexer/index.js";
+
+const AUTHORITY = "5".repeat(44);
+const COUNTERPARTY = "6".repeat(44);
+
+function fixture(): KytTraceEvent[] {
+  return [
+    {
+      stage: "init",
+      tx_signature: ("Sig1" + "1".repeat(44)).slice(0, 44),
+      slot: 1000,
+      timestamp: 1_700_000_000,
+      parties: [
+        { party: "bap", authority: AUTHORITY, cred_pointers: ["a".repeat(64)] },
+        { party: "bpp", authority: COUNTERPARTY, cred_pointers: ["b".repeat(64)] },
+      ],
+    },
+  ];
+}
+
+const FIXED_CLOCK = () => new Date("2026-01-01T00:00:00.000Z");
+
+class FakeSigner implements VcSigner {
+  public lastInput: Record<string, unknown> | undefined;
+  public callCount = 0;
+  public constructor(public readonly issuerDid: string) {}
+  public async sign(
+    vcWithoutProof: Record<string, unknown>,
+  ): Promise<Ed25519Signature2020Proof> {
+    // Snapshot via structured clone so subsequent caller mutations
+    // (e.g. attaching the returned proof to the same object) do not
+    // pollute the captured input.
+    this.lastInput = structuredClone(vcWithoutProof);
+    this.callCount += 1;
+    return {
+      type: "Ed25519Signature2020",
+      created: "2026-01-01T00:00:00.000Z",
+      verificationMethod: `${this.issuerDid}#key-1`,
+      proofPurpose: "assertionMethod",
+      proofValue: "FAKE_PROOF_VALUE_BASE64URL",
+    };
+  }
+}
+
+describe("AuditTrailIndexer + VcSigner (FN-084)", () => {
+  it("default (NoOp) emits no proof key and keeps the v0 issuer DID", async () => {
+    const indexer = new AuditTrailIndexer({
+      source: new InMemoryKytEventSource({ traces: fixture() }),
+      clock: FIXED_CLOCK,
+    });
+    const feed = await indexer.buildAuditFeed(AUTHORITY);
+    expect("proof" in feed).toBe(false);
+    expect(feed.issuer).toBe(AUDIT_TRAIL_ISSUER_DID);
+  });
+
+  it("attaches the proof block when a signer is injected and overrides issuer", async () => {
+    const fakeDid = "did:eto:test:audit-signer";
+    const signer = new FakeSigner(fakeDid);
+    const indexer = new AuditTrailIndexer({
+      source: new InMemoryKytEventSource({ traces: fixture() }),
+      clock: FIXED_CLOCK,
+      signer,
+    });
+    const feed = await indexer.buildAuditFeed(AUTHORITY);
+
+    expect(feed.issuer).toBe(fakeDid);
+    expect(feed.proof).toEqual({
+      type: "Ed25519Signature2020",
+      created: "2026-01-01T00:00:00.000Z",
+      verificationMethod: `${fakeDid}#key-1`,
+      proofPurpose: "assertionMethod",
+      proofValue: "FAKE_PROOF_VALUE_BASE64URL",
+    });
+    // Proof block MUST NOT be in the input passed to sign() (spec §11.4).
+    expect(signer.lastInput).toBeDefined();
+    expect("proof" in (signer.lastInput as object)).toBe(false);
+  });
+
+  it("is deterministic across two builds with identical inputs and a fixed clock", async () => {
+    const signer = new FakeSigner("did:eto:test:audit-signer");
+    const make = () =>
+      new AuditTrailIndexer({
+        source: new InMemoryKytEventSource({ traces: fixture() }),
+        clock: FIXED_CLOCK,
+        signer,
+      });
+    const a = await make().buildAuditFeed(AUTHORITY);
+    const b = await make().buildAuditFeed(AUTHORITY);
+    expect(JSON.stringify(a)).toBe(JSON.stringify(b));
+  });
+});

--- a/tests/indexer/travel-rule-signed.test.ts
+++ b/tests/indexer/travel-rule-signed.test.ts
@@ -1,0 +1,114 @@
+// FN-084 — TravelRuleReportGenerator + VcSigner integration tests.
+
+import { describe, expect, it } from "vitest";
+
+import {
+  AuditTrailIndexer,
+  InMemoryAmountResolver,
+  InMemoryKytEventSource,
+  InMemoryPartyDirectory,
+  TRAVEL_RULE_ISSUER_DID,
+  TravelRuleReportGenerator,
+  type Ed25519Signature2020Proof,
+  type Ivms101Party,
+  type KytTraceEvent,
+  type VcSigner,
+} from "../../src/services/indexer/index.js";
+
+const BAP = "5".repeat(44);
+const BPP = "6".repeat(44);
+const TX = ("CrossJur" + "1".repeat(44)).slice(0, 44);
+
+const partyBap: Ivms101Party = {
+  authority: BAP,
+  accountNumber: "ACC-BAP-0001",
+  name: { kind: "natural", primary: "Alice" },
+  jurisdiction: "US",
+};
+const partyBpp: Ivms101Party = {
+  authority: BPP,
+  accountNumber: "ACC-BPP-0001",
+  name: { kind: "legal", name: "Acme Bank GmbH" },
+  jurisdiction: "DE",
+};
+
+function fixture(): KytTraceEvent[] {
+  return [
+    {
+      stage: "confirm",
+      tx_signature: TX,
+      slot: 2_000,
+      timestamp: 1_700_000_000,
+      parties: [
+        { party: "bap", authority: BAP, cred_pointers: ["a".repeat(64)] },
+        { party: "bpp", authority: BPP, cred_pointers: ["b".repeat(64)] },
+      ],
+    },
+  ];
+}
+
+const FIXED_CLOCK = () => new Date("2026-01-01T00:00:00.000Z");
+
+class FakeSigner implements VcSigner {
+  public lastInput: Record<string, unknown> | undefined;
+  public callCount = 0;
+  public constructor(public readonly issuerDid: string) {}
+  public async sign(
+    vcWithoutProof: Record<string, unknown>,
+  ): Promise<Ed25519Signature2020Proof> {
+    this.lastInput = vcWithoutProof;
+    this.callCount += 1;
+    return {
+      type: "Ed25519Signature2020",
+      created: "2026-01-01T00:00:00.000Z",
+      verificationMethod: `${this.issuerDid}#key-1`,
+      proofPurpose: "assertionMethod",
+      proofValue: "TR_FAKE_PROOF_BASE64URL",
+    };
+  }
+}
+
+function buildGenerator(signer?: VcSigner) {
+  const indexer = new AuditTrailIndexer({
+    source: new InMemoryKytEventSource({ traces: fixture() }),
+    clock: FIXED_CLOCK,
+  });
+  return new TravelRuleReportGenerator({
+    source: indexer,
+    partyDirectory: new InMemoryPartyDirectory({ [BAP]: partyBap, [BPP]: partyBpp }),
+    amountResolver: new InMemoryAmountResolver({
+      [TX]: { amountUsd: 12_500.5, currency: "USD" },
+    }),
+    clock: FIXED_CLOCK,
+    ...(signer ? { signer } : {}),
+  });
+}
+
+describe("TravelRuleReportGenerator + VcSigner (FN-084)", () => {
+  it("default (NoOp) emits no proof key and keeps the v0 issuer DID", async () => {
+    const gen = buildGenerator();
+    const report = await gen.buildReport(BAP);
+    expect("proof" in report).toBe(false);
+    expect(report.issuer).toBe(TRAVEL_RULE_ISSUER_DID);
+  });
+
+  it("attaches the proof block when a signer is injected and overrides issuer", async () => {
+    const fakeDid = "did:eto:test:travel-rule-signer";
+    const signer = new FakeSigner(fakeDid);
+    const gen = buildGenerator(signer);
+    const report = await gen.buildReport(BAP);
+
+    expect(report.issuer).toBe(fakeDid);
+    expect(report.proof).toEqual({
+      type: "Ed25519Signature2020",
+      created: "2026-01-01T00:00:00.000Z",
+      verificationMethod: `${fakeDid}#key-1`,
+      proofPurpose: "assertionMethod",
+      proofValue: "TR_FAKE_PROOF_BASE64URL",
+    });
+    // Proof block MUST NOT be in the input passed to sign() (spec §11.4).
+    expect(signer.lastInput).toBeDefined();
+    expect("proof" in (signer.lastInput as object)).toBe(false);
+    expect(signer.callCount).toBe(1);
+  });
+});

--- a/tests/indexer/vc-signer.test.ts
+++ b/tests/indexer/vc-signer.test.ts
@@ -1,0 +1,243 @@
+// FN-084: unit tests for src/services/indexer/vc-signer.ts.
+
+import { mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+
+import {
+  Ed25519VcSigner,
+  NoOpVcSigner,
+  base64UrlEncode,
+  canonicalizeJcs,
+  createVcSignerFromEnv,
+} from "../../src/services/indexer/vc-signer.js";
+
+const FIXED_CLOCK = () => new Date("2026-01-01T00:00:00.000Z");
+const ZERO_SEED = new Uint8Array(32);
+const TEST_DID = "did:eto:test:signer";
+
+// Precomputed (see PROMPT.md Step 5): signature over
+// sha256(JCS({a:[1,2,3],hello:"world",n:42})) using all-zero seed.
+const EXPECTED_PROOF_VALUE =
+  "WWfyFEoKJzVAovZ4nQhNehe3I_FM4lQ3n7FUEvqw9LxO-IA1RTilC00D1GYvxOedJJmhv79Nn8NhmZhWQXN_Bg";
+const EXPECTED_PROOF_VALUE_WITH_PROOF_KEY =
+  "MkG33UbQWV2Hw0-F0SvGoTMpqblihxInyK734EdByPg36LWNiAUWvNi_lr4O3ZmR3SjDyYlpSdCY3zzFIrXQAA";
+
+describe("canonicalizeJcs", () => {
+  it("sorts object keys lexicographically", () => {
+    expect(canonicalizeJcs({ b: 1, a: 2 })).toBe('{"a":2,"b":1}');
+  });
+
+  it("recursively sorts nested object keys", () => {
+    expect(canonicalizeJcs({ z: { b: 1, a: 2 }, a: 1 })).toBe(
+      '{"a":1,"z":{"a":2,"b":1}}',
+    );
+  });
+
+  it("preserves array order", () => {
+    expect(canonicalizeJcs([3, 1, 2])).toBe("[3,1,2]");
+  });
+
+  it("drops undefined values from objects", () => {
+    expect(canonicalizeJcs({ a: 1, b: undefined, c: 3 })).toBe(
+      '{"a":1,"c":3}',
+    );
+  });
+
+  it("rejects undefined inside an array", () => {
+    expect(() => canonicalizeJcs([1, undefined, 3])).toThrow(TypeError);
+  });
+
+  it("throws on NaN / Infinity", () => {
+    expect(() => canonicalizeJcs(Number.NaN)).toThrow(TypeError);
+    expect(() => canonicalizeJcs(Number.POSITIVE_INFINITY)).toThrow(TypeError);
+    expect(() => canonicalizeJcs(Number.NEGATIVE_INFINITY)).toThrow(TypeError);
+  });
+
+  it("rejects BigInt, Date, function, symbol", () => {
+    expect(() => canonicalizeJcs(1n)).toThrow(TypeError);
+    expect(() => canonicalizeJcs(new Date())).toThrow(TypeError);
+    expect(() => canonicalizeJcs(() => 0)).toThrow(TypeError);
+    expect(() => canonicalizeJcs(Symbol("x"))).toThrow(TypeError);
+  });
+
+  it("escapes string contents like JSON.stringify", () => {
+    expect(canonicalizeJcs('a"b\\c')).toBe('"a\\"b\\\\c"');
+    expect(canonicalizeJcs("héllo")).toBe('"héllo"');
+  });
+
+  it("renders booleans and null", () => {
+    expect(canonicalizeJcs(true)).toBe("true");
+    expect(canonicalizeJcs(false)).toBe("false");
+    expect(canonicalizeJcs(null)).toBe("null");
+  });
+});
+
+describe("base64UrlEncode", () => {
+  it("emits padding-free base64url", () => {
+    expect(base64UrlEncode(new Uint8Array([0xff, 0xee, 0xdd]))).toBe("/+7d".replace(/\+/g, "-").replace(/\//g, "_"));
+    // No `+`, `/`, or `=`.
+    const out = base64UrlEncode(new Uint8Array([1, 2, 3, 4, 5]));
+    expect(out).not.toMatch(/[+/=]/u);
+  });
+});
+
+describe("NoOpVcSigner", () => {
+  it("returns a proof block with empty proofValue and configured DID", async () => {
+    const signer = new NoOpVcSigner(TEST_DID, FIXED_CLOCK);
+    const proof = await signer.sign({ any: "thing" });
+    expect(proof).toEqual({
+      type: "Ed25519Signature2020",
+      created: "2026-01-01T00:00:00.000Z",
+      verificationMethod: `${TEST_DID}#key-1`,
+      proofPurpose: "assertionMethod",
+      proofValue: "",
+    });
+  });
+
+  it("defaults to the unsigned-indexer DID", () => {
+    const signer = new NoOpVcSigner();
+    expect(signer.issuerDid).toBe("did:eto:indexer:unsigned:v0");
+  });
+});
+
+describe("Ed25519VcSigner", () => {
+  it("produces a deterministic proof for a fixed seed/input/clock", async () => {
+    const signer = new Ed25519VcSigner({
+      issuerDid: TEST_DID,
+      secretKey: ZERO_SEED,
+      clock: FIXED_CLOCK,
+    });
+    const proof = await signer.sign({ hello: "world", a: [1, 2, 3], n: 42 });
+    expect(proof.type).toBe("Ed25519Signature2020");
+    expect(proof.created).toBe("2026-01-01T00:00:00.000Z");
+    expect(proof.verificationMethod).toBe(`${TEST_DID}#key-1`);
+    expect(proof.proofPurpose).toBe("assertionMethod");
+    expect(proof.proofValue).toBe(EXPECTED_PROOF_VALUE);
+    expect(proof.proofValue).not.toMatch(/[+/=]/u);
+  });
+
+  it("signs whatever it's given (proof block is the caller's contract)", async () => {
+    // The signer itself signs the entire input. The contract that the
+    // `proof` key MUST be excluded is enforced by the indexer wiring,
+    // not by the signer. This test asserts both signatures and verifies
+    // they differ — which is why the indexer wiring strips `proof`
+    // before calling sign().
+    const signer = new Ed25519VcSigner({
+      issuerDid: TEST_DID,
+      secretKey: ZERO_SEED,
+      clock: FIXED_CLOCK,
+    });
+    const proofWithout = await signer.sign({
+      hello: "world",
+      a: [1, 2, 3],
+      n: 42,
+    });
+    const proofWith = await signer.sign({
+      hello: "world",
+      a: [1, 2, 3],
+      n: 42,
+      proof: { ignore: "me" },
+    });
+    expect(proofWithout.proofValue).toBe(EXPECTED_PROOF_VALUE);
+    expect(proofWith.proofValue).toBe(EXPECTED_PROOF_VALUE_WITH_PROOF_KEY);
+    expect(proofWith.proofValue).not.toBe(proofWithout.proofValue);
+  });
+
+  it("rejects non-32-byte seeds", () => {
+    expect(
+      () =>
+        new Ed25519VcSigner({
+          issuerDid: TEST_DID,
+          secretKey: new Uint8Array(31),
+        }),
+    ).toThrow(/32-byte/u);
+    expect(
+      () =>
+        new Ed25519VcSigner({
+          issuerDid: TEST_DID,
+          secretKey: new Uint8Array(64),
+        }),
+    ).toThrow(/32-byte/u);
+  });
+
+  describe("fromKeyFile", () => {
+    const dir = mkdtempSync(join(tmpdir(), "vc-signer-"));
+
+    it("loads a 32-raw-byte seed file", async () => {
+      const path = join(dir, "raw.bin");
+      writeFileSync(path, ZERO_SEED);
+      const signer = Ed25519VcSigner.fromKeyFile(path, {
+        issuerDid: TEST_DID,
+        clock: FIXED_CLOCK,
+      });
+      const proof = await signer.sign({ hello: "world", a: [1, 2, 3], n: 42 });
+      expect(proof.proofValue).toBe(EXPECTED_PROOF_VALUE);
+    });
+
+    it("loads a hex-encoded seed file (with 0x prefix and whitespace)", async () => {
+      const path = join(dir, "hex.txt");
+      writeFileSync(path, "0x" + "00".repeat(32) + "\n");
+      const signer = Ed25519VcSigner.fromKeyFile(path, {
+        issuerDid: TEST_DID,
+        clock: FIXED_CLOCK,
+      });
+      const proof = await signer.sign({ hello: "world", a: [1, 2, 3], n: 42 });
+      expect(proof.proofValue).toBe(EXPECTED_PROOF_VALUE);
+    });
+
+    it("loads a base64url-encoded seed file", async () => {
+      const path = join(dir, "b64.txt");
+      // base64 of 32 zero bytes
+      writeFileSync(path, "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA");
+      const signer = Ed25519VcSigner.fromKeyFile(path, {
+        issuerDid: TEST_DID,
+        clock: FIXED_CLOCK,
+      });
+      const proof = await signer.sign({ hello: "world", a: [1, 2, 3], n: 42 });
+      expect(proof.proofValue).toBe(EXPECTED_PROOF_VALUE);
+    });
+
+    it("throws on wrong-length seed", () => {
+      const path = join(dir, "bad.bin");
+      writeFileSync(path, new Uint8Array(16));
+      expect(() =>
+        Ed25519VcSigner.fromKeyFile(path, { issuerDid: TEST_DID }),
+      ).toThrow(/32-byte/u);
+    });
+  });
+});
+
+describe("createVcSignerFromEnv", () => {
+  it("returns NoOpVcSigner when AUDIT_SIGNING_KEY_PATH is unset", () => {
+    const signer = createVcSignerFromEnv({
+      issuerDid: TEST_DID,
+      env: {},
+    });
+    expect(signer).toBeInstanceOf(NoOpVcSigner);
+    expect(signer.issuerDid).toBe(TEST_DID);
+  });
+
+  it("returns NoOpVcSigner when AUDIT_SIGNING_KEY_PATH is empty", () => {
+    const signer = createVcSignerFromEnv({
+      issuerDid: TEST_DID,
+      env: { AUDIT_SIGNING_KEY_PATH: "" },
+    });
+    expect(signer).toBeInstanceOf(NoOpVcSigner);
+  });
+
+  it("returns Ed25519VcSigner when AUDIT_SIGNING_KEY_PATH points at a valid seed", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "vc-signer-env-"));
+    const path = join(dir, "seed.bin");
+    writeFileSync(path, ZERO_SEED);
+    const signer = createVcSignerFromEnv({
+      issuerDid: TEST_DID,
+      env: { AUDIT_SIGNING_KEY_PATH: path },
+      clock: FIXED_CLOCK,
+    });
+    expect(signer).toBeInstanceOf(Ed25519VcSigner);
+    const proof = await signer.sign({ hello: "world", a: [1, 2, 3], n: 42 });
+    expect(proof.proofValue).toBe(EXPECTED_PROOF_VALUE);
+  });
+});

--- a/tests/issuers/claim-commitments.test.ts
+++ b/tests/issuers/claim-commitments.test.ts
@@ -1,0 +1,244 @@
+/**
+ * Unit tests for `computeClaimCommitments` (FN-077, §10.3.1).
+ *
+ * The tests pin the §10.3.1 contract:
+ *   - byte-stable lex ordering of `fieldPath` → `idx` mapping,
+ *   - per-leaf `commitment = Poseidon2_t3([value, salt, idx])`,
+ *   - per-leaf `saltCommitment = Poseidon2_t3([salt, 0, idx])`,
+ *   - 64-char lowercase LE hex serialization,
+ *   - `encodeFr`-driven type encoding (number / string / bool / null).
+ *
+ * Salts are injected via a deterministic counter-based PRNG so commitment
+ * hex is reproducible across runs.
+ */
+
+import { describe, expect, it } from "vitest";
+
+import {
+  bytesToHex32,
+  encodeFr,
+  encodeSalt,
+  poseidon2,
+} from "../../src/crypto/poseidon2.js";
+import {
+  computeClaimCommitments,
+  type ClaimCommitment,
+} from "../../src/issuers/claim-commitments.js";
+
+/** Deterministic 32-byte salt: byte 0 = counter, rest 0. */
+function makeCounterSalts(): (len: number) => Uint8Array {
+  let counter = 0;
+  return (len: number): Uint8Array => {
+    if (len !== 32) throw new Error(`expected 32, got ${len}`);
+    const out = new Uint8Array(32);
+    out[0] = counter & 0xff;
+    counter += 1;
+    return out;
+  };
+}
+
+/** Salt that emits all-zero bytes (so `salt_field === 0n`). */
+function zeroSalts(len: number): Uint8Array {
+  if (len !== 32) throw new Error(`expected 32, got ${len}`);
+  return new Uint8Array(32);
+}
+
+describe("computeClaimCommitments — §10.3.1", () => {
+  it("ordering invariant: insertion order does not affect output", () => {
+    const a = computeClaimCommitments(
+      { id: "did:eto:agent:abc", verificationLevel: "orb", action: "x" },
+      { randomBytes: makeCounterSalts() },
+    );
+    const b = computeClaimCommitments(
+      { action: "x", verificationLevel: "orb", id: "did:eto:agent:abc" },
+      { randomBytes: makeCounterSalts() },
+    );
+    expect(a).toEqual(b);
+    // idx → fieldPath mapping is `action(0), id(1), verificationLevel(2)`.
+    expect(a.map((e) => `${e.idx}:${e.fieldPath}`)).toEqual([
+      "0:credentialSubject.action",
+      "1:credentialSubject.id",
+      "2:credentialSubject.verificationLevel",
+    ]);
+  });
+
+  it("nested objects yield dot-separated paths under credentialSubject.", () => {
+    const out = computeClaimCommitments(
+      {
+        id: "did:eto:agent:abc",
+        profile: { name: "Ada", dob: "1815-12-10" },
+      },
+      { randomBytes: makeCounterSalts() },
+    );
+    expect(out.map((e) => e.fieldPath)).toEqual([
+      "credentialSubject.id",
+      "credentialSubject.profile.dob",
+      "credentialSubject.profile.name",
+    ]);
+  });
+
+  it("null and false both encode to 0n at the same salt+idx → identical commitment", () => {
+    const nullOut = computeClaimCommitments(
+      { x: null },
+      { randomBytes: zeroSalts },
+    );
+    const falseOut = computeClaimCommitments(
+      { x: false },
+      { randomBytes: zeroSalts },
+    );
+    expect(nullOut[0]!.commitment).toBe(falseOut[0]!.commitment);
+    expect(nullOut[0]!.saltCommitment).toBe(falseOut[0]!.saltCommitment);
+  });
+
+  it("true and false produce distinct commitments", () => {
+    const t = computeClaimCommitments({ x: true }, { randomBytes: zeroSalts });
+    const f = computeClaimCommitments({ x: false }, { randomBytes: zeroSalts });
+    expect(t[0]!.commitment).not.toBe(f[0]!.commitment);
+  });
+
+  it("§10.3.1 numeric vs short-string encoding: short reps collide (intentional)", () => {
+    // Both 42 and "42" right-align to bytes[30..31]=[0x34,0x32]; this is a
+    // known §10.3.1 property — numeric strings <= 31 bytes share the encoded
+    // field with their string form. Discrimination is done via fieldPath/idx.
+    const intOut = computeClaimCommitments(
+      { x: 42 },
+      { randomBytes: zeroSalts },
+    );
+    const strOut = computeClaimCommitments(
+      { x: "42" },
+      { randomBytes: zeroSalts },
+    );
+    expect(intOut[0]!.commitment).toBe(strOut[0]!.commitment);
+  });
+
+  it("numeric vs long-string encoding: distinct when string > 31 bytes", () => {
+    // String of 32 bytes triggers the length-byte path → distinct from any
+    // numeric encoding.
+    const intOut = computeClaimCommitments(
+      { x: 42 },
+      { randomBytes: zeroSalts },
+    );
+    const longStr = computeClaimCommitments(
+      { x: "4".repeat(32) },
+      { randomBytes: zeroSalts },
+    );
+    expect(intOut[0]!.commitment).not.toBe(longStr[0]!.commitment);
+  });
+
+  it("KAT: numeric 42 with zero salt at idx=0 matches Poseidon-2 reference", () => {
+    const out = computeClaimCommitments(
+      { x: 42 },
+      { randomBytes: zeroSalts },
+    );
+    const valueField = encodeFr(42);
+    const saltField = encodeSalt(new Uint8Array(32));
+    const expected = bytesToHex32(poseidon2([valueField, saltField, 0n]));
+    expect(out[0]!.commitment).toBe(expected);
+    const expectedSalt = bytesToHex32(poseidon2([saltField, 0n, 0n]));
+    expect(out[0]!.saltCommitment).toBe(expectedSalt);
+  });
+
+  it("string >31 bytes: changing length byte changes the commitment", () => {
+    // 31-byte string → fits in left-zero-pad, length byte is 0
+    const short = "a".repeat(31);
+    // 32-byte string → first 31 bytes + length=32 in slot 31
+    const long32 = "a".repeat(32);
+    // 33-byte string → first 31 bytes + length=33 in slot 31
+    const long33 = "a".repeat(33);
+
+    const a = computeClaimCommitments(
+      { x: short },
+      { randomBytes: zeroSalts },
+    );
+    const b = computeClaimCommitments(
+      { x: long32 },
+      { randomBytes: zeroSalts },
+    );
+    const c = computeClaimCommitments(
+      { x: long33 },
+      { randomBytes: zeroSalts },
+    );
+    expect(a[0]!.commitment).not.toBe(b[0]!.commitment);
+    expect(b[0]!.commitment).not.toBe(c[0]!.commitment);
+    // All hex outputs are 64 chars.
+    for (const out of [a, b, c]) {
+      expect(out[0]!.commitment).toMatch(/^[0-9a-f]{64}$/);
+      expect(out[0]!.saltCommitment).toMatch(/^[0-9a-f]{64}$/);
+    }
+  });
+
+  it("idx mirrors lex order over fieldPath", () => {
+    const out = computeClaimCommitments(
+      { z: 1, a: 1, m: 1 },
+      { randomBytes: makeCounterSalts() },
+    );
+    expect(out.map((e) => [e.idx, e.fieldPath])).toEqual([
+      [0, "credentialSubject.a"],
+      [1, "credentialSubject.m"],
+      [2, "credentialSubject.z"],
+    ]);
+  });
+
+  it("saltCommitment formula matches Poseidon-2([salt, 0, idx]) per entry", () => {
+    const rb = makeCounterSalts();
+    // Re-derive same salt sequence to compute expectations.
+    const rb2 = makeCounterSalts();
+    const out = computeClaimCommitments(
+      { a: "foo", b: "bar" },
+      { randomBytes: rb },
+    );
+    for (const entry of out) {
+      const salt = rb2(32);
+      const saltField = encodeSalt(salt);
+      const expected = bytesToHex32(
+        poseidon2([saltField, 0n, BigInt(entry.idx)]),
+      );
+      expect(entry.saltCommitment).toBe(expected);
+    }
+  });
+
+  it("output hex shape: every commitment + saltCommitment is 64 lowercase hex chars", () => {
+    const out = computeClaimCommitments(
+      {
+        id: "did:eto:agent:abc",
+        n: 7,
+        b: true,
+        s: null,
+        nested: { a: "x", b: "y" },
+      },
+      { randomBytes: makeCounterSalts() },
+    );
+    for (const e of out) {
+      expect(e.commitment).toMatch(/^[0-9a-f]{64}$/);
+      expect(e.saltCommitment).toMatch(/^[0-9a-f]{64}$/);
+    }
+  });
+
+  it("array leaves are encoded via JSON.stringify (v0 convention)", () => {
+    const out = computeClaimCommitments(
+      { tags: ["a", "b"] },
+      { randomBytes: zeroSalts },
+    );
+    const expected = bytesToHex32(
+      poseidon2([
+        encodeFr(JSON.stringify(["a", "b"])),
+        encodeSalt(new Uint8Array(32)),
+        0n,
+      ]),
+    );
+    expect(out[0]!.commitment).toBe(expected);
+  });
+
+  it("default WebCrypto path emits unique salts (smoke test)", () => {
+    // Just verify the no-opts call path runs and returns 64-char hex.
+    const out: ClaimCommitment[] = computeClaimCommitments({ a: 1, b: 2 });
+    expect(out).toHaveLength(2);
+    for (const e of out) {
+      expect(e.commitment).toMatch(/^[0-9a-f]{64}$/);
+      expect(e.saltCommitment).toMatch(/^[0-9a-f]{64}$/);
+    }
+    // Re-run should produce different commitments (random salts).
+    const out2 = computeClaimCommitments({ a: 1, b: 2 });
+    expect(out2[0]!.commitment).not.toBe(out[0]!.commitment);
+  });
+});

--- a/tests/issuers/worldcoin.test.ts
+++ b/tests/issuers/worldcoin.test.ts
@@ -401,17 +401,24 @@ describe("Worldcoin issuer — end-to-end (FN-044 / T-1.4.3.2)", () => {
     expect(onChain.issuerAuthority).toBe(ISSUER_AUTHORITY);
     expect(onChain.slot).toBeGreaterThan(0n);
 
-    // The recomputed VC envelope (rebuilt from public inputs) hashes to
+    // The recomputed VC envelope (rebuilt from public inputs +
+    // §10.3.1 claimCommitments carried alongside the VC) hashes to
     // the on-chain claim_hash — closes the chain-of-custody loop a
     // downstream verifier walks: chain → IPFS → hash equality.
-    const rebuilt = buildVerifiedHumanVc({
-      issuerDid: ISSUER_DID,
-      agentCardPubkey: wallet.agentCardPubkey,
-      verificationLevel: "orb",
-      nullifierHash: NULLIFIER,
-      merkleRoot: MERKLE_ROOT,
-      issuanceDate: vc["issuanceDate"] as string,
-    });
+    // claimCommitments are non-deterministic (CSPRNG-salted) so a
+    // pure rebuild can't regenerate them; we copy them through from
+    // the fetched VC, which is exactly what a verifier does.
+    const rebuilt = {
+      ...buildVerifiedHumanVc({
+        issuerDid: ISSUER_DID,
+        agentCardPubkey: wallet.agentCardPubkey,
+        verificationLevel: "orb",
+        nullifierHash: NULLIFIER,
+        merkleRoot: MERKLE_ROOT,
+        issuanceDate: vc["issuanceDate"] as string,
+      }),
+      claimCommitments: vc["claimCommitments"],
+    };
     expect(sha256Hex(canonicalJson(rebuilt))).toBe(onChain.claimHash);
   });
 

--- a/tests/models/agent-identity.test.ts
+++ b/tests/models/agent-identity.test.ts
@@ -1,0 +1,134 @@
+import { describe, it, expect } from "vitest";
+import {
+  buildInterimAgentIdentity,
+  type AgentIdentity,
+  type InterimAgentIdentityInput,
+} from "../../src/models/agent-identity.js";
+
+function baseInput(overrides: Partial<InterimAgentIdentityInput> = {}): InterimAgentIdentityInput {
+  return {
+    scope: "0xAlice",
+    active_wallet_id: "w-1",
+    wallets: [
+      { id: "w-1", label: "primary", svm: "SoMeBaSe58Pubkey", evm: "0xabc" },
+    ],
+    auth_strategy: "siwe",
+    token_expires_at: "2030-01-01T00:00:00.000Z",
+    last_restart_iso: "2026-05-01T00:00:00.000Z",
+    capabilities: ["wallet:read", "transfer:write"],
+    ...overrides,
+  };
+}
+
+describe("buildInterimAgentIdentity", () => {
+  it("builds a thirdweb-kind identity with self_declared attestation when declared_model is supplied", () => {
+    const id = buildInterimAgentIdentity(
+      baseInput({
+        declared_model: { provider: "anthropic", model_id: "claude-sonnet-4-5" },
+      }),
+    );
+
+    expect(id.human_authority.kind).toBe("thirdweb");
+    expect(id.human_authority.sub).toBe("0xAlice");
+    expect(id.human_authority.auth_strategy).toBe("siwe");
+
+    expect(id.model_attestation.attestation_status).toBe("self_declared");
+    if (id.model_attestation.attestation_status === "self_declared") {
+      expect(id.model_attestation.provider).toBe("anthropic");
+      expect(id.model_attestation.model_id).toBe("claude-sonnet-4-5");
+    }
+
+    expect(id.environment.surface).toBe("sse");
+    expect(id.environment.wallet_anchor).toEqual({
+      id: "w-1",
+      svm: "SoMeBaSe58Pubkey",
+      evm: "0xabc",
+      label: "primary",
+    });
+
+    expect(id.session_scope.scope).toBe("0xAlice");
+    expect(id.session_scope.expires_at_iso).toBe("2030-01-01T00:00:00.000Z");
+    expect(id.session_scope.capabilities).toEqual(["wallet:read", "transfer:write"]);
+  });
+
+  it("emits attestation_status: absent when declared_model is omitted", () => {
+    const id = buildInterimAgentIdentity(baseInput());
+    expect(id.model_attestation.attestation_status).toBe("absent");
+  });
+
+  it("falls back to kind=stdio with surface=stdio under __stdio__ scope and no auth_strategy", () => {
+    const id = buildInterimAgentIdentity(
+      baseInput({ scope: "__stdio__", auth_strategy: null }),
+    );
+    expect(id.human_authority.kind).toBe("stdio");
+    expect(id.human_authority.auth_strategy).toBeUndefined();
+    expect(id.environment.surface).toBe("stdio");
+  });
+
+  it("falls back to kind=dev with surface=dev under __dev__ scope and no auth_strategy", () => {
+    const id = buildInterimAgentIdentity(
+      baseInput({ scope: "__dev__", auth_strategy: null }),
+    );
+    expect(id.human_authority.kind).toBe("dev");
+    expect(id.environment.surface).toBe("dev");
+  });
+
+  it("defaults capabilities to [] when omitted (no throw)", () => {
+    const input = baseInput();
+    delete (input as Partial<InterimAgentIdentityInput>).capabilities;
+    const id = buildInterimAgentIdentity(input);
+    expect(id.session_scope.capabilities).toEqual([]);
+  });
+
+  it("falls back to first wallet when active_wallet_id is null", () => {
+    const id = buildInterimAgentIdentity(baseInput({ active_wallet_id: null }));
+    expect(id.environment.wallet_anchor.id).toBe("w-1");
+  });
+
+  it("emits an empty wallet_anchor when wallets is empty", () => {
+    const id = buildInterimAgentIdentity(
+      baseInput({ wallets: [], active_wallet_id: null }),
+    );
+    expect(id.environment.wallet_anchor).toEqual({
+      id: "",
+      svm: null,
+      evm: null,
+      label: null,
+    });
+  });
+
+  it("rejects an input with no scope, referencing session_scope in the error", () => {
+    const bad = baseInput({ scope: "" });
+    expect(() => buildInterimAgentIdentity(bad)).toThrow(/session_scope/);
+  });
+
+  it("type-level: a fully-populated literal satisfies AgentIdentity", () => {
+    const literal = {
+      human_authority: {
+        sub: "0xAlice",
+        kind: "thirdweb",
+        auth_strategy: "siwe",
+      },
+      model_attestation: {
+        attestation_status: "verified",
+        provider: "anthropic",
+        model_id: "claude-sonnet-4-5",
+        kid: "kid-1",
+        issued_at: 1_730_000_000,
+      },
+      environment: {
+        surface: "sse",
+        server_instance: "2026-05-01T00:00:00.000Z",
+        wallet_anchor: { id: "w-1", svm: null, evm: null, label: null },
+      },
+      session_scope: {
+        scope: "0xAlice",
+        jti: "jti-1",
+        expires_at_iso: "2030-01-01T00:00:00.000Z",
+        capabilities: ["wallet:read"],
+      },
+    } satisfies AgentIdentity;
+
+    expect(literal.human_authority.kind).toBe("thirdweb");
+  });
+});

--- a/tests/unit/a2a-tools.test.ts
+++ b/tests/unit/a2a-tools.test.ts
@@ -1,0 +1,108 @@
+import { describe, test, expect, vi } from "vitest";
+
+// src/config.ts has pre-existing duplicate top-level exports (config / ISSUER_URL
+// / PROGRAM_IDS each declared multiple times) that esbuild refuses to parse.
+// That file is outside the scope of this task; we mock it so this test can
+// exercise the send_a2a_message handler without pulling the broken module.
+vi.mock("../../src/config.js", () => ({
+  PROGRAM_IDS: {
+    mcp: new Uint8Array(32),
+    agent: new Uint8Array(32),
+    swarm: new Uint8Array(32),
+    a2a: new Uint8Array(32),
+    zkBn254: new Uint8Array(32),
+    zkVerify: new Uint8Array(32),
+  },
+  ISSUER_URL: "http://localhost:0",
+  config: {},
+}));
+
+const { registerA2ATools } = await import("../../src/tools/a2a.js");
+
+// Minimal McpServer-shaped stub: captures registered tools so we can invoke
+// their handlers directly without booting a real MCP transport.
+type ToolEntry = {
+  description: string;
+  schema: Record<string, unknown>;
+  handler: (args: any) => Promise<any> | any;
+};
+
+function makeStubServer() {
+  const tools: Record<string, ToolEntry> = {};
+  const server = {
+    tool: (
+      name: string,
+      description: string,
+      schema: Record<string, unknown>,
+      handler: (args: any) => Promise<any> | any
+    ) => {
+      tools[name] = { description, schema, handler };
+    },
+  };
+  return { server: server as any, tools };
+}
+
+describe("send_a2a_message bridge-pattern response", () => {
+  test("returns success (no isError) and contains required sections", async () => {
+    const { server, tools } = makeStubServer();
+    registerA2ATools(server);
+
+    const tool = tools["send_a2a_message"];
+    expect(tool).toBeDefined();
+    // Description must no longer claim unavailability.
+    expect(tool.description).not.toMatch(/Not yet available/i);
+    expect(tool.description).toMatch(/bridge/i);
+
+    const res = await tool.handler({});
+    expect(res.isError).not.toBe(true);
+
+    const text: string = res.content[0].text;
+    expect(text).toContain("a2a_message");
+    expect(text).toContain("transfer_native");
+    expect(text).toMatch(/Limitations/);
+    // Future replacement reference.
+    expect(text).toContain("CreateTask");
+    // Should mention SPL Memo size limitation.
+    expect(text).toMatch(/566/);
+  });
+
+  test("interpolates `to` and `body` into the example", async () => {
+    const { server, tools } = makeStubServer();
+    registerA2ATools(server);
+
+    const tool = tools["send_a2a_message"];
+    const recipient = "9xQeWvG816bUx9EPjHmaT23yvVM2ZWbrrpZb9PusVFin";
+    const body = { hello: "world", n: 7 };
+
+    const res = await tool.handler({ to: recipient, body });
+    expect(res.isError).not.toBe(true);
+
+    const text: string = res.content[0].text;
+    expect(text).toContain(recipient);
+    // body is JSON-stringified into the memo (which is itself JSON-stringified
+    // for the example), so quotes appear escaped in the response text.
+    expect(text).toContain('hello');
+    expect(text).toContain('world');
+    expect(text).toContain('"n\\":7');
+  });
+
+  test("falls back to placeholders when `to`/`body` omitted", async () => {
+    const { server, tools } = makeStubServer();
+    registerA2ATools(server);
+    const res = await tools["send_a2a_message"].handler({});
+    const text: string = res.content[0].text;
+    expect(text).toContain("<recipient_svm_address>");
+    expect(text).toContain("<your json body>");
+  });
+
+  test("accepts legacy params (channel_id, message, priority) without throwing", async () => {
+    const { server, tools } = makeStubServer();
+    registerA2ATools(server);
+    const res = await tools["send_a2a_message"].handler({
+      channel_id: "legacy",
+      message: { foo: 1 },
+      priority: "high",
+    });
+    expect(res.isError).not.toBe(true);
+  });
+});

--- a/tests/unit/audit-trail-jose.test.ts
+++ b/tests/unit/audit-trail-jose.test.ts
@@ -1,0 +1,111 @@
+/**
+ * Tests for `signWithJose` — the minimal compact-JWS / VC-JOSE proof suite
+ * wrapper added to audit-trail.ts in FN-030.
+ *
+ * Test cases:
+ *   1. Happy path: output is a 3-part base64url JWS with correct EdDSA header.
+ *   2. Signature verifies against the corresponding public key.
+ *   3. Tampered payload fails Ed25519 signature verification.
+ *   4. Different keys produce different signatures for the same payload.
+ */
+
+import { describe, test, expect } from "vitest";
+import * as ed from "@noble/ed25519";
+import { sha512 } from "@noble/hashes/sha512";
+import { signWithJose } from "../../src/services/indexer/audit-trail.js";
+
+// Configure synchronous sha512 for @noble/ed25519 v2 (required).
+ed.etc.sha512Sync = (...m: Uint8Array[]) => sha512(ed.etc.concatBytes(...m));
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makePrivateKey(): Uint8Array {
+  const k = new Uint8Array(32);
+  crypto.getRandomValues(k);
+  return k;
+}
+
+function b64uDecode(s: string): Uint8Array {
+  return new Uint8Array(Buffer.from(s, "base64url"));
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("signWithJose (FN-030)", () => {
+  test("produces a 3-part compact JWS with alg=EdDSA header", async () => {
+    const key = makePrivateKey();
+    const payload = { sub: "did:eto:agent:test", iat: 1_700_000_000 };
+
+    const jws = await signWithJose(payload, key);
+
+    const parts = jws.split(".");
+    expect(parts).toHaveLength(3);
+
+    const header = JSON.parse(Buffer.from(parts[0]!, "base64url").toString());
+    expect(header.alg).toBe("EdDSA");
+    expect(header.typ).toBe("JWT");
+
+    const decoded = JSON.parse(Buffer.from(parts[1]!, "base64url").toString());
+    expect(decoded).toEqual(payload);
+  });
+
+  test("signature verifies against the Ed25519 public key", async () => {
+    const privateKey = makePrivateKey();
+    const publicKey = await ed.getPublicKeyAsync(privateKey);
+    const payload = { iss: "did:eto:indexer:audit-trail:v0", claim: "test" };
+
+    const jws = await signWithJose(payload, privateKey);
+
+    const parts = jws.split(".");
+    expect(parts).toHaveLength(3);
+
+    const signingInput = new TextEncoder().encode(`${parts[0]}.${parts[1]}`);
+    const sig = b64uDecode(parts[2]!);
+
+    const valid = await ed.verifyAsync(sig, signingInput, publicKey);
+    expect(valid).toBe(true);
+  });
+
+  test("tampered payload fails signature verification", async () => {
+    const privateKey = makePrivateKey();
+    const publicKey = await ed.getPublicKeyAsync(privateKey);
+    const payload = { iss: "legit", data: "original" };
+
+    const jws = await signWithJose(payload, privateKey);
+    const parts = jws.split(".");
+
+    // Replace payload part with a tampered base64url-encoded object.
+    const tampered = Buffer.from(
+      JSON.stringify({ iss: "legit", data: "tampered" }),
+    ).toString("base64url");
+    const tamperedParts = [parts[0], tampered, parts[2]];
+
+    const signingInput = new TextEncoder().encode(
+      `${tamperedParts[0]}.${tamperedParts[1]}`,
+    );
+    const sig = b64uDecode(tamperedParts[2]!);
+
+    const valid = await ed.verifyAsync(sig, signingInput, publicKey);
+    expect(valid).toBe(false);
+  });
+
+  test("different keys produce different signatures for the same payload", async () => {
+    const key1 = makePrivateKey();
+    const key2 = makePrivateKey();
+    const payload = { claim: "shared-payload" };
+
+    const jws1 = await signWithJose(payload, key1);
+    const jws2 = await signWithJose(payload, key2);
+
+    // Header and payload parts are deterministic (same JSON), but signatures differ.
+    const [h1, p1, s1] = jws1.split(".");
+    const [h2, p2, s2] = jws2.split(".");
+    expect(h1).toBe(h2);
+    expect(p1).toBe(p2);
+    expect(s1).not.toBe(s2);
+  });
+});

--- a/tests/unit/memo-parse.test.ts
+++ b/tests/unit/memo-parse.test.ts
@@ -1,0 +1,103 @@
+import { describe, it, expect } from "vitest";
+import {
+  MEMO_PROGRAM_ID_BS58,
+  extractMemosFromLogs,
+  parseMemoPayload,
+  matchesFilter,
+} from "../../src/utils/memo-parse.js";
+
+describe("extractMemosFromLogs", () => {
+  it("returns [] for undefined / empty / no-memo log arrays", () => {
+    expect(extractMemosFromLogs(undefined)).toEqual([]);
+    expect(extractMemosFromLogs([])).toEqual([]);
+    expect(
+      extractMemosFromLogs([
+        "Program 11111111111111111111111111111111 invoke [1]",
+        "Program 11111111111111111111111111111111 success",
+      ])
+    ).toEqual([]);
+  });
+
+  it("extracts a JSON-escaped Memo (len N) payload", () => {
+    const logs = [
+      `Program ${MEMO_PROGRAM_ID_BS58} invoke [1]`,
+      `Program log: Memo (len 13): "{\\"k\\":\\"v\\"}"`,
+      `Program ${MEMO_PROGRAM_ID_BS58} consumed 100 of 200000 compute units`,
+      `Program ${MEMO_PROGRAM_ID_BS58} success`,
+    ];
+    expect(extractMemosFromLogs(logs)).toEqual([`{"k":"v"}`]);
+  });
+
+  it("falls back to the next Program log: line after a memo invoke", () => {
+    const logs = [
+      `Program ${MEMO_PROGRAM_ID_BS58} invoke [1]`,
+      `Program log: hello world`,
+      `Program ${MEMO_PROGRAM_ID_BS58} success`,
+    ];
+    expect(extractMemosFromLogs(logs)).toEqual(["hello world"]);
+  });
+
+  it("returns multiple memos in order", () => {
+    const logs = [
+      `Program ${MEMO_PROGRAM_ID_BS58} invoke [1]`,
+      `Program log: Memo (len 5): "first"`,
+      `Program ${MEMO_PROGRAM_ID_BS58} success`,
+      `Program 11111111111111111111111111111111 invoke [1]`,
+      `Program 11111111111111111111111111111111 success`,
+      `Program ${MEMO_PROGRAM_ID_BS58} invoke [1]`,
+      `Program log: second-raw`,
+      `Program ${MEMO_PROGRAM_ID_BS58} success`,
+    ];
+    expect(extractMemosFromLogs(logs)).toEqual(["first", "second-raw"]);
+  });
+});
+
+describe("parseMemoPayload", () => {
+  it("parses valid JSON objects", () => {
+    expect(parseMemoPayload('{"a":1}')).toEqual({ a: 1 });
+  });
+
+  it("returns the raw string on parse failure", () => {
+    expect(parseMemoPayload("not json")).toBe("not json");
+  });
+
+  it("returns empty string for empty input", () => {
+    expect(parseMemoPayload("")).toBe("");
+  });
+});
+
+describe("matchesFilter", () => {
+  it("returns true when both args are undefined", () => {
+    expect(matchesFilter({ anything: 1 })).toBe(true);
+    expect(matchesFilter("raw")).toBe(true);
+  });
+
+  it("matches a top-level JSON field equality", () => {
+    expect(matchesFilter({ type: "transfer" }, "type", "transfer")).toBe(true);
+  });
+
+  it("rejects a value mismatch", () => {
+    expect(matchesFilter({ type: "transfer" }, "type", "swap")).toBe(false);
+  });
+
+  it("returns false when parsed is a non-object string", () => {
+    expect(matchesFilter("hello", "type", "hello")).toBe(false);
+  });
+
+  it("returns false when the field is missing", () => {
+    expect(matchesFilter({ other: 1 }, "type", "transfer")).toBe(false);
+  });
+
+  it("returns false when only one of field/value is provided", () => {
+    expect(matchesFilter({ type: "transfer" }, "type", undefined)).toBe(false);
+    expect(matchesFilter({ type: "transfer" }, undefined, "transfer")).toBe(false);
+  });
+
+  it("coerces non-string values via String()", () => {
+    expect(matchesFilter({ n: 42 }, "n", "42")).toBe(true);
+  });
+
+  it("rejects arrays", () => {
+    expect(matchesFilter([{ type: "transfer" }], "type", "transfer")).toBe(false);
+  });
+});

--- a/tests/unit/wasm.test.ts
+++ b/tests/unit/wasm.test.ts
@@ -198,13 +198,36 @@ describe("buildTransferTx", () => {
     expect(parsed.numRequiredSignatures).toBe(1);
   });
 
-  test("empty-string memo behaves like no memo", () => {
+  test("empty-string memo behaves like no memo (byte-equal output)", () => {
     const from = makeValidPubkey();
     const to = makeValidPubkey();
-    const tx = buildTransferTx(from, to, 1n, BLOCKHASH, "");
-    const parsed = parseTransaction(tx);
+    const txEmpty = buildTransferTx(from, to, 1n, BLOCKHASH, "");
+    const txNoMemo = buildTransferTx(from, to, 1n, BLOCKHASH);
+    const parsed = parseTransaction(txEmpty);
     expect(parsed.instructions.length).toBe(1);
     expect(parsed.accountKeys.length).toBe(3);
+    expect(parsed.numReadonlyUnsigned).toBe(1);
+    expect(Buffer.from(txEmpty).equals(Buffer.from(txNoMemo))).toBe(true);
+  });
+
+  test("omitted memo arg produces byte-identical tx to undefined memo (BC regression guard)", () => {
+    const from = makeValidPubkey();
+    const to = makeValidPubkey();
+    const txA = buildTransferTx(from, to, 42_000n, BLOCKHASH);
+    const txB = buildTransferTx(from, to, 42_000n, BLOCKHASH, undefined);
+    expect(Buffer.from(txA).equals(Buffer.from(txB))).toBe(true);
+  });
+
+  test("memo round-trips multi-byte UTF-8 (non-ASCII)", () => {
+    const from = makeValidPubkey();
+    const to = makeValidPubkey();
+    const memo = "héllo 🌍 — αβγ";
+    const tx = buildTransferTx(from, to, 1n, BLOCKHASH, memo);
+    const parsed = parseTransaction(tx);
+    const memoIx = parsed.instructions[0];
+    expect(memoIx.programIdIndex).toBe(3);
+    expect(memoIx.accounts.length).toBe(0);
+    expect(new TextDecoder().decode(memoIx.data)).toBe(memo);
   });
 });
 


### PR DESCRIPTION
## Summary
- Adds `signWithJose(payload, key)` to `src/services/indexer/audit-trail.ts`
- Minimal Ed25519 compact-JWS (RFC 7515 / VC-JOSE) using `@noble/ed25519` already in the dependency graph — no new npm dependency
- Header: `{ alg: "EdDSA", typ: "JWT" }`; sits alongside `Ed25519Signature2020` as the `jose` proof suite
- 4 unit tests in `tests/unit/audit-trail-jose.test.ts`: structure, signature verification, tamper-detection, key-independence

## Test plan
- [ ] 4/4 tests pass: `vitest run tests/unit/audit-trail-jose.test.ts`
- [ ] `tsc --noEmit` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)