### PR TITLE
feat(FN-051): ModelAttestation verified arm with session_signed source

### DIFF
--- a/docs/agent-identity-model.md
+++ b/docs/agent-identity-model.md
@@ -69,12 +69,24 @@ decisions on each.
 | **Trust assumption** | When `attestation_status === "verified"`: trust the provider's JWKS. When `"self_declared"`: treat the model claim as a **hint for telemetry only**, never for capability gating. When `"absent"`: do not branch on model identity at all. |
 | **Threat model** | Self-declared values can be spoofed trivially. Verified values inherit the provider's KMS posture; signature replay across audiences is mitigated by `aud` binding to the MCP server's origin. |
 
-JWKS publication contract: see [`model-attestation.md`](./model-attestation.md) §5.1, §5.3.
-
 This is the axis that explicitly *does not work today*. The interim path
 (see [§5](#5-interim-implementation-works-today)) is to record the
 self-declared claim and propagate `attestation_status: "self_declared"` so
 downstream code can refuse to trust it.
+
+**Sub-discriminator on the `verified` arm.** When `attestation_status === "verified"`,
+the arm is itself sub-discriminated by `source: "session_signed" | "provider_oidc"`.
+The invariants are: `source: "session_signed"` ⇒ `provider_verified: false`
+(the gateway minted a session-attestation JWS at auth time — stronger than
+`self_declared` because the gateway witnessed the binding, but the provider
+itself did not sign anything); `source: "provider_oidc"` ⇒ `provider_verified: true`
+(a provider-signed JWS was verified against the provider's published JWKS).
+Capability gating MUST consult `provider_verified`, not just `attestation_status`.
+See [`docs/model-attestation.md`](./model-attestation.md) §5.2 for the
+session-signed payload shape; the `provider_oidc` arm has no on-disk emitter
+today (future work, downstream of FN-052). The corresponding TypeScript shapes
+live in [`src/models/agent-identity.ts`](../src/models/agent-identity.ts) as
+`ModelAttestation` and `InterimAgentIdentityInput.verified_session_jws_claims`.
 
 ### §2.3 — `environment`
 

--- a/src/models/agent-identity.ts
+++ b/src/models/agent-identity.ts
@@ -80,6 +80,14 @@ export type ModelAttestation =
       kid: string;
       /** Issuance timestamp (seconds since epoch) of the verified JWS. */
       issued_at: number;
+      /** How the verification was established. `"session_signed"` = caller
+       *  supplied a JWS bound to this session; `"provider_oidc"` = verified
+       *  against the provider's published JWKS endpoint. */
+      source: "session_signed" | "provider_oidc";
+      /** Whether the provider's own infrastructure attested the model claim. */
+      provider_verified: boolean;
+      /** The raw compact JWS that carried the attestation. */
+      jws: string;
     }
   | {
       attestation_status: "self_declared";
@@ -192,6 +200,23 @@ export interface InterimAgentIdentityInput {
   capabilities?: ReadonlyArray<string>;
   /** Optional: `SessionPayload.jti` when available. */
   jti?: string;
+  /**
+   * Optional: a caller-supplied JWS that was already verified against the
+   * provider's session signing key. When present, `buildInterimAgentIdentity`
+   * emits a `"verified"` attestation with `source: "session_signed"`.
+   */
+  verified_session_jws?: {
+    /** The compact JWS string. */
+    jws: string;
+    /** `sub` claim from the verified token — the model's identity assertion. */
+    sub: string;
+    /** Model identifier claimed in the JWS. */
+    model_id: string;
+    /** Provider that issued the JWS (e.g. `"anthropic"`). */
+    provider: string;
+    /** Expiry of the JWS as a Unix timestamp (seconds). */
+    exp: number;
+  };
 }
 
 /**
@@ -216,7 +241,18 @@ export function buildInterimAgentIdentity(
 
   const human_authority = resolveHumanAuthority(input);
   const environment = resolveEnvironment(input);
-  const model_attestation: ModelAttestation = input.declared_model
+  const model_attestation: ModelAttestation = input.verified_session_jws
+    ? {
+        attestation_status: "verified",
+        provider: input.verified_session_jws.provider,
+        model_id: input.verified_session_jws.model_id,
+        kid: input.verified_session_jws.sub,
+        issued_at: input.verified_session_jws.exp,
+        source: "session_signed",
+        provider_verified: false,
+        jws: input.verified_session_jws.jws,
+      }
+    : input.declared_model
     ? {
         attestation_status: "self_declared",
         provider: input.declared_model.provider,

--- a/src/models/agent-identity.ts
+++ b/src/models/agent-identity.ts
@@ -61,8 +61,12 @@ export interface HumanAuthority {
 /**
  * Discriminator for {@link ModelAttestation}. See spec §2.2 and §4.
  *
- * - `"verified"` — provider-signed JWS verified against published JWKS.
- *   ONLY this state is safe for capability gating.
+ * - `"verified"` — a JWS attesting `(provider, model_id)` was verified.
+ *   The verified arm is itself sub-discriminated by
+ *   {@link AttestationSource} (`source: "session_signed" | "provider_oidc"`).
+ *   Capability gating MUST consult `provider_verified` (not just
+ *   `attestation_status`) — `session_signed` is gateway-witnessed but
+ *   NOT provider-attested.
  * - `"self_declared"` — the agent advertised a model claim but no signature
  *   was verified. Telemetry-only; never gate capabilities on this.
  * - `"absent"` — no claim was made (or verification failed). Do not branch
@@ -70,23 +74,62 @@ export interface HumanAuthority {
  */
 export type AttestationStatus = "verified" | "self_declared" | "absent";
 
-/** A claim about which AI model produced the agent's actions. See spec §2.2. */
+/**
+ * Sub-discriminator for the {@link ModelAttestation} `verified` arm.
+ *
+ * - `"session_signed"` — the gateway minted a session-attestation JWS at
+ *   auth time binding the caller-declared `(provider, model_id)` to the
+ *   session token's `(sub, jti, iat, exp)`. The provider itself did NOT
+ *   sign anything; `provider_verified` is therefore always `false`.
+ *   Stronger than `self_declared` (the gateway witnessed the binding) but
+ *   weaker than `provider_oidc`. See `docs/model-attestation.md` §5.2 and
+ *   `docs/agent-identity-model.md` §2.2.
+ * - `"provider_oidc"` — a provider-signed JWS (e.g. via the provider's
+ *   OIDC JWKS) was verified. `provider_verified` is always `true`.
+ *   Capability gating MAY rely on this; see spec §3.2.
+ */
+export type AttestationSource = "session_signed" | "provider_oidc";
+
+/**
+ * A claim about which AI model produced the agent's actions. See spec §2.2.
+ *
+ * Type-narrowing pattern:
+ * ```ts
+ * if (m.attestation_status === "verified") {
+ *   //                       ^? "session_signed" | "provider_oidc"
+ *   if (m.source === "provider_oidc") {
+ *     // m.provider_verified is `true`
+ *   } else {
+ *     // m.source is "session_signed"; m.provider_verified is `false`
+ *   }
+ * }
+ * ```
+ */
 export type ModelAttestation =
   | {
       attestation_status: "verified";
+      /** Sub-discriminator — see {@link AttestationSource}. */
+      source: "session_signed";
+      /** Always `false` for `session_signed` — the gateway, not the provider, signed. */
+      provider_verified: false;
       provider: string;
       model_id: string;
       /** JWS `kid` from the verified attestation. */
       kid: string;
       /** Issuance timestamp (seconds since epoch) of the verified JWS. */
       issued_at: number;
-      /** How the verification was established. `"session_signed"` = caller
-       *  supplied a JWS bound to this session; `"provider_oidc"` = verified
-       *  against the provider's published JWKS endpoint. */
-      source: "session_signed" | "provider_oidc";
-      /** Whether the provider's own infrastructure attested the model claim. */
-      provider_verified: boolean;
-      /** The raw compact JWS that carried the attestation. */
+      /** The compact-form JWS string (RFC 7515) that produced this verified result. */
+      jws: string;
+    }
+  | {
+      attestation_status: "verified";
+      source: "provider_oidc";
+      /** Always `true` for `provider_oidc` — the provider's signing key signed. */
+      provider_verified: true;
+      provider: string;
+      model_id: string;
+      kid: string;
+      issued_at: number;
       jws: string;
     }
   | {
@@ -201,31 +244,67 @@ export interface InterimAgentIdentityInput {
   /** Optional: `SessionPayload.jti` when available. */
   jti?: string;
   /**
-   * Optional: a caller-supplied JWS that was already verified against the
-   * provider's session signing key. When present, `buildInterimAgentIdentity`
-   * emits a `"verified"` attestation with `source: "session_signed"`.
+   * Optional: a session-attestation JWS that has ALREADY been verified by
+   * the caller (e.g. FN-049's mint path on the same gateway, or FN-052's
+   * counterparty verifier). The builder treats this as opaque — it does
+   * NOT decode, verify, or fetch any JWKS. If supplied,
+   * `verified_session_jws_claims` MUST also be supplied; otherwise the
+   * builder ignores both and falls through to `self_declared` / `absent`.
+   *
+   * Trust boundary: the agent-identity module is intentionally decoupled
+   * from `src/gateway/**` and `src/signing/**`; verification happens in
+   * those layers and the result is passed in here as opaque data.
+   *
+   * See `docs/model-attestation.md` §5.2 for the canonical payload shape.
    */
-  verified_session_jws?: {
-    /** The compact JWS string. */
-    jws: string;
-    /** `sub` claim from the verified token — the model's identity assertion. */
-    sub: string;
-    /** Model identifier claimed in the JWS. */
-    model_id: string;
-    /** Provider that issued the JWS (e.g. `"anthropic"`). */
+  verified_session_jws?: string;
+
+  /**
+   * Optional: pre-validated claims extracted from `verified_session_jws`.
+   * Mirrors a subset of FN-049's `SessionAttestationPayload` — duplicated
+   * here (rather than imported) to keep this module decoupled from
+   * `src/gateway/session-attestation.ts`.
+   *
+   * When both fields are present AND the scope is not a dev/stdio sentinel,
+   * the builder emits a `ModelAttestation` with `attestation_status:
+   * "verified"`, `source: "session_signed"`, `provider_verified: false`.
+   */
+  verified_session_jws_claims?: {
+    /** Mirrors FN-049 `provider_declared`. 1..64 chars. */
     provider: string;
-    /** Expiry of the JWS as a Unix timestamp (seconds). */
-    exp: number;
+    /** Mirrors FN-049 `model_id_declared`. 1..128 chars. */
+    model_id: string;
+    /** JWS header `kid`. Non-empty string. */
+    kid: string;
+    /** Mirrors `payload.iat` (unix seconds). Finite integer. */
+    issued_at: number;
   };
 }
 
 /**
- * Build an {@link AgentIdentity} from a `session_info`-shaped payload, with
- * no provider integration. The result always has
- * `model_attestation.attestation_status` of `"self_declared"` (when
- * `declared_model` is present) or `"absent"`.
+ * Build an {@link AgentIdentity} from a `session_info`-shaped payload.
  *
- * Pure function — no I/O, no global state.
+ * Model-attestation resolution precedence:
+ *
+ * 1. **Negative gates.** If `scope === "__stdio__"`, `scope === "__dev__"`,
+ *    or `auth_strategy === "dev"`, the builder NEVER emits a `verified` arm
+ *    — dev/stdio sessions cannot meaningfully attest a model identity
+ *    (cf. FN-049 mint-path negative gates). Falls through to
+ *    `self_declared` (if `declared_model`) or `absent`.
+ * 2. **Verified arm.** Else if BOTH `verified_session_jws` AND
+ *    `verified_session_jws_claims` are supplied, emits
+ *    `attestation_status: "verified"`, `source: "session_signed"`,
+ *    `provider_verified: false`. The JWS is treated as opaque, already
+ *    validated by the caller.
+ * 3. **Self-declared arm.** Else if `declared_model` is supplied, emits
+ *    `self_declared`.
+ * 4. **Absent.** Otherwise emits `absent`.
+ *
+ * The builder NEVER emits `source: "provider_oidc"` from any input shape.
+ * That arm is type-only at this stage; a future task (downstream of FN-052)
+ * will add a `verified_provider_oidc_jws` builder path.
+ *
+ * Pure function — no I/O, no global state, no `Date.now()`.
  *
  * @throws {Error} if `scope` is missing or empty (see spec §5: there is no
  * meaningful identity without a session-scope persistence key).
@@ -241,24 +320,8 @@ export function buildInterimAgentIdentity(
 
   const human_authority = resolveHumanAuthority(input);
   const environment = resolveEnvironment(input);
-  const model_attestation: ModelAttestation = input.verified_session_jws
-    ? {
-        attestation_status: "verified",
-        provider: input.verified_session_jws.provider,
-        model_id: input.verified_session_jws.model_id,
-        kid: input.verified_session_jws.sub,
-        issued_at: input.verified_session_jws.exp,
-        source: "session_signed",
-        provider_verified: false,
-        jws: input.verified_session_jws.jws,
-      }
-    : input.declared_model
-    ? {
-        attestation_status: "self_declared",
-        provider: input.declared_model.provider,
-        model_id: input.declared_model.model_id,
-      }
-    : { attestation_status: "absent" };
+  const model_attestation = resolveModelAttestation(input);
+
 
   const session_scope: SessionScope = {
     scope: input.scope,
@@ -268,6 +331,49 @@ export function buildInterimAgentIdentity(
   };
 
   return { human_authority, model_attestation, environment, session_scope };
+}
+
+function resolveModelAttestation(
+  input: InterimAgentIdentityInput,
+): ModelAttestation {
+  // Negative gates: dev/stdio sessions cannot meaningfully attest a model.
+  // Mirrors FN-049's mint-path gates so a verified arm is never emitted in
+  // these scopes even if the caller supplied a JWS.
+  const isDevOrStdio =
+    input.scope === "__stdio__" ||
+    input.scope === "__dev__" ||
+    input.auth_strategy === "dev";
+
+  if (
+    !isDevOrStdio &&
+    input.verified_session_jws &&
+    input.verified_session_jws_claims
+  ) {
+    const claims = input.verified_session_jws_claims;
+    return {
+      attestation_status: "verified",
+      source: "session_signed",
+      provider_verified: false,
+      provider: claims.provider,
+      model_id: claims.model_id,
+      kid: claims.kid,
+      issued_at: claims.issued_at,
+      jws: input.verified_session_jws,
+    };
+  }
+
+  // asymmetric input — defensively ignore both; fall through to
+  // self_declared / absent rather than throwing.
+
+  if (input.declared_model) {
+    return {
+      attestation_status: "self_declared",
+      provider: input.declared_model.provider,
+      model_id: input.declared_model.model_id,
+    };
+  }
+
+  return { attestation_status: "absent" };
 }
 
 function resolveHumanAuthority(input: InterimAgentIdentityInput): HumanAuthority {

--- a/tests/models/agent-identity.test.ts
+++ b/tests/models/agent-identity.test.ts
@@ -115,6 +115,9 @@ describe("buildInterimAgentIdentity", () => {
         model_id: "claude-sonnet-4-5",
         kid: "kid-1",
         issued_at: 1_730_000_000,
+        source: "provider_oidc" as const,
+        provider_verified: true,
+        jws: "eyJhbGciOiJFZERTQSJ9.e30.sig",
       },
       environment: {
         surface: "sse",
@@ -130,5 +133,51 @@ describe("buildInterimAgentIdentity", () => {
     } satisfies AgentIdentity;
 
     expect(literal.human_authority.kind).toBe("thirdweb");
+  });
+
+  it("emits source=session_signed verified attestation when verified_session_jws is supplied", () => {
+    const jws = "eyJhbGciOiJFZERTQSJ9.e30.sessionSig";
+    const id = buildInterimAgentIdentity(
+      baseInput({
+        verified_session_jws: {
+          jws,
+          sub: "model-subject-id",
+          model_id: "claude-opus-4-7",
+          provider: "anthropic",
+          exp: 1_800_000_000,
+        },
+      }),
+    );
+
+    expect(id.model_attestation.attestation_status).toBe("verified");
+    if (id.model_attestation.attestation_status === "verified") {
+      expect(id.model_attestation.source).toBe("session_signed");
+      expect(id.model_attestation.provider_verified).toBe(false);
+      expect(id.model_attestation.provider).toBe("anthropic");
+      expect(id.model_attestation.model_id).toBe("claude-opus-4-7");
+      expect(id.model_attestation.jws).toBe(jws);
+      expect(id.model_attestation.kid).toBe("model-subject-id");
+      expect(id.model_attestation.issued_at).toBe(1_800_000_000);
+    }
+  });
+
+  it("verified_session_jws takes precedence over declared_model", () => {
+    const id = buildInterimAgentIdentity(
+      baseInput({
+        verified_session_jws: {
+          jws: "eyJ.e30.sig",
+          sub: "sub-1",
+          model_id: "claude-haiku-4-5",
+          provider: "anthropic",
+          exp: 1_900_000_000,
+        },
+        declared_model: { provider: "openai", model_id: "gpt-4o" },
+      }),
+    );
+
+    expect(id.model_attestation.attestation_status).toBe("verified");
+    if (id.model_attestation.attestation_status === "verified") {
+      expect(id.model_attestation.model_id).toBe("claude-haiku-4-5");
+    }
   });
 });

--- a/tests/models/agent-identity.test.ts
+++ b/tests/models/agent-identity.test.ts
@@ -20,6 +20,22 @@ function baseInput(overrides: Partial<InterimAgentIdentityInput> = {}): InterimA
   };
 }
 
+function verifiedInput(
+  overrides: Partial<InterimAgentIdentityInput> = {},
+): InterimAgentIdentityInput {
+  return baseInput({
+    verified_session_jws:
+      "eyJhbGciOiJFZERTQSIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIweEFsaWNlIn0.sig",
+    verified_session_jws_claims: {
+      provider: "anthropic",
+      model_id: "claude-sonnet-4-5",
+      kid: "kid-test-1",
+      issued_at: 1_730_000_000,
+    },
+    ...overrides,
+  });
+}
+
 describe("buildInterimAgentIdentity", () => {
   it("builds a thirdweb-kind identity with self_declared attestation when declared_model is supplied", () => {
     const id = buildInterimAgentIdentity(
@@ -110,13 +126,13 @@ describe("buildInterimAgentIdentity", () => {
         auth_strategy: "siwe",
       },
       model_attestation: {
-        attestation_status: "verified",
+        attestation_status: "verified" as const,
+        source: "session_signed" as const,
+        provider_verified: false as const,
         provider: "anthropic",
         model_id: "claude-sonnet-4-5",
         kid: "kid-1",
         issued_at: 1_730_000_000,
-        source: "provider_oidc" as const,
-        provider_verified: true,
         jws: "eyJhbGciOiJFZERTQSJ9.e30.sig",
       },
       environment: {
@@ -135,49 +151,112 @@ describe("buildInterimAgentIdentity", () => {
     expect(literal.human_authority.kind).toBe("thirdweb");
   });
 
-  it("emits source=session_signed verified attestation when verified_session_jws is supplied", () => {
-    const jws = "eyJhbGciOiJFZERTQSJ9.e30.sessionSig";
-    const id = buildInterimAgentIdentity(
-      baseInput({
-        verified_session_jws: {
-          jws,
-          sub: "model-subject-id",
-          model_id: "claude-opus-4-7",
-          provider: "anthropic",
-          exp: 1_800_000_000,
-        },
-      }),
-    );
+  it("emits source=session_signed verified attestation when verified_session_jws + claims are supplied", () => {
+    const id = buildInterimAgentIdentity(verifiedInput());
 
     expect(id.model_attestation.attestation_status).toBe("verified");
     if (id.model_attestation.attestation_status === "verified") {
+      // Sub-discriminator narrows to a literal union here.
       expect(id.model_attestation.source).toBe("session_signed");
-      expect(id.model_attestation.provider_verified).toBe(false);
-      expect(id.model_attestation.provider).toBe("anthropic");
-      expect(id.model_attestation.model_id).toBe("claude-opus-4-7");
-      expect(id.model_attestation.jws).toBe(jws);
-      expect(id.model_attestation.kid).toBe("model-subject-id");
-      expect(id.model_attestation.issued_at).toBe(1_800_000_000);
+      if (id.model_attestation.source === "session_signed") {
+        expect(id.model_attestation.provider_verified).toBe(false);
+        expect(id.model_attestation.provider).toBe("anthropic");
+        expect(id.model_attestation.model_id).toBe("claude-sonnet-4-5");
+        expect(id.model_attestation.kid).toBe("kid-test-1");
+        expect(id.model_attestation.issued_at).toBe(1_730_000_000);
+        expect(id.model_attestation.jws).toBe(
+          "eyJhbGciOiJFZERTQSIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIweEFsaWNlIn0.sig",
+        );
+      }
     }
   });
 
-  it("verified_session_jws takes precedence over declared_model", () => {
+  it("verified arm overrides declared_model (precedence rule)", () => {
     const id = buildInterimAgentIdentity(
-      baseInput({
-        verified_session_jws: {
-          jws: "eyJ.e30.sig",
-          sub: "sub-1",
-          model_id: "claude-haiku-4-5",
-          provider: "anthropic",
-          exp: 1_900_000_000,
-        },
+      verifiedInput({
         declared_model: { provider: "openai", model_id: "gpt-4o" },
       }),
     );
 
     expect(id.model_attestation.attestation_status).toBe("verified");
     if (id.model_attestation.attestation_status === "verified") {
-      expect(id.model_attestation.model_id).toBe("claude-haiku-4-5");
+      // Verified-arm provider wins over declared_model.
+      expect(id.model_attestation.provider).toBe("anthropic");
+      expect(id.model_attestation.model_id).toBe("claude-sonnet-4-5");
     }
+  });
+
+  it("suppresses verified arm under __stdio__ scope", () => {
+    const id = buildInterimAgentIdentity(
+      verifiedInput({ scope: "__stdio__", auth_strategy: null }),
+    );
+    expect(id.model_attestation.attestation_status).toBe("absent");
+  });
+
+  it("suppresses verified arm under __dev__ scope", () => {
+    const id = buildInterimAgentIdentity(
+      verifiedInput({ scope: "__dev__", auth_strategy: null }),
+    );
+    expect(id.model_attestation.attestation_status).toBe("absent");
+  });
+
+  it("suppresses verified arm under auth_strategy: 'dev'", () => {
+    const id = buildInterimAgentIdentity(verifiedInput({ auth_strategy: "dev" }));
+    expect(id.model_attestation.attestation_status).toBe("absent");
+  });
+
+  it("falls through to absent when verified_session_jws is supplied without claims", () => {
+    const id = buildInterimAgentIdentity(
+      baseInput({ verified_session_jws: "abc.def.ghi" }),
+    );
+    expect(id.model_attestation.attestation_status).toBe("absent");
+  });
+
+  it("falls through to absent when verified_session_jws_claims is supplied without jws", () => {
+    const id = buildInterimAgentIdentity(
+      baseInput({
+        verified_session_jws_claims: {
+          provider: "p",
+          model_id: "m",
+          kid: "k",
+          issued_at: 1,
+        },
+      }),
+    );
+    expect(id.model_attestation.attestation_status).toBe("absent");
+  });
+
+  it("type-level: a provider_oidc verified literal satisfies AgentIdentity", () => {
+    const literal = {
+      human_authority: {
+        sub: "0xAlice",
+        kind: "thirdweb",
+        auth_strategy: "siwe",
+      },
+      model_attestation: {
+        attestation_status: "verified" as const,
+        source: "provider_oidc" as const,
+        provider_verified: true as const,
+        provider: "anthropic",
+        model_id: "claude-sonnet-4-5",
+        kid: "kid-oidc-1",
+        issued_at: 1_730_000_000,
+        jws: "eyJhbGciOiJFZERTQSJ9.e30.providerSig",
+      },
+      environment: {
+        surface: "sse",
+        server_instance: "2026-05-01T00:00:00.000Z",
+        wallet_anchor: { id: "w-1", svm: null, evm: null, label: null },
+      },
+      session_scope: {
+        scope: "0xAlice",
+        jti: "jti-1",
+        expires_at_iso: "2030-01-01T00:00:00.000Z",
+        capabilities: ["wallet:read"],
+      },
+    } satisfies AgentIdentity;
+
+    expect(literal.model_attestation.source).toBe("provider_oidc");
+    expect(literal.model_attestation.provider_verified).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary
- Extends the `verified` arm of `ModelAttestation` with `source`, `provider_verified`, and `jws` fields
- Adds `session_signed` source sub-discriminator and `verified_session_jws` support in `buildInterimAgentIdentity`
- Updates agent-identity model docs and tests

## Test plan
- [ ] `npm run typecheck` passes
- [ ] `tests/models/agent-identity.test.ts` covers session_signed branch and precedence over declared_model

🤖 Generated with [Claude Code](https://claude.com/claude-code)