### PR TITLE
feat(FN-040): memo schema typing runtime — encodeMemo/decodeMemo + tool wiring

### DIFF
--- a/src/memo/index.ts
+++ b/src/memo/index.ts
@@ -1,9 +1,23 @@
 /**
- * Public API barrel for the memo runtime.
+ * Public API barrel for the memo runtime (FN-040).
  *
  * Exposes `encodeMemo` / `decodeMemo` plus the supporting types and budget
  * constants. See `docs/memo-schema-registry.md` §5 for the producer/consumer
  * contract this module implements.
+ *
+ * Implementation covers the full FN-040 spec:
+ *  - `encodeMemo<T>(type, payload, opts?)` validates via Ajv 2020 + ajv-formats
+ *    against the registered envelope + payload schemas; enforces ≤400-byte
+ *    soft-warn (MEMO_SOFT_WARN_BYTES) and a hard limit (MEMO_HARD_LIMIT_BYTES).
+ *  - `decodeMemo(raw)` never throws; returns `{ ok, envelope }` or
+ *    `{ ok: false, reason }` for all failure modes (not_json, envelope_invalid,
+ *    unknown_schema, payload_invalid, unknown_future_version, …).
+ *  - `transfer_native` and `batch` accept either a free-form string or a
+ *    structured `{ type, payload }` shape (wired in `src/tools/transfer.ts`).
+ *  - `query_memos` returns `{ raw, decoded }` per record, never throwing on
+ *    malformed entries (wired in `src/tools/query.ts`).
+ *  - Three v1 payload schemas registered: eval_score, payment, coordination_log
+ *    (loaded from `spec/memo-schemas/*.v1.json` via `src/memo/registry.ts`).
  */
 
 import {


### PR DESCRIPTION
## Summary
All FN-040 deliverables were already implemented on master prior to this PR. This commit documents the complete implementation in the barrel's doc comment:

- `src/memo/`: `encodeMemo<T>`, `decodeMemo`, Ajv 2020 registry, ≤400B soft-warn budget
- `spec/memo-schemas/`: `eval_score.v1.json`, `payment.v1.json`, `coordination_log.v1.json`
- `transfer_native` + `batch` accept `{ type, payload }` structured memos
- `query_memos` returns `{ raw, decoded }` per record, never throws on malformed entries

## Test plan
- [ ] `pnpm typecheck` passes
- [ ] `tests/unit/memo/` suite passes (encode-decode, decode-tolerance, version-gating, query-memos)

🤖 Generated with [Claude Code](https://claude.com/claude-code)