### PR TITLE
feat(FN-049): mint session attestation JWS at authenticate() time

### DIFF
--- a/src/gateway/auth.ts
+++ b/src/gateway/auth.ts
@@ -2,11 +2,18 @@ import { AsyncLocalStorage } from "node:async_hooks";
 import { config } from "../config.js";
 import { verifySession, hasCapability, CAPABILITY_SCOPES, type Capability, type SessionPayload } from "./session.js";
 import { McpError } from "../errors/index.js";
+import { mintSessionAttestation } from "./session-attestation.js";
 
 export interface AuthContext {
   session: SessionPayload;
   userId: string;
   walletId: string;
+  /**
+   * FN-049: compact-JWS session attestation signed by the server's Ed25519 key.
+   * Null for stdio (__stdio__), dev-bypass, and any session where minting fails.
+   * Non-null for siwe / inapp_email / inapp_oauth sessions.
+   */
+  session_attestation_jws: string | null;
 }
 
 // Ambient bearer token for the current request. The SSE server extracts the
@@ -48,14 +55,20 @@ const DEV_SESSION: SessionPayload = {
 /**
  * Authenticate a request. In dev mode, bypasses auth entirely.
  * In production, verifies the PASETO/HMAC session token.
+ *
+ * FN-049: For non-stdio, non-dev sessions (siwe / inapp_email / inapp_oauth),
+ * mints a compact-JWS session attestation signed by the server's Ed25519 key.
+ * The JWS is returned on `AuthContext.session_attestation_jws`. Failures in
+ * minting never hard-fail auth — the field is null instead.
  */
 export function authenticate(authHeader?: string): AuthContext {
-  // Dev bypass
+  // Dev bypass — no attestation for dev sessions.
   if (config.auth.devBypass) {
     return {
       session: DEV_SESSION,
       userId: DEV_SESSION.sub,
       walletId: DEV_SESSION.wallet_id,
+      session_attestation_jws: null,
     };
   }
 
@@ -84,10 +97,34 @@ export function authenticate(authHeader?: string): AuthContext {
     );
   }
 
+  // FN-049: Mint a session attestation JWS for non-dev, non-stdio strategies.
+  // The auth_strategy field distinguishes real human-attested sessions
+  // (siwe / inapp_email / inapp_oauth) from dev bypass (already short-circuited
+  // above). stdio sessions don't reach this code path (they don't carry tokens).
+  let session_attestation_jws: string | null = null;
+  const strategy = session.auth_strategy;
+  if (
+    strategy === "siwe" ||
+    strategy === "inapp_email" ||
+    strategy === "inapp_oauth"
+  ) {
+    try {
+      session_attestation_jws = mintSessionAttestation({
+        sub: session.sub,
+        jti: session.jti,
+        exp: session.exp,
+      });
+    } catch {
+      // Never hard-fail auth due to attestation minting failure.
+      session_attestation_jws = null;
+    }
+  }
+
   return {
     session,
     userId: session.sub,
     walletId: session.wallet_id,
+    session_attestation_jws,
   };
 }
 

--- a/src/gateway/session-attestation.ts
+++ b/src/gateway/session-attestation.ts
@@ -1,0 +1,102 @@
+// FN-049 — Session attestation JWS minter.
+//
+// Produces a compact-JWS (RFC 7515) signed by the server's Ed25519 key from
+// `src/signing/server-key.ts`. The JWS body encodes a minimal attestation
+// claim set tying the session identity to a model declaration.
+//
+// This module is intentionally decoupled from `src/gateway/auth.ts` to keep
+// the attestation logic testable in isolation. `authenticate()` in auth.ts
+// calls `mintSessionAttestation()` after verifying the session token for
+// non-stdio, non-dev sessions.
+//
+// Attestation payload fields:
+//   iss  — "eto-mcp" (fixed issuer)
+//   sub  — session subject (from SessionPayload.sub)
+//   jti  — session token id (from SessionPayload.jti)
+//   aud  — "eto-agent" (fixed audience)
+//   iat  — seconds since epoch, minted now
+//   exp  — session expiry (from SessionPayload.exp)
+//   model_id     — caller-declared model id (optional, string)
+//   provider     — caller-declared provider  (optional, string)
+//
+// The JWS header carries `{ alg: "EdDSA", kid: <current-kid> }`.
+
+import * as ed from "@noble/ed25519";
+import { sha512 } from "@noble/hashes/sha512";
+import {
+  getServerSigningKey,
+} from "../signing/server-key.js";
+import { getCurrentKid } from "../signing/jwks.js";
+
+// Ensure sha512Sync is installed (idempotent).
+ed.etc.sha512Sync = (...m: Uint8Array[]) => sha512(ed.etc.concatBytes(...m));
+
+/** RFC 7515 §2 base64url (no padding). */
+function b64url(bytes: Uint8Array): string {
+  return Buffer.from(bytes)
+    .toString("base64")
+    .replace(/\+/g, "-")
+    .replace(/\//g, "_")
+    .replace(/=+$/g, "");
+}
+
+function b64urlJson(obj: unknown): string {
+  return b64url(new TextEncoder().encode(JSON.stringify(obj)));
+}
+
+export interface SessionAttestationInput {
+  /** SessionPayload.sub */
+  sub: string;
+  /** SessionPayload.jti */
+  jti: string;
+  /** SessionPayload.exp (seconds since epoch) */
+  exp: number;
+  /** Caller-declared model id (optional) */
+  model_id_declared?: string;
+  /** Caller-declared provider (optional) */
+  provider_declared?: string;
+  /** Audience; defaults to "eto-agent" */
+  aud?: string;
+}
+
+/** Compact-JWS attestation token. Verify with the server's published JWKS. */
+export type SessionAttestationJws = string;
+
+/**
+ * Mint a compact-JWS session attestation signed by the server's Ed25519 key.
+ *
+ * Returns the JWS string. Throws only on signing failure (e.g., missing key
+ * in production). Call-sites in `authenticate()` catch and fall back to null
+ * to ensure auth never hard-fails due to attestation minting.
+ */
+export function mintSessionAttestation(
+  input: SessionAttestationInput,
+): SessionAttestationJws {
+  const kid = getCurrentKid();
+
+  const header = b64urlJson({ alg: "EdDSA", kid });
+
+  const payload: Record<string, unknown> = {
+    iss: "eto-mcp",
+    sub: input.sub,
+    jti: input.jti,
+    aud: input.aud ?? "eto-agent",
+    iat: Math.floor(Date.now() / 1000),
+    exp: input.exp,
+  };
+  if (typeof input.model_id_declared === "string") {
+    payload["model_id"] = input.model_id_declared;
+  }
+  if (typeof input.provider_declared === "string") {
+    payload["provider"] = input.provider_declared;
+  }
+
+  const body = b64urlJson(payload);
+  const signingInput = `${header}.${body}`;
+  const signingInputBytes = new TextEncoder().encode(signingInput);
+
+  const { privateKey } = getServerSigningKey();
+  const sig = ed.sign(signingInputBytes, privateKey);
+
+  return `${signingInput}.${b64url(sig)}`;
+}

--- a/src/signing/jwks.ts
+++ b/src/signing/jwks.ts
@@ -98,6 +98,11 @@ function purgeExpired(now: Date): void {
   if (now.getTime() > expiresAt) overlap = null;
 }
 
+/** Returns the `kid` for the current server key (without building the full JWKS doc). */
+export function getCurrentKid(): string {
+  return computeKid(getServerInstance(), rotationEpoch);
+}
+
 /** Returns the JWKS to publish at the well-known endpoint. */
 export function getCurrentJwks(now: Date = new Date()): Jwks {
   purgeExpired(now);

--- a/tests/gateway/session-attestation.test.ts
+++ b/tests/gateway/session-attestation.test.ts
@@ -1,0 +1,103 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { createSession, type AuthStrategy } from "../../src/gateway/session.js";
+import { authenticate } from "../../src/gateway/auth.js";
+import { __resetForTests } from "../../src/signing/server-key.js";
+import * as ed from "@noble/ed25519";
+import { sha512 } from "@noble/hashes/sha512";
+
+// Ensure sha512Sync is installed for tests.
+ed.etc.sha512Sync = (...m: Uint8Array[]) => sha512(ed.etc.concatBytes(...m));
+
+// Helpers
+function makeToken(strategy: AuthStrategy, ttlSeconds = 3600): string {
+  return createSession({
+    userId: `user-${strategy}`,
+    walletId: "wallet-1",
+    network: "testnet",
+    capabilities: ["wallet:read"],
+    ttlSeconds,
+    authStrategy: strategy,
+  });
+}
+
+/** Decode a compact-JWS without verifying — for test assertions. */
+function decodeJws(jws: string): { header: Record<string, unknown>; payload: Record<string, unknown> } {
+  const [headerB64, payloadB64] = jws.split(".");
+  const header = JSON.parse(Buffer.from(headerB64, "base64url").toString("utf8"));
+  const payload = JSON.parse(Buffer.from(payloadB64, "base64url").toString("utf8"));
+  return { header, payload };
+}
+
+beforeEach(() => {
+  // Reset the server key so each test starts with a fresh ephemeral key.
+  __resetForTests();
+});
+
+describe("FN-049: mintSessionAttestation via authenticate()", () => {
+  it("mints a compact-JWS for a siwe session", () => {
+    const token = makeToken("siwe");
+    // authenticate() uses ambient bearer; supply explicit header.
+    process.env["ETO_AUTH_DEV_BYPASS"] = ""; // ensure dev bypass is off in this test
+    const ctx = authenticate(`Bearer ${token}`);
+    expect(ctx.session_attestation_jws).not.toBeNull();
+    const jws = ctx.session_attestation_jws!;
+    expect(jws.split(".").length).toBe(3);
+    const { header, payload } = decodeJws(jws);
+    expect(header["alg"]).toBe("EdDSA");
+    expect(typeof header["kid"]).toBe("string");
+    expect(payload["iss"]).toBe("eto-mcp");
+    expect(payload["sub"]).toBe("user-siwe");
+    expect(payload["aud"]).toBe("eto-agent");
+    expect(typeof payload["jti"]).toBe("string");
+    expect(typeof payload["iat"]).toBe("number");
+    expect(typeof payload["exp"]).toBe("number");
+  });
+
+  it("mints a JWS for inapp_email strategy", () => {
+    const token = makeToken("inapp_email");
+    const ctx = authenticate(`Bearer ${token}`);
+    expect(ctx.session_attestation_jws).not.toBeNull();
+    const { payload } = decodeJws(ctx.session_attestation_jws!);
+    expect(payload["sub"]).toBe("user-inapp_email");
+  });
+
+  it("mints a JWS for inapp_oauth strategy", () => {
+    const token = makeToken("inapp_oauth");
+    const ctx = authenticate(`Bearer ${token}`);
+    expect(ctx.session_attestation_jws).not.toBeNull();
+    const { payload } = decodeJws(ctx.session_attestation_jws!);
+    expect(payload["sub"]).toBe("user-inapp_oauth");
+  });
+
+  it("returns null session_attestation_jws for dev strategy (when devBypass off, dev token)", () => {
+    const token = makeToken("dev");
+    const ctx = authenticate(`Bearer ${token}`);
+    // dev strategy sessions should not get a JWS
+    expect(ctx.session_attestation_jws).toBeNull();
+  });
+
+  it("returns null session_attestation_jws for dev strategy token (no JWS for dev sessions)", () => {
+    // dev strategy sessions don't get a JWS — already covered above by the
+    // "dev strategy" test. Verify explicitly that dev-bypass auth also returns null
+    // by checking the dev session constant exposed through a no-header call
+    // when devBypass is active. Since we cannot easily toggle the singleton,
+    // we verify indirectly: a token with auth_strategy "dev" returns null.
+    const token = makeToken("dev");
+    const ctx = authenticate(`Bearer ${token}`);
+    expect(ctx.session_attestation_jws).toBeNull();
+  });
+
+  it("JWS signature is verifiable with the server public key", async () => {
+    const token = makeToken("siwe");
+    const ctx = authenticate(`Bearer ${token}`);
+    const jws = ctx.session_attestation_jws!;
+    const [headerB64, payloadB64, sigB64] = jws.split(".");
+    const signingInput = new TextEncoder().encode(`${headerB64}.${payloadB64}`);
+    const sig = new Uint8Array(Buffer.from(sigB64, "base64url"));
+    // Import after reset so we get the same key instance
+    const { getServerPublicKeyBytes } = await import("../../src/signing/server-key.js");
+    const pubKey = getServerPublicKeyBytes();
+    const valid = await ed.verify(sig, signingInput, pubKey);
+    expect(valid).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- Adds `src/gateway/session-attestation.ts` with `mintSessionAttestation()` — produces a compact-JWS (EdDSA, RFC 7515) for non-stdio, non-dev sessions
- Extends `AuthContext` with `session_attestation_jws: string | null` — non-null for siwe / inapp_email / inapp_oauth, null for dev-bypass and dev-strategy sessions
- Adds `getCurrentKid()` helper to `src/signing/jwks.ts` (FN-048 module) to avoid re-computing the kid
- Tests cover all three real auth strategies, dev-strategy null case, and end-to-end EdDSA signature verification

Note: depends on FN-048 (JWKS / server signing key). Base branch is `fusion/fn-048`.

## Test plan
- [x] `bun run test -- tests/gateway/session-attestation.test.ts` → 6 passed
- [x] `npm run typecheck` → 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)