### PR TITLE
feat(FN-101): add price.cents to bank BPP umbrella tags

### DIFF
--- a/keeper/bpps/bank/config.ts
+++ b/keeper/bpps/bank/config.ts
@@ -76,7 +76,7 @@ export const BANK_UMBRELLA_TAGS: CapabilityTags = {
   domain: "bank",
   action: "catalog",
   version: "0.1.0",
-  price: { amount: "0", currency: "ETO" },
+  price: { amount: "0", currency: "ETO", cents: 0 },
   // TODO(FN-099): add the verified-human + kyc.us-test required
   // credentials once the gate policy lands.
   requiredCredentials: [],

--- a/keeper/templates/bpp/types.ts
+++ b/keeper/templates/bpp/types.ts
@@ -106,6 +106,8 @@ export interface CapabilityTags {
   readonly price: {
     readonly amount: string;
     readonly currency: Currency;
+    /** Integer minor units (cents for USD/EUSD; ETO micro-units for ETO). Added by ADR-0001. */
+    readonly cents?: number;
   };
   /** Credentials the BAP must present at Beckn `init` time. */
   readonly requiredCredentials: readonly RequiredCredential[];
@@ -276,6 +278,7 @@ export const zCapabilityTags = z
       .object({
         amount: z.string().regex(/^\d+(\.\d+)?$/, "decimal amount string"),
         currency: z.enum(SUPPORTED_CURRENCIES),
+        cents: z.number().int().nonnegative().optional(),
       })
       .strict(),
     requiredCredentials: z.array(zRequiredCredential),

--- a/tests/unit/bank-bpp.test.ts
+++ b/tests/unit/bank-bpp.test.ts
@@ -126,6 +126,11 @@ describe("buildBankCatalog", () => {
     }
   });
 
+  it("umbrella tags carry cents: 0 (ADR-0001)", () => {
+    const { tags } = buildConfig({ authority: FIXED_BPP_AUTHORITY });
+    expect(tags.price).toEqual({ amount: "0", currency: "ETO", cents: 0 });
+  });
+
   it("accepts pricing overrides", () => {
     const c = buildBankCatalog({
       bppAuthority: FIXED_BPP_AUTHORITY,


### PR DESCRIPTION
## Summary
- Adds optional `cents?: number` field to `CapabilityTags.price` type and Zod schema (ADR-0001 follow-up)
- Sets `cents: 0` in `BANK_UMBRELLA_TAGS` in `keeper/bpps/bank/config.ts` (free capability advertisement)
- Adds umbrella tags price assertion in `tests/unit/bank-bpp.test.ts`

## Test plan
- [ ] `pnpm test tests/unit/bank-bpp.test.ts` passes (51 tests)
- [ ] `pnpm tsc -p tsconfig.build.json --noEmit` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)