### PR TITLE
fix(FN-069): FN-020 verification gate — claimCommitments green on master

### DIFF
--- a/tests/bank/credential-schemas.test.ts
+++ b/tests/bank/credential-schemas.test.ts
@@ -7,6 +7,10 @@
  * schema. The example claimCommitments are real Poseidon-2 outputs from
  * FN-082's `eto-zk-cli commit` (BN254 Fr, t=3) and so the per-entry
  * `commitment`/`saltCommitment` patterns are also exercised here.
+ *
+ * FN-069 gate: verified green on master — `pnpm typecheck` passes, this test
+ * suite passes, confirming FN-200 (claimCommitments) is correctly implemented.
+ * FN-020 is closed by this gate. FN-077 is unblocked.
  */
 import { describe, it, expect } from "vitest";
 import { readFileSync } from "node:fs";


### PR DESCRIPTION
## Summary
- Verification gate confirming FN-200 (§10.3.1 claimCommitments in banking credential templates) is correctly implemented and all tests pass
- `pnpm typecheck` passes on master
- `tests/bank/credential-schemas.test.ts` suite passes — all four credential schemas (account-checking, account-savings, card-debit, tax-1099) validate correctly
- Adds gate note to the test file doc comment per FN-069 spec

## Status
- FN-020: closed (claimCommitments verified)
- FN-077: unblocked

🤖 Generated with [Claude Code](https://claude.com/claude-code)