### PR TITLE
feat(FN-101): advertise price.cents=0 on bank BPP umbrella tag

### DIFF
--- a/keeper/bpps/bank/config.ts
+++ b/keeper/bpps/bank/config.ts
@@ -76,7 +76,8 @@ export const BANK_UMBRELLA_TAGS: CapabilityTags = {
   domain: "bank",
   action: "catalog",
   version: "0.1.0",
-  price: { amount: "0", currency: "ETO" },
+  // cents = 0 because the umbrella catalog tag advertises the BPP for free; per-capability prices live in BankCatalog. ADR-0001 follow-up.
+  price: { amount: "0", currency: "ETO", cents: 0 },
   // TODO(FN-099): add the verified-human + kyc.us-test required
   // credentials once the gate policy lands.
   requiredCredentials: [],

--- a/tests/unit/bank-bpp.test.ts
+++ b/tests/unit/bank-bpp.test.ts
@@ -21,7 +21,7 @@ import { createBankHandler } from "../../keeper/bpps/bank/handler.js";
 import { InMemoryCatalogCommitRecorder, publishBankCatalog } from "../../keeper/bpps/bank/catalog-publisher.js";
 import { makeStubSigner } from "../../keeper/templates/bpp/index.js";
 import { zBankCapability, zBankCatalog, zCatalogCommitPayload } from "../../keeper/bpps/bank/types.js";
-import { zBppConfig } from "../../keeper/templates/bpp/types.js";
+import { zBppConfig, zCapabilityTags } from "../../keeper/templates/bpp/types.js";
 import {
   BANK_NETWORK_LABEL,
   computeBankNetworkId,
@@ -294,6 +294,18 @@ describe("buildConfig", () => {
   it("catalog has 5 capabilities", () => {
     const { catalog } = buildConfig({ authority: FIXED_BPP_AUTHORITY });
     expect(catalog.capabilities.length).toBe(5);
+  });
+
+  it("umbrella tag price advertises free capability with integer cents", () => {
+    const { config } = buildConfig({ authority: FIXED_BPP_AUTHORITY });
+    expect(config.capabilityTags.price.amount).toBe("0");
+    expect(config.capabilityTags.price.currency).toBe("ETO");
+    expect(config.capabilityTags.price.cents).toBe(0);
+  });
+
+  it("umbrella tag round-trips through zCapabilityTags", () => {
+    const { config } = buildConfig({ authority: FIXED_BPP_AUTHORITY });
+    expect(() => zCapabilityTags.parse(config.capabilityTags)).not.toThrow();
   });
 });
 


### PR DESCRIPTION
## Summary
- Add `cents: 0` to `BANK_UMBRELLA_TAGS.price` in `keeper/bpps/bank/config.ts` (ADR-0001 follow-up)
- Add explicit umbrella tag price-shape assertion and `zCapabilityTags` round-trip test in `tests/unit/bank-bpp.test.ts`
- Read-only audit of `handler.ts` confirmed: no decimal-string fee math present

## Test plan
- [ ] `pnpm typecheck` passes (verified)
- [ ] New assertions: `price.cents === 0`, `price.amount === "0"`, `price.currency === "ETO"`
- [ ] `zCapabilityTags.parse(config.capabilityTags)` does not throw

🤖 Generated with [Claude Code](https://claude.com/claude-code)