### PR TITLE
feat(FN-051): extend ModelAttestation verified arm with source sub-discriminator

### DIFF
--- a/docs/agent-identity-model.md
+++ b/docs/agent-identity-model.md
@@ -1,0 +1,324 @@
+# ETO Agent Identity Model — `human × model × environment`
+
+> Tracking issue: [etofdn/eto-mcp#11](https://github.com/etofdn/eto-mcp/issues/11)
+> Upstream task: **FN-058** (this spec).
+> Downstream: **FN-059** (authority-inheritance enforcement), **FN-060** (A2A coordination), **FN-061** (model-attestation research). Part of the **FN-054** A2A milestone.
+>
+> Status: **normative spec, no runtime wiring yet.** A reference TypeScript shape lives at [`src/models/agent-identity.ts`](../src/models/agent-identity.ts); no MCP tool currently emits or consumes it. FN-059 is the first task that will wire it into a request handler.
+
+---
+
+## §1 — Why a multi-axis identity
+
+Today's session model in `src/gateway/session.ts` answers a single question:
+*"Is this caller's bearer token validly signed for some `sub`?"* That binds a
+request to a **human authority** (the user behind `sub`) and to a bounded
+**session scope** (`exp`, `caps`, `wallet_id`). It is silent on two questions
+that A2A coordination ([FN-054](#)) forces us to answer:
+
+1. **Which AI model produced this action?** Two MCP sessions can share the same
+   `sub` while running on completely different model providers (Claude, GPT,
+   self-hosted Llama). Trust decisions about *autonomous-agent* behavior — rate
+   limits, capability gating, audit logs — need to attribute actions to a
+   model, not just a person.
+2. **Where is the agent executing?** "The same human" running ETO from the
+   stdio CLI on their laptop, from a hosted SSE deployment, and from a CI
+   runner is three different *execution surfaces*. The cryptographic anchor
+   (the wallet keys actually doing the signing) and the network-reachable
+   endpoint are surface-specific.
+
+The agent identity model therefore tuples four orthogonal axes:
+
+```
+AgentIdentity = {
+  human_authority,    // who authorized this agent
+  model_attestation,  // what AI is steering it
+  environment,        // where it's running + crypto anchor
+  session_scope,      // bounded MCP session window
+}
+```
+
+Each axis has its own source-of-truth, its own threat model, and its own
+verification roadmap. They compose: an A2A counterpart that wants to trust an
+incoming message MUST evaluate all four, and MAY make different trust
+decisions on each.
+
+---
+
+## §2 — The four fields
+
+### §2.1 — `human_authority`
+
+| | |
+|---|---|
+| **Definition** | The human (or human-controlled service account) that consented to this agent acting on their behalf. |
+| **Type (TS)** | `HumanAuthority` |
+| **Source-of-truth (today)** | `SessionPayload.sub` + `SessionPayload.auth_strategy` from `src/gateway/session.ts`, surfaced via `authenticate()` in `src/gateway/auth.ts`. |
+| **Concrete values today** | `sub` = thirdweb-issued wallet address (SIWE / inapp_email / inapp_oauth strategies), the literal `"dev-user"` (dev-bypass), or the synthetic `"__stdio__"` scope when running over stdio without auth. |
+| **Trust assumption** | The session token's HMAC signature attests that *some* trusted auth backend issued this `sub`. The strength of that attestation is a function of `auth_strategy`: `siwe` ≥ `inapp_oauth` ≥ `inapp_email` ≫ `dev`. `__stdio__` carries no human attestation at all and MUST be treated as local-only. |
+| **Threat model** | Compromise of `SESSION_SIGNING_KEY` lets an attacker forge any `sub`. Compromise of an upstream IdP (thirdweb) lets an attacker take over a single user's `sub`. Cross-tenant impersonation is out of scope for this spec (see [§7 Non-goals](#7-non-goals)). |
+
+### §2.2 — `model_attestation`
+
+| | |
+|---|---|
+| **Definition** | A claim about which AI model/provider produced the agent's tool calls, and whether that claim is cryptographically verified. |
+| **Type (TS)** | `ModelAttestation` with discriminator `attestation_status: "verified" \| "self_declared" \| "absent"`. |
+| **Source-of-truth (forward)** | A provider-signed JWT/JWS attesting `{ model_id, provider, issued_at, audience }`, verified against the provider's published JWKS. Tracked by **FN-061**. |
+| **Source-of-truth (today)** | None. The MCP server cannot today verify what model is on the other end of the protocol; the field is `attestation_status: "self_declared"` carrying whatever the agent advertises in a `User-Agent`-style header, or `attestation_status: "absent"` if nothing was sent. |
+| **Trust assumption** | When `attestation_status === "verified"`: trust the provider's JWKS. When `"self_declared"`: treat the model claim as a **hint for telemetry only**, never for capability gating. When `"absent"`: do not branch on model identity at all. |
+| **Threat model** | Self-declared values can be spoofed trivially. Verified values inherit the provider's KMS posture; signature replay across audiences is mitigated by `aud` binding to the MCP server's origin. |
+
+This is the axis that explicitly *does not work today*. The interim path
+(see [§5](#5-interim-implementation-works-today)) is to record the
+self-declared claim and propagate `attestation_status: "self_declared"` so
+downstream code can refuse to trust it.
+
+**Sub-discriminator on the `verified` arm.** When `attestation_status === "verified"`,
+the arm is itself sub-discriminated by `source: "session_signed" | "provider_oidc"`.
+The invariants are: `source: "session_signed"` ⇒ `provider_verified: false`
+(the gateway minted a session-attestation JWS at auth time — stronger than
+`self_declared` because the gateway witnessed the binding, but the provider
+itself did not sign anything); `source: "provider_oidc"` ⇒ `provider_verified: true`
+(a provider-signed JWS was verified against the provider's published JWKS).
+Capability gating MUST consult `provider_verified`, not just `attestation_status`.
+See [`docs/model-attestation.md`](./model-attestation.md) §5.2 for the
+session-signed payload shape; the `provider_oidc` arm has no on-disk emitter
+today (future work, downstream of FN-052). The corresponding TypeScript shapes
+live in [`src/models/agent-identity.ts`](../src/models/agent-identity.ts) as
+`ModelAttestation` and `InterimAgentIdentityInput.verified_session_jws_claims`.
+
+### §2.3 — `environment`
+
+| | |
+|---|---|
+| **Definition** | The execution surface the agent is running on, plus the cryptographic wallet anchor it controls. |
+| **Type (TS)** | `Environment` |
+| **Source-of-truth** | `currentScope()` from `src/signing/session-context.ts` (`__stdio__` / `__dev__` / thirdweb sub) for the surface; `localSignerFactory` (`src/signing/local-signer.ts`) for the SVM (Ed25519 base58) and EVM (secp256k1 0x-hex) addresses derived from the active wallet. |
+| **Concrete values** | `surface ∈ { "stdio", "sse", "dev" }`, `server_instance` = `last_restart_iso` from `session_info`, `wallet_anchor = { id, svm, evm }` from the active wallet. |
+| **Trust assumption** | The wallet anchor is the **strongest** signal in this entire model: anyone presenting a signature over a fresh challenge from `wallet_anchor.svm` or `wallet_anchor.evm` proves possession of the corresponding private key. A2A trust SHOULD prefer wallet-anchor proofs over `human_authority` claims when they disagree. |
+| **Threat model** | A surface label (`"sse"`) is unauthenticated metadata. A wallet address is authenticated metadata only after a fresh signature challenge — never trust a wallet address presented in a payload alone. |
+
+### §2.4 — `session_scope`
+
+| | |
+|---|---|
+| **Definition** | The bounded MCP session window inside which this identity is valid. |
+| **Type (TS)** | `SessionScope` |
+| **Source-of-truth** | `SessionPayload.{ jti, exp, caps }` plus the persistence-key `scope` string from `currentScope()`. |
+| **Concrete values** | `{ scope, jti, expires_at_iso, capabilities[] }`. |
+| **Trust assumption** | A token with `exp < now` is invalid regardless of how strong every other axis is. Capabilities (`caps[]`) are the authoritative authorization list; identity in this spec does NOT confer capability — it only attributes. |
+| **Threat model** | Token replay before `exp` is mitigated by HMAC binding + the `revoked_jtis` denylist in `src/gateway/session.ts`. Capability escalation is gated by `requireCapability()`, not by anything in this spec. |
+
+---
+
+## §3 — Authority inheritance rule
+
+> **Rule.** Two `AgentIdentity` values `A` and `B` MAY transitively trust each
+> other for the *intersection* of `A.session_scope.capabilities` and
+> `B.session_scope.capabilities`, **iff** all of the following hold:
+>
+> 1. `A.human_authority.sub === B.human_authority.sub`, AND
+> 2. Both `A.human_authority` and `B.human_authority` carry an
+>    `auth_strategy` other than `"dev"` and a scope other than `"__stdio__"`
+>    (i.e. both are anchored to a real human-authenticated backend), AND
+> 3. Neither `session_scope` is expired.
+>
+> The rule is **silent on `model_attestation`**: two agents inherit authority
+> across model providers, because the human is the same human. The rule is
+> **silent on `environment`**: a user can fan out work from their laptop to a
+> hosted runner under the same `sub`, and inheritance still holds.
+
+### §3.1 — Worked example
+
+Alice signs in with thirdweb SIWE on her laptop. The MCP server issues
+session token `T_laptop` with `sub = 0xAlice`, `auth_strategy = "siwe"`,
+`caps = [a2a:write, transfer:write, …]`. Her IDE runs Claude.
+
+Alice also has a hosted runner that authenticated as `0xAlice` through the
+same thirdweb provider; it holds session token `T_runner` with the same `sub`
+but `caps = [a2a:write, a2a:read]` only (narrowed by capability scoping at
+issuance). It runs GPT.
+
+A2A message flow: the runner agent (GPT) sends an A2A message to a counterpart
+that holds `T_laptop` (Claude). The receiver evaluates inheritance:
+
+- `sub` matches (`0xAlice` ↔ `0xAlice`) ✓
+- both `auth_strategy = "siwe"` ✓
+- both unexpired ✓
+
+→ The receiver MAY treat the message as Alice-authorized. The action it can
+ultimately *perform* is gated by **its own** `capabilities[]`, not the
+sender's: inheritance attributes intent, it does not lend caps. If the
+receiver only has `a2a:read`, it cannot turn an inherited request into a
+`transfer:write`.
+
+### §3.2 — When inheritance does NOT apply
+
+- `__stdio__` ↔ anything: stdio carries no human attestation, so it cannot
+  inherit from or to an authenticated session. Stdio agents are local trust
+  only.
+- `__dev__` / `auth_strategy = "dev"`: dev-bypass MUST NOT inherit into
+  production-strategy sessions even on a `sub` collision.
+- `model_attestation`-based gating: a counterpart MAY *additionally* require
+  `model_attestation.attestation_status === "verified"` for a specific
+  capability. That check is layered ON TOP of the rule above; it does not
+  weaken it.
+
+---
+
+## §4 — Verification roadmap for `model_attestation`
+
+The eventual flow ([FN-061](#) tracks the research):
+
+1. The agent runtime obtains a short-lived JWT from its model provider with
+   payload approximately:
+   ```json
+   {
+     "iss": "https://provider.example/v1",
+     "sub": "model:claude-3-7-sonnet-20250219",
+     "aud": "https://mcp.eto.example",
+     "iat": 1735689600,
+     "exp": 1735690200,
+     "model_id": "claude-3-7-sonnet-20250219",
+     "provider": "anthropic"
+   }
+   ```
+2. The agent attaches the JWT in an `X-Model-Attestation` header (or MCP
+   transport equivalent) on each outbound MCP request.
+3. The MCP server verifies the JWT against the provider's published JWKS
+   (cached, with rotation). `aud` MUST equal the server's canonical origin.
+4. On success: emit `ModelAttestation` with `attestation_status: "verified"`,
+   carrying `provider`, `model_id`, and the signature's `kid`.
+5. On any failure (signature, `aud`, `exp`, unknown provider): emit
+   `attestation_status: "absent"`. Do NOT downgrade to `"self_declared"` —
+   self-declared is for the case where there was *no* attestation attempted.
+
+**Open design questions** flagged for FN-061:
+
+- Signature algorithm — RFC 9458/9461 / JWS `EdDSA` vs. `ES256`.
+- Key discovery — direct JWKS URL vs. a registry like
+  [`oauth-for-ai-agents`](https://github.com/etofdn/eto-mcp/issues/11)-style
+  IdP federation.
+- Revocation — short `exp` (≤ 60 s) is the working assumption; explicit
+  revocation lists are deferred.
+- Tenant binding — whether `aud` alone is enough, or a per-deployment nonce
+  is required to defeat replay across ETO instances.
+
+---
+
+## §5 — Interim implementation (works today)
+
+Until FN-061 lands, every `AgentIdentity` we can construct has
+`model_attestation.attestation_status` of `"self_declared"` or `"absent"`.
+Construction reuses the existing `session_info` MCP tool's response shape
+*as data input only* — no new tool, no change to `session_info` itself
+(that's FN-059's job).
+
+A pure builder is exported as
+[`buildInterimAgentIdentity`](../src/models/agent-identity.ts) with this
+contract:
+
+```ts
+buildInterimAgentIdentity({
+  // session_info-shaped payload:
+  scope,                       // currentScope()
+  active_wallet_id,            // wallet.ts
+  wallets: [{ id, label, svm, evm }, ...],
+  auth_strategy,               // SessionPayload.auth_strategy | null
+  token_expires_at,            // ISO string | null
+  last_restart_iso,            // server boot ISO
+  // optional caller-provided hints:
+  declared_model?: { provider, model_id }, // becomes self_declared attestation
+  capabilities?: string[],     // SessionPayload.caps | undefined
+  jti?: string,                // SessionPayload.jti | undefined
+}): AgentIdentity
+```
+
+The builder:
+
+1. Maps `scope` + `auth_strategy` into `human_authority`, computing
+   `human_authority.kind` as `"thirdweb"` (real `sub`),
+   `"stdio"` (`scope === "__stdio__"`), `"dev"` (`auth_strategy === "dev"`
+   or `scope === "__dev__"`), or `"unknown"`.
+2. Maps the active wallet's `{svm, evm}` into `environment.wallet_anchor`,
+   and `last_restart_iso` into `environment.server_instance`. Surface is
+   inferred from `scope` (`"__stdio__"` → `"stdio"`, `"__dev__"` → `"dev"`,
+   anything else → `"sse"`).
+3. If `declared_model` is provided, emits
+   `attestation_status: "self_declared"` carrying it. Otherwise emits
+   `attestation_status: "absent"`.
+4. Maps `token_expires_at`, `capabilities`, `jti`, and `scope` into
+   `session_scope`.
+
+**The builder MUST throw** if `scope` is missing — there is no meaningful
+identity without a session-scope persistence key.
+
+**Trust degradation.** Any consumer of an interim `AgentIdentity` MUST
+treat `model_attestation` as untrusted telemetry. Specifically:
+
+- Authority inheritance ([§3](#3--authority-inheritance-rule)) is permitted
+  on `human_authority` alone, since that field is HMAC-attested today.
+- Capability gating MUST NOT branch on `model_attestation` until `verified`
+  is reachable.
+
+---
+
+## §6 — Type reference
+
+The canonical TS surface is in [`src/models/agent-identity.ts`](../src/models/agent-identity.ts).
+Field-level JSDoc cites the section numbers in this document.
+
+```ts
+interface AgentIdentity {
+  human_authority: HumanAuthority;     // §2.1
+  model_attestation: ModelAttestation; // §2.2
+  environment: Environment;            // §2.3
+  session_scope: SessionScope;         // §2.4
+}
+```
+
+---
+
+## §7 — Non-goals
+
+This spec deliberately does NOT cover:
+
+- **Revocation transport.** Token revocation lives in
+  `src/gateway/session.ts`'s `revokeJti` denylist and is independent of
+  this identity shape.
+- **Attestation transport.** How `X-Model-Attestation` arrives at the server
+  (HTTP header vs. MCP-protocol extension) is FN-061's call.
+- **Cross-tenant delegation.** "Alice's agent acts on behalf of Bob" is not a
+  case of authority inheritance; it requires a delegation credential and is
+  out of scope.
+- **A2A wire format.** How an `AgentIdentity` is serialized into an A2A
+  envelope is FN-060's call.
+- **MCP tool changes.** `session_info` and `SessionPayload` are unchanged.
+  FN-059 is the first task that will wire `AgentIdentity` into a handler.
+
+---
+
+## §8 — Open questions
+
+| # | Question | Resolved by |
+|---|---|---|
+| Q1 | Should `human_authority.kind === "stdio"` ever participate in inheritance with another stdio session on the same host? | FN-059 |
+| Q2 | What is the exact JWS algorithm and JWKS discovery story for `model_attestation`? | FN-061 |
+| Q3 | Does `environment.surface` need a fourth value (`"http-bridge"`) for the SSE-bridge variant? | FN-060 |
+| Q4 | Should `session_scope.capabilities` be re-projected into a coarser A2A capability vocabulary, or carried verbatim? | FN-060 |
+| Q5 | Is `wallet_anchor` allowed to carry multiple wallets (the user's full set), or must it be the single active wallet at issuance? | FN-059 |
+
+---
+
+## §9 — Cross-references
+
+- Upstream tracking issue: [etofdn/eto-mcp#11](https://github.com/etofdn/eto-mcp/issues/11)
+- A2A milestone: **FN-054**
+- Authority-inheritance enforcement: **FN-059** (consumes this spec)
+- A2A coordination wire format: **FN-060**
+- Model-attestation research: **FN-061**
+- Session and capability primitives: [`src/gateway/session.ts`](../src/gateway/session.ts), [`src/gateway/auth.ts`](../src/gateway/auth.ts)
+- Scope context: [`src/signing/session-context.ts`](../src/signing/session-context.ts)
+- Wallet anchor: [`src/signing/local-signer.ts`](../src/signing/local-signer.ts)
+- Today's identity-adjacent tool: [`src/tools/session.ts`](../src/tools/session.ts) (`session_info`)

--- a/src/models/agent-identity.ts
+++ b/src/models/agent-identity.ts
@@ -80,6 +80,14 @@ export type ModelAttestation =
       kid: string;
       /** Issuance timestamp (seconds since epoch) of the verified JWS. */
       issued_at: number;
+      /** How the verification was established. `"session_signed"` = caller
+       *  supplied a JWS bound to this session; `"provider_oidc"` = verified
+       *  against the provider's published JWKS endpoint. */
+      source: "session_signed" | "provider_oidc";
+      /** Whether the provider's own infrastructure attested the model claim. */
+      provider_verified: boolean;
+      /** The raw compact JWS that carried the attestation. */
+      jws: string;
     }
   | {
       attestation_status: "self_declared";
@@ -192,6 +200,23 @@ export interface InterimAgentIdentityInput {
   capabilities?: ReadonlyArray<string>;
   /** Optional: `SessionPayload.jti` when available. */
   jti?: string;
+  /**
+   * Optional: a caller-supplied JWS that was already verified against the
+   * provider's session signing key. When present, `buildInterimAgentIdentity`
+   * emits a `"verified"` attestation with `source: "session_signed"`.
+   */
+  verified_session_jws?: {
+    /** The compact JWS string. */
+    jws: string;
+    /** `sub` claim from the verified token — the model's identity assertion. */
+    sub: string;
+    /** Model identifier claimed in the JWS. */
+    model_id: string;
+    /** Provider that issued the JWS (e.g. `"anthropic"`). */
+    provider: string;
+    /** Expiry of the JWS as a Unix timestamp (seconds). */
+    exp: number;
+  };
 }
 
 /**
@@ -216,7 +241,18 @@ export function buildInterimAgentIdentity(
 
   const human_authority = resolveHumanAuthority(input);
   const environment = resolveEnvironment(input);
-  const model_attestation: ModelAttestation = input.declared_model
+  const model_attestation: ModelAttestation = input.verified_session_jws
+    ? {
+        attestation_status: "verified",
+        provider: input.verified_session_jws.provider,
+        model_id: input.verified_session_jws.model_id,
+        kid: input.verified_session_jws.sub,
+        issued_at: input.verified_session_jws.exp,
+        source: "session_signed",
+        provider_verified: false,
+        jws: input.verified_session_jws.jws,
+      }
+    : input.declared_model
     ? {
         attestation_status: "self_declared",
         provider: input.declared_model.provider,

--- a/src/models/agent-identity.ts
+++ b/src/models/agent-identity.ts
@@ -61,8 +61,12 @@ export interface HumanAuthority {
 /**
  * Discriminator for {@link ModelAttestation}. See spec §2.2 and §4.
  *
- * - `"verified"` — provider-signed JWS verified against published JWKS.
- *   ONLY this state is safe for capability gating.
+ * - `"verified"` — a JWS attesting `(provider, model_id)` was verified.
+ *   The verified arm is itself sub-discriminated by
+ *   {@link AttestationSource} (`source: "session_signed" | "provider_oidc"`).
+ *   Capability gating MUST consult `provider_verified` (not just
+ *   `attestation_status`) — `session_signed` is gateway-witnessed but
+ *   NOT provider-attested.
  * - `"self_declared"` — the agent advertised a model claim but no signature
  *   was verified. Telemetry-only; never gate capabilities on this.
  * - `"absent"` — no claim was made (or verification failed). Do not branch
@@ -70,23 +74,62 @@ export interface HumanAuthority {
  */
 export type AttestationStatus = "verified" | "self_declared" | "absent";
 
-/** A claim about which AI model produced the agent's actions. See spec §2.2. */
+/**
+ * Sub-discriminator for the {@link ModelAttestation} `verified` arm.
+ *
+ * - `"session_signed"` — the gateway minted a session-attestation JWS at
+ *   auth time binding the caller-declared `(provider, model_id)` to the
+ *   session token's `(sub, jti, iat, exp)`. The provider itself did NOT
+ *   sign anything; `provider_verified` is therefore always `false`.
+ *   Stronger than `self_declared` (the gateway witnessed the binding) but
+ *   weaker than `provider_oidc`. See `docs/model-attestation.md` §5.2 and
+ *   `docs/agent-identity-model.md` §2.2.
+ * - `"provider_oidc"` — a provider-signed JWS (e.g. via the provider's
+ *   OIDC JWKS) was verified. `provider_verified` is always `true`.
+ *   Capability gating MAY rely on this; see spec §3.2.
+ */
+export type AttestationSource = "session_signed" | "provider_oidc";
+
+/**
+ * A claim about which AI model produced the agent's actions. See spec §2.2.
+ *
+ * Type-narrowing pattern:
+ * ```ts
+ * if (m.attestation_status === "verified") {
+ *   //                       ^? "session_signed" | "provider_oidc"
+ *   if (m.source === "provider_oidc") {
+ *     // m.provider_verified is `true`
+ *   } else {
+ *     // m.source is "session_signed"; m.provider_verified is `false`
+ *   }
+ * }
+ * ```
+ */
 export type ModelAttestation =
   | {
       attestation_status: "verified";
+      /** Sub-discriminator — see {@link AttestationSource}. */
+      source: "session_signed";
+      /** Always `false` for `session_signed` — the gateway, not the provider, signed. */
+      provider_verified: false;
       provider: string;
       model_id: string;
       /** JWS `kid` from the verified attestation. */
       kid: string;
       /** Issuance timestamp (seconds since epoch) of the verified JWS. */
       issued_at: number;
-      /** How the verification was established. `"session_signed"` = caller
-       *  supplied a JWS bound to this session; `"provider_oidc"` = verified
-       *  against the provider's published JWKS endpoint. */
-      source: "session_signed" | "provider_oidc";
-      /** Whether the provider's own infrastructure attested the model claim. */
-      provider_verified: boolean;
-      /** The raw compact JWS that carried the attestation. */
+      /** The compact-form JWS string (RFC 7515) that produced this verified result. */
+      jws: string;
+    }
+  | {
+      attestation_status: "verified";
+      source: "provider_oidc";
+      /** Always `true` for `provider_oidc` — the provider's signing key signed. */
+      provider_verified: true;
+      provider: string;
+      model_id: string;
+      kid: string;
+      issued_at: number;
       jws: string;
     }
   | {
@@ -201,31 +244,67 @@ export interface InterimAgentIdentityInput {
   /** Optional: `SessionPayload.jti` when available. */
   jti?: string;
   /**
-   * Optional: a caller-supplied JWS that was already verified against the
-   * provider's session signing key. When present, `buildInterimAgentIdentity`
-   * emits a `"verified"` attestation with `source: "session_signed"`.
+   * Optional: a session-attestation JWS that has ALREADY been verified by
+   * the caller (e.g. FN-049's mint path on the same gateway, or FN-052's
+   * counterparty verifier). The builder treats this as opaque — it does
+   * NOT decode, verify, or fetch any JWKS. If supplied,
+   * `verified_session_jws_claims` MUST also be supplied; otherwise the
+   * builder ignores both and falls through to `self_declared` / `absent`.
+   *
+   * Trust boundary: the agent-identity module is intentionally decoupled
+   * from `src/gateway/**` and `src/signing/**`; verification happens in
+   * those layers and the result is passed in here as opaque data.
+   *
+   * See `docs/model-attestation.md` §5.2 for the canonical payload shape.
    */
-  verified_session_jws?: {
-    /** The compact JWS string. */
-    jws: string;
-    /** `sub` claim from the verified token — the model's identity assertion. */
-    sub: string;
-    /** Model identifier claimed in the JWS. */
-    model_id: string;
-    /** Provider that issued the JWS (e.g. `"anthropic"`). */
+  verified_session_jws?: string;
+
+  /**
+   * Optional: pre-validated claims extracted from `verified_session_jws`.
+   * Mirrors a subset of FN-049's `SessionAttestationPayload` — duplicated
+   * here (rather than imported) to keep this module decoupled from
+   * `src/gateway/session-attestation.ts`.
+   *
+   * When both fields are present AND the scope is not a dev/stdio sentinel,
+   * the builder emits a `ModelAttestation` with `attestation_status:
+   * "verified"`, `source: "session_signed"`, `provider_verified: false`.
+   */
+  verified_session_jws_claims?: {
+    /** Mirrors FN-049 `provider_declared`. 1..64 chars. */
     provider: string;
-    /** Expiry of the JWS as a Unix timestamp (seconds). */
-    exp: number;
+    /** Mirrors FN-049 `model_id_declared`. 1..128 chars. */
+    model_id: string;
+    /** JWS header `kid`. Non-empty string. */
+    kid: string;
+    /** Mirrors `payload.iat` (unix seconds). Finite integer. */
+    issued_at: number;
   };
 }
 
 /**
- * Build an {@link AgentIdentity} from a `session_info`-shaped payload, with
- * no provider integration. The result always has
- * `model_attestation.attestation_status` of `"self_declared"` (when
- * `declared_model` is present) or `"absent"`.
+ * Build an {@link AgentIdentity} from a `session_info`-shaped payload.
  *
- * Pure function — no I/O, no global state.
+ * Model-attestation resolution precedence:
+ *
+ * 1. **Negative gates.** If `scope === "__stdio__"`, `scope === "__dev__"`,
+ *    or `auth_strategy === "dev"`, the builder NEVER emits a `verified` arm
+ *    — dev/stdio sessions cannot meaningfully attest a model identity
+ *    (cf. FN-049 mint-path negative gates). Falls through to
+ *    `self_declared` (if `declared_model`) or `absent`.
+ * 2. **Verified arm.** Else if BOTH `verified_session_jws` AND
+ *    `verified_session_jws_claims` are supplied, emits
+ *    `attestation_status: "verified"`, `source: "session_signed"`,
+ *    `provider_verified: false`. The JWS is treated as opaque, already
+ *    validated by the caller.
+ * 3. **Self-declared arm.** Else if `declared_model` is supplied, emits
+ *    `self_declared`.
+ * 4. **Absent.** Otherwise emits `absent`.
+ *
+ * The builder NEVER emits `source: "provider_oidc"` from any input shape.
+ * That arm is type-only at this stage; a future task (downstream of FN-052)
+ * will add a `verified_provider_oidc_jws` builder path.
+ *
+ * Pure function — no I/O, no global state, no `Date.now()`.
  *
  * @throws {Error} if `scope` is missing or empty (see spec §5: there is no
  * meaningful identity without a session-scope persistence key).
@@ -241,24 +320,8 @@ export function buildInterimAgentIdentity(
 
   const human_authority = resolveHumanAuthority(input);
   const environment = resolveEnvironment(input);
-  const model_attestation: ModelAttestation = input.verified_session_jws
-    ? {
-        attestation_status: "verified",
-        provider: input.verified_session_jws.provider,
-        model_id: input.verified_session_jws.model_id,
-        kid: input.verified_session_jws.sub,
-        issued_at: input.verified_session_jws.exp,
-        source: "session_signed",
-        provider_verified: false,
-        jws: input.verified_session_jws.jws,
-      }
-    : input.declared_model
-    ? {
-        attestation_status: "self_declared",
-        provider: input.declared_model.provider,
-        model_id: input.declared_model.model_id,
-      }
-    : { attestation_status: "absent" };
+  const model_attestation = resolveModelAttestation(input);
+
 
   const session_scope: SessionScope = {
     scope: input.scope,
@@ -268,6 +331,49 @@ export function buildInterimAgentIdentity(
   };
 
   return { human_authority, model_attestation, environment, session_scope };
+}
+
+function resolveModelAttestation(
+  input: InterimAgentIdentityInput,
+): ModelAttestation {
+  // Negative gates: dev/stdio sessions cannot meaningfully attest a model.
+  // Mirrors FN-049's mint-path gates so a verified arm is never emitted in
+  // these scopes even if the caller supplied a JWS.
+  const isDevOrStdio =
+    input.scope === "__stdio__" ||
+    input.scope === "__dev__" ||
+    input.auth_strategy === "dev";
+
+  if (
+    !isDevOrStdio &&
+    input.verified_session_jws &&
+    input.verified_session_jws_claims
+  ) {
+    const claims = input.verified_session_jws_claims;
+    return {
+      attestation_status: "verified",
+      source: "session_signed",
+      provider_verified: false,
+      provider: claims.provider,
+      model_id: claims.model_id,
+      kid: claims.kid,
+      issued_at: claims.issued_at,
+      jws: input.verified_session_jws,
+    };
+  }
+
+  // asymmetric input — defensively ignore both; fall through to
+  // self_declared / absent rather than throwing.
+
+  if (input.declared_model) {
+    return {
+      attestation_status: "self_declared",
+      provider: input.declared_model.provider,
+      model_id: input.declared_model.model_id,
+    };
+  }
+
+  return { attestation_status: "absent" };
 }
 
 function resolveHumanAuthority(input: InterimAgentIdentityInput): HumanAuthority {

--- a/src/models/agent-identity.ts
+++ b/src/models/agent-identity.ts
@@ -1,0 +1,280 @@
+/**
+ * Agent Identity Model — `human × model × environment × session`.
+ *
+ * Reference TypeScript shape for the spec at
+ * [`docs/agent-identity-model.md`](../../docs/agent-identity-model.md).
+ *
+ * **Status (FN-095):** foundational module providing AgentIdentity types and
+ * `buildInterimAgentIdentity` constructor. This module is intentionally
+ * decoupled from any MCP tool implementation — it accepts a structurally typed
+ * input (a `session_info`-shaped payload) rather than importing from
+ * `src/tools/session.ts`.
+ *
+ * Field-level JSDoc references the section numbers in
+ * `docs/agent-identity-model.md` (e.g. `§2.1`).
+ */
+
+import type { SvmAddress, EvmAddress } from "./index.js";
+
+// ---------------------------------------------------------------------------
+// §2.1 — human_authority
+// ---------------------------------------------------------------------------
+
+/**
+ * Which auth backend issued the human attestation behind this identity.
+ *
+ * Matches the realistic set of strategies in `src/gateway/session.ts`
+ * (`AuthStrategy`) plus two synthetic kinds:
+ *
+ * - `"stdio"` — the stdio entrypoint runs in the literal `"__stdio__"` scope
+ *   without any human attestation. Local-trust only.
+ * - `"unknown"` — fallback when no `auth_strategy` is present and the scope
+ *   is not one of the known synthetic scopes.
+ *
+ * See spec §2.1.
+ */
+export type HumanAuthorityKind =
+  | "thirdweb" // siwe / inapp_email / inapp_oauth — real human-attested
+  | "dev"      // dev-bypass; never inherits authority
+  | "stdio"    // __stdio__ scope; local trust only
+  | "unknown";
+
+/**
+ * The human (or human-controlled service account) that consented to this
+ * agent acting on their behalf. See spec §2.1.
+ */
+export interface HumanAuthority {
+  /** Persistence-key form of the human identity. Today: `SessionPayload.sub`,
+   *  `"__stdio__"`, or `"__dev__"`. See spec §2.1. */
+  sub: string;
+  /** Coarse classification of the auth backend; see {@link HumanAuthorityKind}. */
+  kind: HumanAuthorityKind;
+  /** Raw `auth_strategy` from the session token, when present. Mirrors
+   *  `SessionPayload.auth_strategy` from `src/gateway/session.ts`. */
+  auth_strategy?: "siwe" | "inapp_email" | "inapp_oauth" | "dev";
+}
+
+// ---------------------------------------------------------------------------
+// §2.2 — model_attestation
+// ---------------------------------------------------------------------------
+
+/**
+ * Discriminator for {@link ModelAttestation}. See spec §2.2 and §4.
+ *
+ * - `"verified"` — provider-signed JWS verified against published JWKS.
+ *   ONLY this state is safe for capability gating.
+ * - `"self_declared"` — the agent advertised a model claim but no signature
+ *   was verified. Telemetry-only; never gate capabilities on this.
+ * - `"absent"` — no claim was made (or verification failed). Do not branch
+ *   on model identity at all.
+ */
+export type AttestationStatus = "verified" | "self_declared" | "absent";
+
+/** A claim about which AI model produced the agent's actions. See spec §2.2. */
+export type ModelAttestation =
+  | {
+      attestation_status: "verified";
+      provider: string;
+      model_id: string;
+      /** JWS `kid` from the verified attestation. */
+      kid: string;
+      /** Issuance timestamp (seconds since epoch) of the verified JWS. */
+      issued_at: number;
+    }
+  | {
+      attestation_status: "self_declared";
+      provider: string;
+      model_id: string;
+    }
+  | {
+      attestation_status: "absent";
+    };
+
+// ---------------------------------------------------------------------------
+// §2.3 — environment
+// ---------------------------------------------------------------------------
+
+/** Execution surface the agent is running on. See spec §2.3. */
+export type ExecutionSurface = "stdio" | "sse" | "dev";
+
+/**
+ * Cryptographic anchor — the wallet whose private keys actually sign actions.
+ * Matches the active-wallet shape returned by `session_info`. See spec §2.3.
+ */
+export interface WalletAnchor {
+  id: string;
+  /** Base58 Ed25519 public key. Null if the signer could not be loaded. */
+  svm: SvmAddress | null;
+  /** 0x-hex secp256k1 address. Null if the signer could not be loaded. */
+  evm: EvmAddress | null;
+  label?: string | null;
+}
+
+/** Where the agent is executing + its cryptographic anchor. See spec §2.3. */
+export interface Environment {
+  surface: ExecutionSurface;
+  /** Stable per-process identifier; today: the server's `last_restart_iso`. */
+  server_instance: string;
+  /** The active wallet whose keys sign actions. */
+  wallet_anchor: WalletAnchor;
+}
+
+// ---------------------------------------------------------------------------
+// §2.4 — session_scope
+// ---------------------------------------------------------------------------
+
+/** The bounded MCP session window. See spec §2.4. */
+export interface SessionScope {
+  /** Persistence-key form of the scope; mirrors `currentScope()`. */
+  scope: string;
+  /** Session token id (`SessionPayload.jti`) when known. */
+  jti?: string;
+  /** ISO-8601 expiry; null when no token is bound (e.g. stdio). */
+  expires_at_iso: string | null;
+  /** Capabilities granted on the session token; see `CAPABILITY_SCOPES`. */
+  capabilities: string[];
+}
+
+// ---------------------------------------------------------------------------
+// §6 — top-level shape
+// ---------------------------------------------------------------------------
+
+/**
+ * The canonical agent identity tuple. See spec §1 and §6.
+ *
+ * Consumers MUST evaluate all four axes independently; see §3 for the
+ * authority-inheritance rule and §5 for the trust degradation that applies
+ * when `model_attestation.attestation_status !== "verified"`.
+ */
+export interface AgentIdentity {
+  /** §2.1 — who authorized this agent. */
+  human_authority: HumanAuthority;
+  /** §2.2 — which AI model is steering it. */
+  model_attestation: ModelAttestation;
+  /** §2.3 — where it's running and the cryptographic anchor. */
+  environment: Environment;
+  /** §2.4 — bounded MCP session window. */
+  session_scope: SessionScope;
+}
+
+// ---------------------------------------------------------------------------
+// §5 — interim builder
+// ---------------------------------------------------------------------------
+
+/**
+ * Structurally typed input mirroring the `session_info` MCP tool's response
+ * shape. We accept it as a plain shape (not by importing from
+ * `src/tools/session.ts`) so this module stays decoupled from the tool layer.
+ *
+ * See spec §5.
+ */
+export interface InterimAgentIdentityInput {
+  /** From `currentScope()`; required. */
+  scope: string;
+  /** Active wallet id; from `getActiveWalletId()`. */
+  active_wallet_id: string | null;
+  /** Wallet list as returned by `session_info`. */
+  wallets: ReadonlyArray<{
+    id: string;
+    label?: string | null;
+    svm: SvmAddress | null;
+    evm: EvmAddress | null;
+  }>;
+  /** From `SessionPayload.auth_strategy`. */
+  auth_strategy?: "siwe" | "inapp_email" | "inapp_oauth" | "dev" | null;
+  /** ISO string from `session_info.token_expires_at`. */
+  token_expires_at?: string | null;
+  /** ISO string from `session_info.last_restart_iso`. */
+  last_restart_iso: string;
+  /** Optional: caller-declared model. Becomes a `self_declared` attestation. */
+  declared_model?: { provider: string; model_id: string };
+  /** Optional: capabilities from `SessionPayload.caps`. Defaults to `[]`. */
+  capabilities?: ReadonlyArray<string>;
+  /** Optional: `SessionPayload.jti` when available. */
+  jti?: string;
+}
+
+/**
+ * Build an {@link AgentIdentity} from a `session_info`-shaped payload, with
+ * no provider integration. The result always has
+ * `model_attestation.attestation_status` of `"self_declared"` (when
+ * `declared_model` is present) or `"absent"`.
+ *
+ * Pure function — no I/O, no global state.
+ *
+ * @throws {Error} if `scope` is missing or empty (see spec §5: there is no
+ * meaningful identity without a session-scope persistence key).
+ */
+export function buildInterimAgentIdentity(
+  input: InterimAgentIdentityInput,
+): AgentIdentity {
+  if (!input.scope || typeof input.scope !== "string") {
+    throw new Error(
+      "buildInterimAgentIdentity: missing required `session_scope` source — `scope` must be a non-empty string (see docs/agent-identity-model.md §5).",
+    );
+  }
+
+  const human_authority = resolveHumanAuthority(input);
+  const environment = resolveEnvironment(input);
+  const model_attestation: ModelAttestation = input.declared_model
+    ? {
+        attestation_status: "self_declared",
+        provider: input.declared_model.provider,
+        model_id: input.declared_model.model_id,
+      }
+    : { attestation_status: "absent" };
+
+  const session_scope: SessionScope = {
+    scope: input.scope,
+    expires_at_iso: input.token_expires_at ?? null,
+    capabilities: [...(input.capabilities ?? [])],
+    ...(input.jti !== undefined ? { jti: input.jti } : {}),
+  };
+
+  return { human_authority, model_attestation, environment, session_scope };
+}
+
+function resolveHumanAuthority(input: InterimAgentIdentityInput): HumanAuthority {
+  const strategy = input.auth_strategy ?? undefined;
+  let kind: HumanAuthorityKind;
+  if (input.scope === "__stdio__") kind = "stdio";
+  else if (input.scope === "__dev__" || strategy === "dev") kind = "dev";
+  else if (
+    strategy === "siwe" ||
+    strategy === "inapp_email" ||
+    strategy === "inapp_oauth"
+  )
+    kind = "thirdweb";
+  else kind = "unknown";
+
+  return {
+    sub: input.scope,
+    kind,
+    ...(strategy !== undefined ? { auth_strategy: strategy } : {}),
+  };
+}
+
+function resolveEnvironment(input: InterimAgentIdentityInput): Environment {
+  let surface: ExecutionSurface;
+  if (input.scope === "__stdio__") surface = "stdio";
+  else if (input.scope === "__dev__" || input.auth_strategy === "dev") surface = "dev";
+  else surface = "sse";
+
+  const active = input.wallets.find((w) => w.id === input.active_wallet_id) ??
+    input.wallets[0];
+
+  const wallet_anchor: WalletAnchor = active
+    ? {
+        id: active.id,
+        svm: active.svm,
+        evm: active.evm,
+        label: active.label ?? null,
+      }
+    : { id: "", svm: null, evm: null, label: null };
+
+  return {
+    surface,
+    server_instance: input.last_restart_iso,
+    wallet_anchor,
+  };
+}

--- a/tests/models/agent-identity.test.ts
+++ b/tests/models/agent-identity.test.ts
@@ -115,6 +115,9 @@ describe("buildInterimAgentIdentity", () => {
         model_id: "claude-sonnet-4-5",
         kid: "kid-1",
         issued_at: 1_730_000_000,
+        source: "provider_oidc" as const,
+        provider_verified: true,
+        jws: "eyJhbGciOiJFZERTQSJ9.e30.sig",
       },
       environment: {
         surface: "sse",
@@ -130,5 +133,51 @@ describe("buildInterimAgentIdentity", () => {
     } satisfies AgentIdentity;
 
     expect(literal.human_authority.kind).toBe("thirdweb");
+  });
+
+  it("emits source=session_signed verified attestation when verified_session_jws is supplied", () => {
+    const jws = "eyJhbGciOiJFZERTQSJ9.e30.sessionSig";
+    const id = buildInterimAgentIdentity(
+      baseInput({
+        verified_session_jws: {
+          jws,
+          sub: "model-subject-id",
+          model_id: "claude-opus-4-7",
+          provider: "anthropic",
+          exp: 1_800_000_000,
+        },
+      }),
+    );
+
+    expect(id.model_attestation.attestation_status).toBe("verified");
+    if (id.model_attestation.attestation_status === "verified") {
+      expect(id.model_attestation.source).toBe("session_signed");
+      expect(id.model_attestation.provider_verified).toBe(false);
+      expect(id.model_attestation.provider).toBe("anthropic");
+      expect(id.model_attestation.model_id).toBe("claude-opus-4-7");
+      expect(id.model_attestation.jws).toBe(jws);
+      expect(id.model_attestation.kid).toBe("model-subject-id");
+      expect(id.model_attestation.issued_at).toBe(1_800_000_000);
+    }
+  });
+
+  it("verified_session_jws takes precedence over declared_model", () => {
+    const id = buildInterimAgentIdentity(
+      baseInput({
+        verified_session_jws: {
+          jws: "eyJ.e30.sig",
+          sub: "sub-1",
+          model_id: "claude-haiku-4-5",
+          provider: "anthropic",
+          exp: 1_900_000_000,
+        },
+        declared_model: { provider: "openai", model_id: "gpt-4o" },
+      }),
+    );
+
+    expect(id.model_attestation.attestation_status).toBe("verified");
+    if (id.model_attestation.attestation_status === "verified") {
+      expect(id.model_attestation.model_id).toBe("claude-haiku-4-5");
+    }
   });
 });

--- a/tests/models/agent-identity.test.ts
+++ b/tests/models/agent-identity.test.ts
@@ -20,6 +20,22 @@ function baseInput(overrides: Partial<InterimAgentIdentityInput> = {}): InterimA
   };
 }
 
+function verifiedInput(
+  overrides: Partial<InterimAgentIdentityInput> = {},
+): InterimAgentIdentityInput {
+  return baseInput({
+    verified_session_jws:
+      "eyJhbGciOiJFZERTQSIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIweEFsaWNlIn0.sig",
+    verified_session_jws_claims: {
+      provider: "anthropic",
+      model_id: "claude-sonnet-4-5",
+      kid: "kid-test-1",
+      issued_at: 1_730_000_000,
+    },
+    ...overrides,
+  });
+}
+
 describe("buildInterimAgentIdentity", () => {
   it("builds a thirdweb-kind identity with self_declared attestation when declared_model is supplied", () => {
     const id = buildInterimAgentIdentity(
@@ -110,13 +126,13 @@ describe("buildInterimAgentIdentity", () => {
         auth_strategy: "siwe",
       },
       model_attestation: {
-        attestation_status: "verified",
+        attestation_status: "verified" as const,
+        source: "session_signed" as const,
+        provider_verified: false as const,
         provider: "anthropic",
         model_id: "claude-sonnet-4-5",
         kid: "kid-1",
         issued_at: 1_730_000_000,
-        source: "provider_oidc" as const,
-        provider_verified: true,
         jws: "eyJhbGciOiJFZERTQSJ9.e30.sig",
       },
       environment: {
@@ -135,49 +151,112 @@ describe("buildInterimAgentIdentity", () => {
     expect(literal.human_authority.kind).toBe("thirdweb");
   });
 
-  it("emits source=session_signed verified attestation when verified_session_jws is supplied", () => {
-    const jws = "eyJhbGciOiJFZERTQSJ9.e30.sessionSig";
-    const id = buildInterimAgentIdentity(
-      baseInput({
-        verified_session_jws: {
-          jws,
-          sub: "model-subject-id",
-          model_id: "claude-opus-4-7",
-          provider: "anthropic",
-          exp: 1_800_000_000,
-        },
-      }),
-    );
+  it("emits source=session_signed verified attestation when verified_session_jws + claims are supplied", () => {
+    const id = buildInterimAgentIdentity(verifiedInput());
 
     expect(id.model_attestation.attestation_status).toBe("verified");
     if (id.model_attestation.attestation_status === "verified") {
+      // Sub-discriminator narrows to a literal union here.
       expect(id.model_attestation.source).toBe("session_signed");
-      expect(id.model_attestation.provider_verified).toBe(false);
-      expect(id.model_attestation.provider).toBe("anthropic");
-      expect(id.model_attestation.model_id).toBe("claude-opus-4-7");
-      expect(id.model_attestation.jws).toBe(jws);
-      expect(id.model_attestation.kid).toBe("model-subject-id");
-      expect(id.model_attestation.issued_at).toBe(1_800_000_000);
+      if (id.model_attestation.source === "session_signed") {
+        expect(id.model_attestation.provider_verified).toBe(false);
+        expect(id.model_attestation.provider).toBe("anthropic");
+        expect(id.model_attestation.model_id).toBe("claude-sonnet-4-5");
+        expect(id.model_attestation.kid).toBe("kid-test-1");
+        expect(id.model_attestation.issued_at).toBe(1_730_000_000);
+        expect(id.model_attestation.jws).toBe(
+          "eyJhbGciOiJFZERTQSIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIweEFsaWNlIn0.sig",
+        );
+      }
     }
   });
 
-  it("verified_session_jws takes precedence over declared_model", () => {
+  it("verified arm overrides declared_model (precedence rule)", () => {
     const id = buildInterimAgentIdentity(
-      baseInput({
-        verified_session_jws: {
-          jws: "eyJ.e30.sig",
-          sub: "sub-1",
-          model_id: "claude-haiku-4-5",
-          provider: "anthropic",
-          exp: 1_900_000_000,
-        },
+      verifiedInput({
         declared_model: { provider: "openai", model_id: "gpt-4o" },
       }),
     );
 
     expect(id.model_attestation.attestation_status).toBe("verified");
     if (id.model_attestation.attestation_status === "verified") {
-      expect(id.model_attestation.model_id).toBe("claude-haiku-4-5");
+      // Verified-arm provider wins over declared_model.
+      expect(id.model_attestation.provider).toBe("anthropic");
+      expect(id.model_attestation.model_id).toBe("claude-sonnet-4-5");
     }
+  });
+
+  it("suppresses verified arm under __stdio__ scope", () => {
+    const id = buildInterimAgentIdentity(
+      verifiedInput({ scope: "__stdio__", auth_strategy: null }),
+    );
+    expect(id.model_attestation.attestation_status).toBe("absent");
+  });
+
+  it("suppresses verified arm under __dev__ scope", () => {
+    const id = buildInterimAgentIdentity(
+      verifiedInput({ scope: "__dev__", auth_strategy: null }),
+    );
+    expect(id.model_attestation.attestation_status).toBe("absent");
+  });
+
+  it("suppresses verified arm under auth_strategy: 'dev'", () => {
+    const id = buildInterimAgentIdentity(verifiedInput({ auth_strategy: "dev" }));
+    expect(id.model_attestation.attestation_status).toBe("absent");
+  });
+
+  it("falls through to absent when verified_session_jws is supplied without claims", () => {
+    const id = buildInterimAgentIdentity(
+      baseInput({ verified_session_jws: "abc.def.ghi" }),
+    );
+    expect(id.model_attestation.attestation_status).toBe("absent");
+  });
+
+  it("falls through to absent when verified_session_jws_claims is supplied without jws", () => {
+    const id = buildInterimAgentIdentity(
+      baseInput({
+        verified_session_jws_claims: {
+          provider: "p",
+          model_id: "m",
+          kid: "k",
+          issued_at: 1,
+        },
+      }),
+    );
+    expect(id.model_attestation.attestation_status).toBe("absent");
+  });
+
+  it("type-level: a provider_oidc verified literal satisfies AgentIdentity", () => {
+    const literal = {
+      human_authority: {
+        sub: "0xAlice",
+        kind: "thirdweb",
+        auth_strategy: "siwe",
+      },
+      model_attestation: {
+        attestation_status: "verified" as const,
+        source: "provider_oidc" as const,
+        provider_verified: true as const,
+        provider: "anthropic",
+        model_id: "claude-sonnet-4-5",
+        kid: "kid-oidc-1",
+        issued_at: 1_730_000_000,
+        jws: "eyJhbGciOiJFZERTQSJ9.e30.providerSig",
+      },
+      environment: {
+        surface: "sse",
+        server_instance: "2026-05-01T00:00:00.000Z",
+        wallet_anchor: { id: "w-1", svm: null, evm: null, label: null },
+      },
+      session_scope: {
+        scope: "0xAlice",
+        jti: "jti-1",
+        expires_at_iso: "2030-01-01T00:00:00.000Z",
+        capabilities: ["wallet:read"],
+      },
+    } satisfies AgentIdentity;
+
+    expect(literal.model_attestation.source).toBe("provider_oidc");
+    expect(literal.model_attestation.provider_verified).toBe(true);
   });
 });

--- a/tests/models/agent-identity.test.ts
+++ b/tests/models/agent-identity.test.ts
@@ -1,0 +1,134 @@
+import { describe, it, expect } from "vitest";
+import {
+  buildInterimAgentIdentity,
+  type AgentIdentity,
+  type InterimAgentIdentityInput,
+} from "../../src/models/agent-identity.js";
+
+function baseInput(overrides: Partial<InterimAgentIdentityInput> = {}): InterimAgentIdentityInput {
+  return {
+    scope: "0xAlice",
+    active_wallet_id: "w-1",
+    wallets: [
+      { id: "w-1", label: "primary", svm: "SoMeBaSe58Pubkey", evm: "0xabc" },
+    ],
+    auth_strategy: "siwe",
+    token_expires_at: "2030-01-01T00:00:00.000Z",
+    last_restart_iso: "2026-05-01T00:00:00.000Z",
+    capabilities: ["wallet:read", "transfer:write"],
+    ...overrides,
+  };
+}
+
+describe("buildInterimAgentIdentity", () => {
+  it("builds a thirdweb-kind identity with self_declared attestation when declared_model is supplied", () => {
+    const id = buildInterimAgentIdentity(
+      baseInput({
+        declared_model: { provider: "anthropic", model_id: "claude-sonnet-4-5" },
+      }),
+    );
+
+    expect(id.human_authority.kind).toBe("thirdweb");
+    expect(id.human_authority.sub).toBe("0xAlice");
+    expect(id.human_authority.auth_strategy).toBe("siwe");
+
+    expect(id.model_attestation.attestation_status).toBe("self_declared");
+    if (id.model_attestation.attestation_status === "self_declared") {
+      expect(id.model_attestation.provider).toBe("anthropic");
+      expect(id.model_attestation.model_id).toBe("claude-sonnet-4-5");
+    }
+
+    expect(id.environment.surface).toBe("sse");
+    expect(id.environment.wallet_anchor).toEqual({
+      id: "w-1",
+      svm: "SoMeBaSe58Pubkey",
+      evm: "0xabc",
+      label: "primary",
+    });
+
+    expect(id.session_scope.scope).toBe("0xAlice");
+    expect(id.session_scope.expires_at_iso).toBe("2030-01-01T00:00:00.000Z");
+    expect(id.session_scope.capabilities).toEqual(["wallet:read", "transfer:write"]);
+  });
+
+  it("emits attestation_status: absent when declared_model is omitted", () => {
+    const id = buildInterimAgentIdentity(baseInput());
+    expect(id.model_attestation.attestation_status).toBe("absent");
+  });
+
+  it("falls back to kind=stdio with surface=stdio under __stdio__ scope and no auth_strategy", () => {
+    const id = buildInterimAgentIdentity(
+      baseInput({ scope: "__stdio__", auth_strategy: null }),
+    );
+    expect(id.human_authority.kind).toBe("stdio");
+    expect(id.human_authority.auth_strategy).toBeUndefined();
+    expect(id.environment.surface).toBe("stdio");
+  });
+
+  it("falls back to kind=dev with surface=dev under __dev__ scope and no auth_strategy", () => {
+    const id = buildInterimAgentIdentity(
+      baseInput({ scope: "__dev__", auth_strategy: null }),
+    );
+    expect(id.human_authority.kind).toBe("dev");
+    expect(id.environment.surface).toBe("dev");
+  });
+
+  it("defaults capabilities to [] when omitted (no throw)", () => {
+    const input = baseInput();
+    delete (input as Partial<InterimAgentIdentityInput>).capabilities;
+    const id = buildInterimAgentIdentity(input);
+    expect(id.session_scope.capabilities).toEqual([]);
+  });
+
+  it("falls back to first wallet when active_wallet_id is null", () => {
+    const id = buildInterimAgentIdentity(baseInput({ active_wallet_id: null }));
+    expect(id.environment.wallet_anchor.id).toBe("w-1");
+  });
+
+  it("emits an empty wallet_anchor when wallets is empty", () => {
+    const id = buildInterimAgentIdentity(
+      baseInput({ wallets: [], active_wallet_id: null }),
+    );
+    expect(id.environment.wallet_anchor).toEqual({
+      id: "",
+      svm: null,
+      evm: null,
+      label: null,
+    });
+  });
+
+  it("rejects an input with no scope, referencing session_scope in the error", () => {
+    const bad = baseInput({ scope: "" });
+    expect(() => buildInterimAgentIdentity(bad)).toThrow(/session_scope/);
+  });
+
+  it("type-level: a fully-populated literal satisfies AgentIdentity", () => {
+    const literal = {
+      human_authority: {
+        sub: "0xAlice",
+        kind: "thirdweb",
+        auth_strategy: "siwe",
+      },
+      model_attestation: {
+        attestation_status: "verified",
+        provider: "anthropic",
+        model_id: "claude-sonnet-4-5",
+        kid: "kid-1",
+        issued_at: 1_730_000_000,
+      },
+      environment: {
+        surface: "sse",
+        server_instance: "2026-05-01T00:00:00.000Z",
+        wallet_anchor: { id: "w-1", svm: null, evm: null, label: null },
+      },
+      session_scope: {
+        scope: "0xAlice",
+        jti: "jti-1",
+        expires_at_iso: "2030-01-01T00:00:00.000Z",
+        capabilities: ["wallet:read"],
+      },
+    } satisfies AgentIdentity;
+
+    expect(literal.human_authority.kind).toBe("thirdweb");
+  });
+});


### PR DESCRIPTION
## Summary
- Adds `source: "session_signed" | "provider_oidc"` sub-discriminator under `attestation_status: "verified"` in `ModelAttestation`
- Adds `provider_verified: boolean` and `jws: string` fields to the verified variant
- Extends `InterimAgentIdentityInput` with optional `verified_session_jws` (and parsed claims)
- `buildInterimAgentIdentity` emits `source: "session_signed"` when `verified_session_jws` is supplied, taking precedence over `declared_model`
- Updates `tests/models/agent-identity.test.ts` to cover all four discriminants (verified/session_signed, verified/provider_oidc, self_declared, absent)
- Adds `docs/agent-identity-model.md` spec doc

Note: depends on FN-095 (AgentIdentity model foundation) which is in PR #148.

## Test plan
- [x] `bun run test -- tests/models/agent-identity.test.ts` → 17 passed
- [x] `npm run typecheck` → 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)