### PR TITLE
fix(FN-108): align AUTH_DEV_BYPASS to canonical ETO_AUTH_DEV_BYPASS

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -188,8 +188,9 @@ export function loadAppConfig(
 // consumers (auth.ts, server.ts, sse-server.ts, submitter.ts, …) import
 // from this single export.
 //
-// devBypass env var: ETO_AUTH_DEV_BYPASS=true
+// devBypass env var: ETO_AUTH_DEV_BYPASS=true  (FN-108: canonical name)
 //   - Must be set explicitly; never enabled by NODE_ENV alone.
+//   - The legacy AUTH_DEV_BYPASS name is no longer read anywhere.
 //   - In production, this MUST NOT be set (server.ts validates this).
 
 function validateNetwork(v: string | undefined): "mainnet" | "testnet" | "devnet" {


### PR DESCRIPTION
## Summary
- The legacy `AUTH_DEV_BYPASS` reader in the static config object was already removed in a prior cleanup
- Documents the canonical `ETO_AUTH_DEV_BYPASS` name explicitly in the config comment, clarifying the old name is no longer read anywhere
- All three locations (config.ts, server.ts:19, gateway/thirdweb.ts:27) already use the canonical `ETO_AUTH_DEV_BYPASS`

## Test plan
- [ ] `pnpm typecheck` passes
- [ ] No `AUTH_DEV_BYPASS` without `ETO_` prefix anywhere in `src/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)