### PR TITLE
feat(FN-103): shared projectCapabilityTags catalog helper (ADR-0001)

### DIFF
--- a/keeper/templates/bpp/catalog.ts
+++ b/keeper/templates/bpp/catalog.ts
@@ -1,0 +1,77 @@
+/**
+ * Catalog projection helper for BPP capability tags (ADR-0001, FN-103).
+ *
+ * `projectCapabilityTags(tags)` converts a `CapabilityTags` object into a
+ * `CatalogEntry` — the wire shape emitted in Beckn catalog/search responses.
+ * It surfaces `tags.price.cents` in the response and, in dev/test mode,
+ * asserts the invariant that `Number(amount) * 100 === cents` for 2-decimal
+ * currencies (`ETO`, `EUSD`, `USD`).
+ *
+ * The assertion is guarded by `NODE_ENV !== "production"` so it fires during
+ * unit tests and local runs but never blocks production traffic.
+ */
+
+import type { CapabilityTags } from "./types.js";
+
+/** Two-decimal currencies where the minor-unit assertion applies. */
+const TWO_DECIMAL_CURRENCIES = new Set(["ETO", "EUSD", "USD"]);
+
+/**
+ * Wire shape for a Beckn catalog/search item.  Extends the BPP-internal
+ * `CapabilityTags` shape with an explicit `priceCents` integer field so
+ * callers never have to parse the `amount` decimal themselves.
+ */
+export interface CatalogEntry {
+  readonly domain: string;
+  readonly action: string;
+  readonly version: string;
+  readonly price: {
+    readonly amount: string;
+    readonly currency: string;
+    readonly cents: number;
+  };
+  readonly requiredCredentials: CapabilityTags["requiredCredentials"];
+  readonly description: string;
+}
+
+/**
+ * Project `CapabilityTags` → `CatalogEntry`.
+ *
+ * In non-production environments, asserts the dev-mode invariant:
+ *   `Math.round(Number(amount) * 100) === cents`
+ * for 2-decimal currencies (`ETO`, `EUSD`, `USD`) when both `amount` and
+ * `cents` are present in `tags.price`.
+ *
+ * @throws {Error} In non-production if the invariant is violated.
+ */
+export function projectCapabilityTags(tags: CapabilityTags): CatalogEntry {
+  const { price } = tags;
+
+  if (process.env["NODE_ENV"] !== "production") {
+    if (
+      TWO_DECIMAL_CURRENCIES.has(price.currency) &&
+      price.cents !== undefined
+    ) {
+      const derived = Math.round(Number(price.amount) * 100);
+      if (derived !== price.cents) {
+        throw new Error(
+          `ADR-0001 invariant violated for ${tags.domain}:${tags.action}: ` +
+          `Number("${price.amount}") * 100 = ${derived}, expected cents = ${price.cents}`,
+        );
+      }
+    }
+  }
+
+  return {
+    domain: tags.domain,
+    action: tags.action,
+    version: tags.version,
+    price: {
+      amount: price.amount,
+      currency: price.currency,
+      cents: price.cents,
+    },
+    requiredCredentials: tags.requiredCredentials,
+    description: tags.description,
+  };
+}

--- a/keeper/templates/bpp/index.ts
+++ b/keeper/templates/bpp/index.ts
@@ -18,3 +18,4 @@ export * from "./register.js";
 export * from "./credential-gate.js";
 export * from "./runtime.js";
 export * from "./chain.js";
+export * from "./catalog.js";

--- a/tests/unit/bank-bpp.test.ts
+++ b/tests/unit/bank-bpp.test.ts
@@ -19,7 +19,7 @@ import { BANK_CAPABILITY_KEYS, buildBankCatalog, canonicalCatalogJson, catalogHa
 import { buildConfig } from "../../keeper/bpps/bank/config.js";
 import { createBankHandler } from "../../keeper/bpps/bank/handler.js";
 import { InMemoryCatalogCommitRecorder, publishBankCatalog } from "../../keeper/bpps/bank/catalog-publisher.js";
-import { makeStubSigner } from "../../keeper/templates/bpp/index.js";
+import { makeStubSigner, projectCapabilityTags } from "../../keeper/templates/bpp/index.js";
 import { zBankCapability, zBankCatalog, zCatalogCommitPayload } from "../../keeper/bpps/bank/types.js";
 import { zBppConfig, zCapabilityTags } from "../../keeper/templates/bpp/types.js";
 import {
@@ -284,6 +284,13 @@ describe("buildConfig", () => {
   it("capabilityTags has version === '0.1.0'", () => {
     const { config } = buildConfig({ authority: FIXED_BPP_AUTHORITY });
     expect(config.capabilityTags.version).toBe("0.1.0");
+  });
+
+  it("projectCapabilityTags surfaces price.cents on umbrella tag (ADR-0001)", () => {
+    const { config } = buildConfig({ authority: FIXED_BPP_AUTHORITY });
+    const entry = projectCapabilityTags(config.capabilityTags);
+    expect(entry.domain).toBe("bank");
+    expect(entry.price.cents).toBe(config.capabilityTags.price.cents);
   });
 
   it("description is short enough (≤ 512 chars)", () => {

--- a/tests/unit/code-audit-solidity-bpp.test.ts
+++ b/tests/unit/code-audit-solidity-bpp.test.ts
@@ -7,7 +7,7 @@
  */
 
 import { describe, expect, it } from "vitest";
-import { zBppConfig, zCapabilityTags } from "../../keeper/templates/bpp/index.js";
+import { zBppConfig, zCapabilityTags, projectCapabilityTags } from "../../keeper/templates/bpp/index.js";
 import type { AgentCardSnapshot } from "../../keeper/templates/bpp/index.js";
 import {
   config,
@@ -59,6 +59,14 @@ describe("config + tags", () => {
     expect(tags.price).toEqual({ amount: "1.00", currency: "ETO" });
     expect(tags.requiredCredentials).toEqual([]);
     expect(tags.description.length).toBeLessThanOrEqual(512);
+  });
+
+  it("projectCapabilityTags surfaces price.cents (ADR-0001)", () => {
+    const entry = projectCapabilityTags(tags);
+    expect(entry.domain).toBe(tags.domain);
+    expect(entry.action).toBe(tags.action);
+    expect(entry.price.cents).toBe(tags.price.cents);
+    expect(entry.price.cents).toBe(100);
   });
 
   it("config (sans extension field) passes zBppConfig", () => {

--- a/tests/unit/data-analyze-bpp.test.ts
+++ b/tests/unit/data-analyze-bpp.test.ts
@@ -15,6 +15,7 @@ import {
   InMemoryEventSource,
   runBpp,
   zBppConfig,
+  projectCapabilityTags,
   type BeckonInitEvent,
   type Logger,
 } from "../../keeper/templates/bpp/index.js";
@@ -152,6 +153,14 @@ describe("config + tags", () => {
     expect(tags.price).toEqual({ amount: "0.25", currency: "ETO" });
     expect(tags.requiredCredentials).toEqual([]);
     expect(tags.description.length).toBeLessThanOrEqual(512);
+  });
+
+  it("projectCapabilityTags surfaces price.cents (ADR-0001)", () => {
+    const entry = projectCapabilityTags(tags);
+    expect(entry.domain).toBe(tags.domain);
+    expect(entry.action).toBe(tags.action);
+    expect(entry.price.cents).toBe(tags.price.cents);
+    expect(entry.price.cents).toBe(25);
   });
 
   it("buildConfig honours DATA_ANALYZE_AUTHORITY env", () => {

--- a/tests/unit/image-generate-bpp.test.ts
+++ b/tests/unit/image-generate-bpp.test.ts
@@ -21,6 +21,7 @@ import {
   InMemoryEventSource,
   runBpp,
   zBppConfig,
+  projectCapabilityTags,
   type BeckonInitEvent,
   type Logger,
 } from "../../keeper/templates/bpp/index.js";
@@ -160,6 +161,13 @@ describe("config", () => {
     expect(tags.version).toBe("1.0.0");
     expect(tags.price.currency).toBe("ETO");
     expect(tags.requiredCredentials).toEqual([]);
+  });
+
+  it("projectCapabilityTags surfaces price.cents (ADR-0001)", () => {
+    const entry = projectCapabilityTags(tags);
+    expect(entry.domain).toBe(tags.domain);
+    expect(entry.action).toBe(tags.action);
+    expect(entry.price.cents).toBe(tags.price.cents);
   });
 
   it("parses against zBppConfig", () => {

--- a/tests/unit/text-summarize-bpp.test.ts
+++ b/tests/unit/text-summarize-bpp.test.ts
@@ -13,6 +13,7 @@ import {
   InMemoryEventSource,
   runBpp,
   zBppConfig,
+  projectCapabilityTags,
   type BeckonInitEvent,
   type Logger,
 } from "../../keeper/templates/bpp/index.js";
@@ -130,6 +131,14 @@ describe("config + tags", () => {
     expect(tags.price).toEqual({ amount: "0.10", currency: "ETO" });
     expect(tags.requiredCredentials).toEqual([]);
     expect(tags.description.length).toBeLessThanOrEqual(512);
+  });
+
+  it("projectCapabilityTags surfaces price.cents (ADR-0001)", () => {
+    const entry = projectCapabilityTags(tags);
+    expect(entry.domain).toBe(tags.domain);
+    expect(entry.action).toBe(tags.action);
+    expect(entry.price.cents).toBe(tags.price.cents);
+    expect(entry.price.cents).toBe(10);
   });
 
   it("buildConfig honours TEXT_SUMMARIZE_AUTHORITY env", () => {

--- a/tests/unit/web-research-bpp.test.ts
+++ b/tests/unit/web-research-bpp.test.ts
@@ -7,7 +7,7 @@
  */
 
 import { describe, expect, it } from "vitest";
-import { zBppConfig } from "../../keeper/templates/bpp/index.js";
+import { zBppConfig, projectCapabilityTags } from "../../keeper/templates/bpp/index.js";
 import {
   config,
   tags,
@@ -93,6 +93,14 @@ describe("config + tags", () => {
     expect(tags.price).toEqual({ amount: "0.50", currency: "ETO", cents: 50 });
     expect(tags.requiredCredentials).toEqual([]);
     expect(tags.description.length).toBeLessThanOrEqual(512);
+  });
+
+  it("projectCapabilityTags surfaces price.cents (ADR-0001)", () => {
+    const entry = projectCapabilityTags(tags);
+    expect(entry.domain).toBe(tags.domain);
+    expect(entry.action).toBe(tags.action);
+    expect(entry.price.cents).toBe(tags.price.cents);
+    expect(entry.price.cents).toBe(50);
   });
 
   it("buildConfig honours WEB_RESEARCH_AUTHORITY env", () => {


### PR DESCRIPTION
## Summary
- Adds `keeper/templates/bpp/catalog.ts` with `CatalogEntry` interface and `projectCapabilityTags(tags)` helper
- Helper surfaces `tags.price.cents` in Beckn catalog/search responses and asserts `Math.round(Number(amount) * 100) === cents` for ETO/EUSD/USD in non-production environments
- Exported via template barrel (`keeper/templates/bpp/index.ts`)
- Reused in all six BPP catalog tests: code-audit-solidity, web-research, text-summarize, image-generate, data-analyze, bank

## Test plan
- [ ] `pnpm typecheck` passes (clean)
- [ ] All six BPP tests pass with new `projectCapabilityTags surfaces price.cents (ADR-0001)` test case
- [ ] Invariant assertion catches mismatched amount/cents in dev mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)