### PR TITLE
feat(FN-100): add price.cents to web-research BPP config

### DIFF
--- a/keeper/bpps/web-research/config.ts
+++ b/keeper/bpps/web-research/config.ts
@@ -17,7 +17,7 @@ export const tags: CapabilityTags = {
   domain: "web",
   action: "research",
   version: "1.0.0",
-  price: { amount: "0.50", currency: "ETO" },
+  price: { amount: "0.50", currency: "ETO", cents: 50 },
   // TODO(FN-081): once the verified-human credential schema lands,
   // populate this with the schema hash so the BPP rejects anonymous
   // BAPs at Beckn `init`.

--- a/keeper/templates/bpp/types.ts
+++ b/keeper/templates/bpp/types.ts
@@ -106,6 +106,8 @@ export interface CapabilityTags {
   readonly price: {
     readonly amount: string;
     readonly currency: Currency;
+    /** Integer minor units (cents for USD/EUSD; ETO micro-units for ETO). Added by FN-100/ADR-0001. */
+    readonly cents?: number;
   };
   /** Credentials the BAP must present at Beckn `init` time. */
   readonly requiredCredentials: readonly RequiredCredential[];
@@ -276,6 +278,7 @@ export const zCapabilityTags = z
       .object({
         amount: z.string().regex(/^\d+(\.\d+)?$/, "decimal amount string"),
         currency: z.enum(SUPPORTED_CURRENCIES),
+        cents: z.number().int().nonnegative().optional(),
       })
       .strict(),
     requiredCredentials: z.array(zRequiredCredential),

--- a/tests/unit/web-research-bpp.test.ts
+++ b/tests/unit/web-research-bpp.test.ts
@@ -90,7 +90,7 @@ describe("config + tags", () => {
     expect(tags.domain).toBe("web");
     expect(tags.action).toBe("research");
     expect(tags.version).toBe("1.0.0");
-    expect(tags.price).toEqual({ amount: "0.50", currency: "ETO" });
+    expect(tags.price).toEqual({ amount: "0.50", currency: "ETO", cents: 50 });
     expect(tags.requiredCredentials).toEqual([]);
     expect(tags.description.length).toBeLessThanOrEqual(512);
   });


### PR DESCRIPTION
## Summary
- Adds optional `cents?: number` field to `CapabilityTags.price` type and Zod schema (ADR-0001 follow-up)
- Sets `cents: 50` in `keeper/bpps/web-research/config.ts` alongside existing `{ amount: "0.50", currency: "ETO" }`
- Updates catalog-publish assertion in `tests/unit/web-research-bpp.test.ts`

## Test plan
- [ ] `pnpm test tests/unit/web-research-bpp.test.ts` passes (57 tests)
- [ ] `pnpm tsc -p tsconfig.build.json --noEmit` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)