### PR TITLE
feat(FN-050): surface model_attestation_jws in session_info tool

### DIFF
--- a/src/tools/session.ts
+++ b/src/tools/session.ts
@@ -1,8 +1,10 @@
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod";
 import { localSignerFactory } from "../signing/local-signer.js";
 import { currentScope } from "../signing/session-context.js";
 import { getActiveWalletId } from "./wallet.js";
 import { authenticate } from "../gateway/auth.js";
+import { mintSessionAttestation } from "../gateway/session-attestation.js";
 import { getServerInstance } from "../signing/server-key.js";
 
 // FN-048: `last_restart_iso` is sourced from the canonical owner in
@@ -12,9 +14,14 @@ import { getServerInstance } from "../signing/server-key.js";
 export function registerSessionTools(server: McpServer): void {
   server.tool(
     "session_info",
-    "Returns a snapshot of the current MCP session: the caller's scope (thirdweb sub / __stdio__ / __dev__), their persisted wallets with derived SVM+EVM addresses, the active wallet id, the declared auth strategy on the session token, and the server's last restart timestamp. Useful for agents that want to confirm they landed on the same wallet set after an SSE reconnect.",
-    {},
-    async () => {
+    "Returns a snapshot of the current MCP session: the caller's scope (thirdweb sub / __stdio__ / __dev__), their persisted wallets with derived SVM+EVM addresses, the active wallet id, the declared auth strategy on the session token, and the server's last restart timestamp. Pass declared_model to mint a session attestation JWS tying your declared model identity to this session. Useful for agents that want to confirm they landed on the same wallet set after an SSE reconnect.",
+    {
+      declared_model: z.object({
+        provider: z.string().describe("AI provider name (e.g. 'anthropic')"),
+        model_id: z.string().describe("Model identifier (e.g. 'claude-sonnet-4-5')"),
+      }).optional().describe("Caller-declared model identity. When provided, mints a session attestation JWS. Absent in stdio/dev sessions."),
+    },
+    async (args) => {
       try {
         const scope = currentScope();
         const walletIds = await localSignerFactory.listWallets();
@@ -38,16 +45,37 @@ export function registerSessionTools(server: McpServer): void {
         let authStrategy: string | undefined;
         let tokenExpiresAt: string | null = null;
         let tokenExpiresInSeconds: number | null = null;
+        let sessionAttestationJws: string | null = null;
+
         try {
-          const { session } = authenticate();
-          authStrategy = session.auth_strategy;
-          if (session.exp) {
+          const authCtx = authenticate();
+          authStrategy = authCtx.session.auth_strategy;
+          if (authCtx.session.exp) {
             const now = Math.floor(Date.now() / 1000);
-            tokenExpiresAt = new Date(session.exp * 1000).toISOString();
-            tokenExpiresInSeconds = Math.max(0, session.exp - now);
+            tokenExpiresAt = new Date(authCtx.session.exp * 1000).toISOString();
+            tokenExpiresInSeconds = Math.max(0, authCtx.session.exp - now);
+          }
+          // FN-050: if declared_model is supplied and we have a valid session,
+          // mint a fresh attestation JWS that includes the model claim.
+          if (args.declared_model && authCtx.session_attestation_jws !== null) {
+            try {
+              sessionAttestationJws = mintSessionAttestation({
+                sub: authCtx.session.sub,
+                jti: authCtx.session.jti,
+                exp: authCtx.session.exp,
+                model_id_declared: args.declared_model.model_id,
+                provider_declared: args.declared_model.provider,
+              });
+            } catch {
+              // Fall back to the base JWS minted at auth time.
+              sessionAttestationJws = authCtx.session_attestation_jws;
+            }
+          } else {
+            // No declared_model — surface the attestation minted at auth time (may be null).
+            sessionAttestationJws = authCtx.session_attestation_jws;
           }
         } catch {
-          // No session (unauth or error) — leave undefined
+          // No session (unauth or error) — leave undefined/null
         }
 
         const payload = {
@@ -58,6 +86,8 @@ export function registerSessionTools(server: McpServer): void {
           token_expires_at: tokenExpiresAt,
           token_expires_in_seconds: tokenExpiresInSeconds,
           last_restart_iso: getServerInstance(),
+          // FN-050: null in stdio / dev / when no declared_model and no real auth.
+          model_attestation_jws: sessionAttestationJws,
         };
 
         return { content: [{ type: "text" as const, text: JSON.stringify(payload, null, 2) }] };

--- a/tests/unit/session-info-attestation.test.ts
+++ b/tests/unit/session-info-attestation.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { mintSessionAttestation } from "../../src/gateway/session-attestation.js";
+import { __resetForTests } from "../../src/signing/server-key.js";
+import * as ed from "@noble/ed25519";
+import { sha512 } from "@noble/hashes/sha512";
+
+ed.etc.sha512Sync = (...m: Uint8Array[]) => sha512(ed.etc.concatBytes(...m));
+
+// FN-050: unit tests for the session_info model_attestation_jws field.
+//
+// Tests verify that mintSessionAttestation correctly embeds declared model
+// fields (model_id, provider) into the JWS payload, and that the JWS shape
+// is correct when model fields are absent (null case).
+
+function decodePayload(jws: string): Record<string, unknown> {
+  const [, payloadB64] = jws.split(".");
+  return JSON.parse(Buffer.from(payloadB64, "base64url").toString("utf8"));
+}
+
+const BASE_INPUT = {
+  sub: "user-siwe",
+  jti: "jti-test-1",
+  exp: Math.floor(Date.now() / 1000) + 3600,
+};
+
+beforeEach(() => {
+  __resetForTests();
+});
+
+describe("FN-050: model_attestation_jws surface in session_info", () => {
+  it("JWS payload includes model_id and provider when declared_model is supplied", () => {
+    const jws = mintSessionAttestation({
+      ...BASE_INPUT,
+      model_id_declared: "claude-sonnet-4-5",
+      provider_declared: "anthropic",
+    });
+    const payload = decodePayload(jws);
+    expect(payload["model_id"]).toBe("claude-sonnet-4-5");
+    expect(payload["provider"]).toBe("anthropic");
+    expect(payload["sub"]).toBe("user-siwe");
+  });
+
+  it("JWS payload omits model_id and provider when declared_model is absent", () => {
+    const jws = mintSessionAttestation(BASE_INPUT);
+    const payload = decodePayload(jws);
+    expect(payload["model_id"]).toBeUndefined();
+    expect(payload["provider"]).toBeUndefined();
+    // Core fields still present
+    expect(payload["sub"]).toBe("user-siwe");
+    expect(payload["iss"]).toBe("eto-mcp");
+  });
+
+  it("JWS has three dot-separated parts (compact-JWS format)", () => {
+    const jws = mintSessionAttestation(BASE_INPUT);
+    expect(jws.split(".").length).toBe(3);
+  });
+
+  it("JWS header carries alg: EdDSA", () => {
+    const jws = mintSessionAttestation(BASE_INPUT);
+    const [headerB64] = jws.split(".");
+    const header = JSON.parse(Buffer.from(headerB64, "base64url").toString("utf8"));
+    expect(header["alg"]).toBe("EdDSA");
+  });
+});


### PR DESCRIPTION
## Summary
- Extends `session_info` MCP tool with optional `declared_model` input (`{ provider, model_id }`)
- Adds `model_attestation_jws: string | null` to the `session_info` response shape
- When `declared_model` is supplied and a real session is active, mints a fresh JWS embedding the model claim via `mintSessionAttestation()`
- Null in stdio / dev / unauthenticated sessions (no real auth context)
- Tests verify JWS payload shape with and without `declared_model`, compact-JWS format, and EdDSA header

Note: depends on FN-049 (session attestation minter). Base branch is `fusion/fn-049`.

## Test plan
- [x] `bun run test -- tests/unit/session-info-attestation.test.ts` → 4 passed
- [x] `npm run typecheck` → 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)