### PR TITLE
feat(FN-084): align data-analyze layout with code-audit-solidity reference

### DIFF
--- a/keeper/bpps/data-analyze/analyzers/index.ts
+++ b/keeper/bpps/data-analyze/analyzers/index.ts
@@ -1,0 +1,10 @@
+/**
+ * Public seam for the `data:analyze` analyser sub-package (FN-084).
+ *
+ * Mirrors `code:audit:solidity/auditors/index.ts`: exposes the orchestration
+ * entry-point (`analyze`) plus the typed sub-modules for consumers that need
+ * to inject individual pieces.
+ */
+
+export * from "./llm.js";
+export * from "./profiler.js";

--- a/keeper/bpps/data-analyze/analyzers/llm.ts
+++ b/keeper/bpps/data-analyze/analyzers/llm.ts
@@ -1,0 +1,22 @@
+/**
+ * LLM analyser seam for the `data:analyze` BPP (FN-084 layout alignment).
+ *
+ * Re-exports from `../analyzer.ts` — the Anthropic-backed analyser that
+ * produces a structured `AnalysisReport` + Markdown from a `DatasetProfile`.
+ *
+ * Mirrors the `code:audit:solidity` layout where the LLM call lives in
+ * `auditors/llm.ts`. The root `analyzer.ts` is the canonical source;
+ * this module is the stable public seam under the `analyzers/` subdir.
+ */
+
+export {
+  analyze,
+  sha256Hex,
+  AnthropicLlmClient,
+  type LlmClient,
+  type LlmRequest,
+  type AnthropicLike,
+  type AnalyzeOpts,
+  type AnalyzeDeps,
+  type AnalyzeResult,
+} from "../analyzer.js";

--- a/keeper/bpps/data-analyze/handler.ts
+++ b/keeper/bpps/data-analyze/handler.ts
@@ -10,12 +10,12 @@
  */
 
 import type { BppHandler, TaskResult } from "../../templates/bpp/index.js";
-import type { FetchCsvDeps, FetchedCsv } from "./fetcher.js";
-import { fetchCsv } from "./fetcher.js";
-import type { ProfileDeps, ProfileResult, ProfileOpts } from "./profiler.js";
-import { profileCsv } from "./profiler.js";
-import type { AnalyzeDeps, AnalyzeOpts, AnalyzeResult } from "./analyzer.js";
-import { analyze, sha256Hex } from "./analyzer.js";
+import type { FetchCsvDeps, FetchedCsv } from "./source-loader.js";
+import { fetchCsv } from "./source-loader.js";
+import type { ProfileDeps, ProfileResult, ProfileOpts } from "./analyzers/profiler.js";
+import { profileCsv } from "./analyzers/profiler.js";
+import type { AnalyzeDeps, AnalyzeOpts, AnalyzeResult } from "./analyzers/llm.js";
+import { analyze, sha256Hex } from "./analyzers/llm.js";
 import type {
   AnalyzeInput,
   AnalyzeOutput,

--- a/keeper/bpps/data-analyze/index.ts
+++ b/keeper/bpps/data-analyze/index.ts
@@ -33,7 +33,7 @@ export {
   type FetchLikeResponse,
   type FetchCsvDeps,
   type FetchedCsv,
-} from "./fetcher.js";
+} from "./source-loader.js";
 export {
   profileCsv,
   parseCsv,
@@ -43,7 +43,7 @@ export {
   type ProfileResult,
   type DatasetSample,
   type ColumnFlags,
-} from "./profiler.js";
+} from "./analyzers/profiler.js";
 export {
   analyze,
   sha256Hex,
@@ -54,7 +54,7 @@ export {
   type AnalyzeOpts,
   type AnalyzeDeps,
   type AnalyzeResult,
-} from "./analyzer.js";
+} from "./analyzers/llm.js";
 export {
   zAnalyzeInput,
   zAnalyzeOutput,

--- a/tests/unit/data-analyze-bpp.test.ts
+++ b/tests/unit/data-analyze-bpp.test.ts
@@ -35,17 +35,17 @@ import {
 import {
   fetchCsv,
   type FetchLike,
-} from "../../keeper/bpps/data-analyze/fetcher.js";
+} from "../../keeper/bpps/data-analyze/source-loader.js";
 import {
   parseCsv,
   detectDelimiter,
   profileCsv,
-} from "../../keeper/bpps/data-analyze/profiler.js";
+} from "../../keeper/bpps/data-analyze/analyzers/profiler.js";
 import {
   analyze,
   sha256Hex,
   type LlmClient,
-} from "../../keeper/bpps/data-analyze/analyzer.js";
+} from "../../keeper/bpps/data-analyze/analyzers/llm.js";
 import {
   buildHandlerFromPrimitives,
   createDataAnalyzeHandler,
@@ -1105,5 +1105,78 @@ describe("idempotent retry (FN-022)", () => {
     // The first event's payload wins (the second is suppressed entirely).
     const out = inner.completed[0]!.output as { result: AnalyzeOutput };
     expect(out.result.artifact.content).not.toContain("MALICIOUS");
+  });
+});
+
+/* ========================================================================== */
+/* FN-084 — catalog price.cents + idempotent-failure de-dupe                 */
+/* ========================================================================== */
+
+describe("FN-084: catalog tags surface price.cents (ADR-0001)", () => {
+  it("tags.price includes cents alongside amount+currency", () => {
+    // Both the config-level tags object and the runtime BPP config expose
+    // tags.price.cents so catalog/search responses carry the integer form.
+    expect(tags.domain).toBe("data");
+    expect(tags.action).toBe("analyze");
+    expect(tags.price).toMatchObject({
+      amount: "0.25",
+      currency: "ETO",
+      cents: 25,
+    });
+    // Assert dev-mode invariant: Number(amount) * 100 === cents
+    const priceCents = (tags.price as { amount: string; cents: number }).cents;
+    const priceAmount = parseFloat(
+      (tags.price as { amount: string }).amount,
+    );
+    expect(Math.round(priceAmount * 100)).toBe(priceCents);
+  });
+});
+
+describe("FN-084: idempotent retry produces exactly one completed-or-failed entry", () => {
+  it("two BeckonInitEvents with same taskId → exactly one inner.completed entry", async () => {
+    const handler = buildHandlerFromPrimitives({
+      fetchDeps: { fetch: makeFetch({}) },
+      analyzeDeps: { llm: cannedLlm },
+      modelId: "test-model",
+      now: () => 1700_000_000,
+    });
+
+    const events = new InMemoryEventSource<unknown>();
+    const inner = new InMemoryChain();
+    const chain = new SigningRuntimeChain({
+      inner,
+      signer: makeStubSigner("fn-084-idem"),
+      now: () => 1700_000_000,
+    });
+    const gate = defaultCredentialGate([], {
+      loadAgentCard: async () => ({ authority: "BAP", credentials: [] }),
+      now: () => 0,
+    });
+
+    const done = runBpp<unknown, AnalyzeOutput>(config, handler, {
+      eventSource: events,
+      chain,
+      gate,
+      logger: silentLogger,
+    });
+
+    const evt: BeckonInitEvent<unknown> = {
+      taskId: "fn-084-dedupe-1",
+      bapPubkey: "BAP",
+      bppPubkey: config.authority,
+      networkPubkey: "NET",
+      action: "data:analyze",
+      input: { source: { kind: "csv", text: "x,y\n1,2\n3,4\n" } },
+      observedAt: 0,
+    };
+
+    // Push the same event twice to exercise the de-dupe path.
+    events.push(evt);
+    events.push(evt);
+    events.close();
+    await done;
+
+    const totalOutcomes = inner.completed.length + inner.failed.length;
+    expect(totalOutcomes).toBe(1);
   });
 });


### PR DESCRIPTION
## Summary
- Updates `handler.ts` and `index.ts` imports: `./fetcher.js` → `./source-loader.js`, `./profiler.js` → `./analyzers/profiler.js`, `./analyzer.js` → `./analyzers/llm.js`
- Creates `analyzers/llm.ts` (re-exports from `../analyzer.ts`) mirroring `code-audit-solidity/auditors/llm.ts`
- Creates `analyzers/index.ts` as public seam over the `analyzers/` subdir
- Updates test file imports to match new paths
- Adds two missing test cases (FN-084): catalog `tags.price.cents` ADR-0001 invariant + idempotent retry de-dupe path

## Test plan
- [ ] `pnpm typecheck` passes (clean)
- [ ] `pnpm vitest run tests/unit/data-analyze-bpp.test.ts` — all tests pass including new FN-084 tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)