### PR TITLE
feat(FN-117): build target for memo-ingester-main via tsconfig.build.services.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "README.md"
   ],
   "scripts": {
-    "build": "tsc -p tsconfig.build.issuers.json",
+    "build": "tsc -p tsconfig.build.issuers.json && tsc -p tsconfig.build.services.json",
     "typecheck": "tsc -p tsconfig.issuers.json --noEmit",
     "test": "vitest run",
     "test:watch": "vitest",

--- a/src/services/indexer/memo-ingester-main.ts
+++ b/src/services/indexer/memo-ingester-main.ts
@@ -1,0 +1,24 @@
+/**
+ * FN-105: Entrypoint for MemoBlockIngester service (FN-117 build target).
+ *
+ * Run via: node dist/services/indexer/memo-ingester-main.js
+ *       or: tsx src/services/indexer/memo-ingester-main.ts
+ *
+ * Set ETO_MEMO_INGESTER_ENABLED=true to activate.
+ * Mirrors the src/bridge-server.ts lifecycle pattern.
+ */
+
+if (process.env["ETO_MEMO_INGESTER_ENABLED"] !== "true") {
+  console.error(
+    "[memo-ingester] disabled (set ETO_MEMO_INGESTER_ENABLED=true to enable)",
+  );
+  process.exit(0);
+}
+
+// Full implementation wired in FN-105 / FN-118.
+// This file is a build target stub; the ingester modules will be populated
+// as FN-105 lands on master.
+console.log("[memo-ingester] started (stub mode — FN-105 pending)");
+
+process.on("SIGTERM", () => process.exit(0));
+process.on("SIGINT", () => process.exit(0));

--- a/tsconfig.build.services.json
+++ b/tsconfig.build.services.json
@@ -1,0 +1,9 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "rootDir": "./src",
+    "outDir": "./dist"
+  },
+  "include": ["src/services/indexer/memo-ingester-main.ts"],
+  "exclude": ["dist", "node_modules", "**/*.test.ts"]
+}


### PR DESCRIPTION
## Summary
- Adds `tsconfig.build.services.json` targeting `src/services/indexer/memo-ingester-main.ts`
- Wires the new tsconfig into `npm run build` alongside `tsconfig.build.issuers.json`
- Adds `src/services/indexer/memo-ingester-main.ts` stub entrypoint (full implementation lands with FN-105)
- Operators can now run `node dist/services/indexer/memo-ingester-main.js` instead of requiring `tsx`

## Test plan
- [ ] `pnpm typecheck` passes
- [ ] `tsc -p tsconfig.build.services.json --noEmit` is clean
- [ ] `npm run build` compiles both issuers and services targets

🤖 Generated with [Claude Code](https://claude.com/claude-code)