### PR TITLE
fix(FN-062): remove stale workaround comments after config.ts dedup

### DIFF
--- a/tests/unit/rpc-client-faucet.test.ts
+++ b/tests/unit/rpc-client-faucet.test.ts
@@ -5,11 +5,9 @@
  * returned as a fallback, turning rate-limit / mock-faucet error payloads
  * into strings that callers treated as real signatures.
  *
- * NOTE: `src/config.ts` currently has multiple duplicate `export const config`
- * declarations (tracked by FN-062 / FN-066) that cause esbuild to refuse to
- * transform the file. We work around that here by stubbing the config module
- * via `vi.mock` rather than importing the real one. Do NOT dedupe config.ts
- * as part of FN-197 — that is explicitly out of scope.
+ * NOTE: `src/config.ts` is stubbed via `vi.mock` so the rpc-client import
+ * resolves to a lightweight fixture without pulling in the full env-reading
+ * config loader (dedup of config.ts was completed in FN-062 / FN-066).
  */
 
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";

--- a/tests/unit/submitter-poll-confirmation.test.ts
+++ b/tests/unit/submitter-poll-confirmation.test.ts
@@ -9,11 +9,10 @@
  * loop; real errors are surfaced after `config.tx.maxPollErrors`
  * consecutive occurrences.
  *
- * NOTE on `vi.mock("../../src/config.js")`: `src/config.ts` currently has
- * multiple duplicate `export const config` declarations (tracked by
- * FN-062 / FN-066) that cause esbuild to refuse to transform it. We stub
- * the config module so the test file can be transformed at all. Do NOT
- * dedupe config.ts as part of FN-197 — that is explicitly out of scope.
+ * NOTE on `vi.mock("../../src/config.js")`: `src/config.ts` is stubbed so
+ * the submitter import resolves to a lightweight fixture without pulling in
+ * the full env-reading config loader (dedup of config.ts was completed in
+ * FN-062 / FN-066).
  */
 
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";


### PR DESCRIPTION
## Summary

- FN-062 / FN-066 already landed the single canonical `export const config` in `src/config.ts`
- Two test files still carried stale NOTE comments describing the pre-dedup state as a current bug and the `vi.mock` workaround as necessary for that reason
- Updated comments to reflect the actual current state (dedup complete)

## Test plan

- [ ] `npx vitest run tests/unit/rpc-client-faucet.test.ts tests/unit/submitter-poll-confirmation.test.ts` — 13 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)