### PR TITLE
feat(FN-111): SSRF guard for text-summarize fetchUrl

### DIFF
--- a/keeper/bpps/text-summarize/fetcher.ts
+++ b/keeper/bpps/text-summarize/fetcher.ts
@@ -14,6 +14,10 @@
  * All side-effecting seams (`fetch`, `pdfExtractor`) are injected so
  * the test suite drives the path with deterministic stubs.
  *
+ * SSRF guard (FN-111): `fetchUrl` calls `assertPublicHttpUrl` before
+ * opening a network connection to block loopback, private-range IPv4,
+ * IPv6 link-local / ULA, and non-http(s) schemes.
+ *
  * **PDF extractor:** by default we ship the `noopPdfExtractor` (throws
  * `pdf_extraction_unavailable`); deploys that need PDF support inject
  * a real extractor backed by `pdf-parse` or similar. We deliberately
@@ -24,6 +28,7 @@
  */
 
 import type { SummarizeSource } from "./types.js";
+import { assertPublicHttpUrl } from "../web-research/fetcher.js";
 
 /* -------------------------------------------------------------------------- */
 /* Types                                                                      */
@@ -99,6 +104,8 @@ async function fetchUrl(
   maxBytesOpt: number | undefined,
   deps: FetchSourceDeps,
 ): Promise<FetchedSource> {
+  // SSRF guard (FN-111): block loopback / private / link-local / IMDS targets.
+  assertPublicHttpUrl(url);
   const maxBytes = maxBytesOpt ?? DEFAULT_FETCH_MAX_BYTES;
   const timeoutMs = deps.fetchTimeoutMs ?? DEFAULT_FETCH_TIMEOUT_MS;
   const ctrl = new AbortController();

--- a/tests/unit/text-summarize-bpp.test.ts
+++ b/tests/unit/text-summarize-bpp.test.ts
@@ -35,6 +35,7 @@ import {
   type FetchLike,
   type PdfExtractor,
 } from "../../keeper/bpps/text-summarize/fetcher.js";
+import { assertPublicHttpUrl } from "../../keeper/bpps/web-research/fetcher.js";
 import {
   summarize,
   sha256Hex,
@@ -335,6 +336,60 @@ describe("fetchSource", () => {
     await expect(noopPdfExtractor(new Uint8Array())).rejects.toThrow(
       /pdf_extraction_unavailable/,
     );
+  });
+});
+
+/* ========================================================================== */
+/* Step 2b — SSRF guard (FN-111)                                              */
+/* ========================================================================== */
+
+describe("assertPublicHttpUrl (SSRF guard) via text-summarize fetcher", () => {
+  it("accepts public http(s) URLs", () => {
+    expect(() => assertPublicHttpUrl("https://example.com/page")).not.toThrow();
+    expect(() => assertPublicHttpUrl("http://example.com/page")).not.toThrow();
+  });
+
+  it("rejects file:// and non-http(s) schemes", () => {
+    expect(() => assertPublicHttpUrl("file:///etc/passwd")).toThrow(/unsupported_scheme/);
+    expect(() => assertPublicHttpUrl("ftp://example.com")).toThrow(/unsupported_scheme/);
+  });
+
+  it("rejects localhost / 127.0.0.1 / RFC1918 ranges", () => {
+    expect(() => assertPublicHttpUrl("http://localhost/x")).toThrow(/forbidden_host/);
+    expect(() => assertPublicHttpUrl("http://127.0.0.1/x")).toThrow(/forbidden_host/);
+    expect(() => assertPublicHttpUrl("http://10.0.0.5/x")).toThrow(/forbidden_host/);
+    expect(() => assertPublicHttpUrl("http://192.168.1.1/x")).toThrow(/forbidden_host/);
+    expect(() => assertPublicHttpUrl("http://172.20.5.5/x")).toThrow(/forbidden_host/);
+  });
+
+  it("rejects link-local / IMDS addresses", () => {
+    expect(() => assertPublicHttpUrl("http://169.254.1.1/x")).toThrow(/forbidden_host/);
+    expect(() => assertPublicHttpUrl("http://169.254.169.254/latest/meta-data")).toThrow(/forbidden_host/);
+  });
+
+  it("rejects IPv6 link-local and loopback", () => {
+    expect(() => assertPublicHttpUrl("http://[::1]/x")).toThrow(/forbidden_host/);
+    expect(() => assertPublicHttpUrl("http://[fe80::1]/x")).toThrow(/forbidden_host/);
+  });
+
+  it("fetchSource with url kind rejects loopback before calling fetch", async () => {
+    const fetch = makeFetch({});
+    await expect(
+      fetchSource(
+        { kind: "url", url: "http://127.0.0.1/secret" },
+        { fetch, pdfExtractor: noopPdfExtractor },
+      ),
+    ).rejects.toThrow(/forbidden_host/);
+  });
+
+  it("fetchSource with url kind rejects private range before calling fetch", async () => {
+    const fetch = makeFetch({});
+    await expect(
+      fetchSource(
+        { kind: "url", url: "http://10.0.0.1/internal" },
+        { fetch, pdfExtractor: noopPdfExtractor },
+      ),
+    ).rejects.toThrow(/forbidden_host/);
   });
 });
 


### PR DESCRIPTION
## Summary
- Calls `assertPublicHttpUrl` (shared from `web-research/fetcher.ts`) before any network connection in `fetchUrl`, blocking loopback, RFC1918, link-local, IMDS, and non-http(s) schemes
- Adds unit tests mirroring the FN-079 acceptance vectors used in `tests/unit/web-research-bpp.test.ts`

## Test plan
- [ ] `pnpm typecheck` passes (clean)
- [ ] `pnpm vitest run tests/unit/text-summarize-bpp.test.ts` — new SSRF tests pass
- [ ] Loopback, private range, link-local, IMDS all rejected before fetch is called

🤖 Generated with [Claude Code](https://claude.com/claude-code)